### PR TITLE
Use newly uploaded osx ffmpeg exe

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -27,8 +27,8 @@ from ..core import (Format, get_remote_file, string_types, read_n_bytes,
                     image_as_uint8, get_platform)
 
 FNAME_PER_PLATFORM = {
-    'osx32': 'ffmpeg.osx.snowleopardandabove',
-    'osx64': 'ffmpeg.osx.snowleopardandabove',
+    'osx32': 'ffmpeg.osx',
+    'osx64': 'ffmpeg.osx',
     'win32': 'ffmpeg.win32.exe',
     'win64': 'ffmpeg.win32.exe',
     'linux32': 'ffmpeg.linux32',

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -293,7 +293,7 @@ def test_webcam():
     need_internet()
     
     try:
-        imageio.read('<video2>')
+        imageio.read('<video0>')
     except Exception:
         skip('no web cam')
 


### PR DESCRIPTION
I uploaded a new ffmpeg exe, which should make cameras work on OSX. See #31.

@kuchi do you have time to verify that this now works?