### PR TITLE
dpxSupport

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -679,5 +679,5 @@ class StreamCatcher(threading.Thread):
 
 # Register. You register an *instance* of a Format class.
 format = FfmpegFormat('ffmpeg', 'Many video formats and cameras (via ffmpeg)', 
-                      '.mov .avi .mpg .mpeg .mp4 .mkv', 'I')
+                      '.mov .avi .mpg .mpeg .mp4 .mkv .dpx', 'iI')
 formats.add_format(format)

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -118,7 +118,7 @@ class FfmpegFormat(Format):
     """
     
     def _can_read(self, request):
-        if request.mode[1] not in 'I?':
+        if request.mode[1] not in self._modes+'?':
             return False
         
         # Read from video stream?

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -27,7 +27,7 @@ def test_select():
     
     assert F.can_read(core.Request(fname1, 'rI'))
     assert F.can_write(core.Request(fname1, 'wI'))
-    assert not F.can_read(core.Request(fname1, 'ri'))
+    assert F.can_read(core.Request(fname1, 'ri'))
     assert not F.can_read(core.Request(fname1, 'rv'))
 
     # ffmpeg is default


### PR DESCRIPTION
needed support for dpx files, ffmpeg already has this. Call imageio.imread(dpxPath, format='FFMPEG') to use
