### PR TITLE
BugFix request.py 

### DIFF
--- a/imageio/request.py
+++ b/imageio/request.py
@@ -123,12 +123,12 @@ class Request(object):
         elif isinstance(self, ReadRequest):
             if hasattr(uri, 'read') and hasattr(uri, 'close'):
                 self._uri_type = URI_FILE
-                self._filename = '<file>'
+                self._filename = uri.name
                 self._file = uri
         elif isinstance(self, WriteRequest):
             if hasattr(uri, 'write') and hasattr(uri, 'close'):
                 self._uri_type = URI_FILE
-                self._filename = '<file>'
+                self._filename = uri.name
                 self._file = uri
         
         # Check if a zipfile


### PR DESCRIPTION
I found a bug in image reading when uri is file object.

This program demonstrates it:

---

import imageio

path="C:\1.jpg"

fl=open(path,'rb')

imageio.imread(path) # OK
imageio.imread(fl,format='jpg') # OK
imageio.imread(fl) # ValueError: Could not find a format to read the specified file.

---

Maybe this is not the best solution, but it solves the problem on pyzo2014a win7.
