### PR TITLE
Fix the first metadata 'FrameTime' from GifFormat.Writer._append_bitmap

### DIFF
--- a/imageio/plugins/freeimagemulti.py
+++ b/imageio/plugins/freeimagemulti.py
@@ -238,6 +238,10 @@ class GifFormat(FreeimageMulti):
             # Prepare meta data
             meta = meta.copy()
             meta_a = meta['ANIMATION'] = {}
+            # If this is the first frame, assign it our "global" meta data
+            if len(self._bm) == 0:
+                meta.update(self._meta)
+                meta_a = meta['ANIMATION']
             # Set frame time
             index = len(self._bm)
             if index < len(self._frametime):
@@ -245,9 +249,6 @@ class GifFormat(FreeimageMulti):
             else:
                 ft = self._frametime[-1]
             meta_a['FrameTime'] = np.array([ft]).astype(np.uint32)
-            # If this is the first frame, assign it our "global" meta data
-            if len(self._bm) == 0:
-                meta.update(self._meta)
                 
             # Check array
             if im.ndim == 3 and im.shape[-1] == 4:
@@ -272,6 +273,7 @@ class GifFormat(FreeimageMulti):
                 del meta['ANIMATION']
             # Set meta data and return
             sub2.set_meta_data(meta)
+            print("meta:",meta)
             return sub2
         
         def _get_sub_rectangles(self, prev, im):

--- a/imageio/plugins/freeimagemulti.py
+++ b/imageio/plugins/freeimagemulti.py
@@ -273,7 +273,6 @@ class GifFormat(FreeimageMulti):
                 del meta['ANIMATION']
             # Set meta data and return
             sub2.set_meta_data(meta)
-            print("meta:",meta)
             return sub2
         
         def _get_sub_rectangles(self, prev, im):


### PR DESCRIPTION
When I write a Gif using imageio with a custom frame time, the first frame is aways 0.1s, so I fixed the GifFormat.Writer._append_bitmap by enforcing the frame time on meta.