### PR TITLE
Improvements to format selection and freeimage lazily loads its lib

### DIFF
--- a/imageio/core/__init__.py
+++ b/imageio/core/__init__.py
@@ -9,7 +9,7 @@
 from .util import Image, Dict, asarray, image_as_uint8, urlopen  # noqa
 from .util import BaseProgressIndicator, StdoutProgressIndicator  # noqa
 from .util import string_types, text_type, binary_type, IS_PYPY  # noqa
-from .util import get_platform, appdata_dir, resource_dirs  # noqa
+from .util import get_platform, appdata_dir, resource_dirs, has_module  # noqa
 from .findlib import load_lib  # noqa
 from .fetching import get_remote_file, InternetNotAllowedError  # noqa
 from .request import Request, read_n_bytes, RETURN_BYTES  # noqa

--- a/imageio/core/format.py
+++ b/imageio/core/format.py
@@ -90,7 +90,7 @@ class Format:
             extensions = extensions.replace(',', ' ').split(' ')
         #
         if isinstance(extensions, (tuple, list)):
-            self._extensions = tuple([e.strip('.').lower() 
+            self._extensions = tuple(['.' + e.strip('.').lower() 
                                       for e in extensions if e])
         else:
             raise ValueError('Invalid value for extensions given.')
@@ -134,7 +134,7 @@ class Format:
     @property
     def extensions(self):
         """ A list of file extensions supported by this plugin.
-        These are all lowercase without a leading dot.
+        These are all lowercase with a leading dot.
         """
         return self._extensions
     
@@ -542,10 +542,9 @@ class FormatManager:
         
         if '.' in name:
             # Look for extension
-            e1, e2 = os.path.splitext(name)
+            e1, e2 = os.path.splitext(name.lower())
             name = e2 or e1
             # Search for format that supports this extension
-            name = name.lower()[1:]
             for format in self._formats:
                 if name in format.extensions:
                     return format
@@ -563,11 +562,11 @@ class FormatManager:
         raise IndexError('No format known by name %s.' % name)
     
     def add_format(self, format, overwrite=False):
-        """ add_formar(format, overwrite=False)
+        """ add_format(format, overwrite=False)
         
         Register a format, so that imageio can use it. If a format with the
         same name already exists, an error is raised, unless overwrite is True,
-        in which case it is replaced.
+        in which case the current format is replaced.
         """
         if not isinstance(format, Format):
             raise ValueError('add_format needs argument to be a Format object')
@@ -588,8 +587,24 @@ class FormatManager:
         Returns None if no appropriate format was found. (used internally)
         """
         select_mode = request.mode[1] if request.mode[1] in 'iIvV' else ''
+        select_ext = request.filename.lower()
+        
+        # Select formats that seem to be able to read it
+        selected_formats = []
         for format in self._formats:
             if select_mode in format.modes:
+                if select_ext.endswith(format.extensions):
+                    selected_formats.append(format)
+        
+        # Select the first that can
+        for format in selected_formats:
+            if format.can_read(request):
+                return format
+        
+        # If no format could read it, it could be that file has no or
+        # the wrong extension. We ask all formats again.
+        for format in self._formats:
+            if format not in selected_formats:
                 if format.can_read(request):
                     return format
     
@@ -600,8 +615,25 @@ class FormatManager:
         Returns None if no appropriate format was found. (used internally)
         """
         select_mode = request.mode[1] if request.mode[1] in 'iIvV' else ''
+        select_ext = request.filename.lower()
+        
+        # Select formats that seem to be able to write it
+        selected_formats = []
         for format in self._formats:
             if select_mode in format.modes:
+                if select_ext.endswith(format.extensions):
+                    selected_formats.append(format)
+        
+        # Select the first that can
+        for format in selected_formats:
+            if format.can_write(request):
+                return format
+        
+        # If none of the selected formats could write it, maybe another
+        # format can still write it. It might prefer a different mode,
+        # or be able to handle more formats than it says by its extensions.
+        for format in self._formats:
+            if format not in selected_formats:
                 if format.can_write(request):
                     return format
     

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -496,3 +496,18 @@ def get_platform():
         return None
     
     return plat % (struct.calcsize('P') * 8)  # 32 or 64 bits
+
+
+def has_module(module_name):
+    """Check to see if a python module is available.
+    """
+    if sys.version_info > (3, ):
+        import importlib
+        return importlib.find_loader(module_name) is not None
+    else:  # pragma: no cover
+        import imp
+        try:
+            imp.find_module(module_name)
+        except ImportError:
+            return False
+        return True

--- a/imageio/plugins/__init__.py
+++ b/imageio/plugins/__init__.py
@@ -78,18 +78,16 @@ For the Format.Writer class:
 
 """
 
-# First import plugins that we want to take precedence over freeimage,
-# also for checking read/write, so we can use these without triggering
-# a freeimage download.
+# First import plugins that we want to take precedence over freeimage
 from . import tifffile  # noqa
-from . import ffmpeg  # noqa
 
-# Load freeimage, note it will load the lib when checking if it can read/write
 from . import freeimage  # noqa
 from . import freeimagemulti  # noqa
 
-from . import dicom  # noqa
+from . import ffmpeg  # noqa
 from . import avbin  # noqa
+
+from . import dicom  # noqa
 from . import npz  # noqa
 from . import swf  # noqa
 from . import fits  # noqa

--- a/imageio/plugins/__init__.py
+++ b/imageio/plugins/__init__.py
@@ -78,14 +78,21 @@ For the Format.Writer class:
 
 """
 
+# First import plugins that we want to take precedence over freeimage,
+# also for checking read/write, so we can use these without triggering
+# a freeimage download.
 from . import tifffile  # noqa
+from . import ffmpeg  # noqa
+
+# Load freeimage, note it will load the lib when checking if it can read/write
 from . import freeimage  # noqa
 from . import freeimagemulti  # noqa
-from . import example  # noqa
+
 from . import dicom  # noqa
-from . import ffmpeg  # noqa
 from . import avbin  # noqa
 from . import npz  # noqa
 from . import swf  # noqa
 from . import fits  # noqa
 from . import simpleitk  # noqa
+
+from . import example  # noqa

--- a/imageio/plugins/avbin.py
+++ b/imageio/plugins/avbin.py
@@ -200,26 +200,9 @@ class AvBinFormat(Format):
         Format.__init__(self, *args, **kwargs)
     
     def _can_read(self, request):
-        # This method is called when the format manager is searching
-        # for a format to read a certain image. Return True if this format
-        # can do it.
-        #
-        # The format manager is aware of the extensions and the modes
-        # that each format can handle. However, the ability to read a
-        # format could be more subtle. Also, the format would ideally
-        # check the request.firstbytes and look for a header of some
-        # kind. Further, the extension might not always be known.
-        #
-        # The request object has:
-        # request.filename: a representation of the source (only for reporing)
-        # request.firstbytes: the first 256 bytes of the file.
-        # request.mode[0]: read or write mode
-        # request.mode[1]: what kind of data the user expects: one of 'iIvV?'
-        
         if request.mode[1] in (self.modes + '?'):
-            for ext in self.extensions:
-                if request.filename.endswith('.' + ext):
-                    return True
+            if request.filename.lower().endswith(self.extensions):
+                return True
     
     def _can_write(self, request):
         return False  # AvBin does not support writing videos

--- a/imageio/plugins/example.py
+++ b/imageio/plugins/example.py
@@ -37,10 +37,16 @@ class DummyFormat(Format):
         # can do it.
         #
         # The format manager is aware of the extensions and the modes
-        # that each format can handle. However, the ability to read a
-        # format could be more subtle. Also, the format would ideally
-        # check the request.firstbytes and look for a header of some
-        # kind. Further, the extension might not always be known.
+        # that each format can handle. It will first ask all formats
+        # that seem* to be able to read it whether they can. If none
+        # can, it will ask the remaining formats if they can: the
+        # extension might be missing, and this allows formats to provide
+        # functionality for certain extensions, while giving preference
+        # to other plugins.
+        #
+        # If a format says it can, it should live up to it. The format
+        # would ideally check the request.firstbytes and look for a
+        # header of some kind.
         #
         # The request object has:
         # request.filename: a representation of the source (only for reporting)
@@ -49,21 +55,21 @@ class DummyFormat(Format):
         # request.mode[1]: what kind of data the user expects: one of 'iIvV?'
         
         if request.mode[1] in (self.modes + '?'):
-            for ext in self.extensions:
-                if request.filename.endswith('.' + ext):
-                    return True
+            if request.filename.lower().endswith(self.extensions):
+                return True
     
     def _can_write(self, request):
         # This method is called when the format manager is searching
-        # for a format to write a certain image. Return True if the
-        # format can do it.
+        # for a format to write a certain image. It will first ask all
+        # formats that seem* to be able to write it whether they can.
+        # If none can, it will ask the remaining formats if they can.
         #
-        # In most cases, the code does suffice.
+        # Return True if the format can do it.
         
+        # In most cases, this code does suffice:
         if request.mode[1] in (self.modes + '?'):
-            for ext in self.extensions:
-                if request.filename.endswith('.' + ext):
-                    return True
+            if request.filename.lower().endswith(self.extensions):
+                return True
     
     # -- reader
     

--- a/imageio/plugins/example.py
+++ b/imageio/plugins/example.py
@@ -38,7 +38,7 @@ class DummyFormat(Format):
         #
         # The format manager is aware of the extensions and the modes
         # that each format can handle. It will first ask all formats
-        # that seem* to be able to read it whether they can. If none
+        # that *seem* to be able to read it whether they can. If none
         # can, it will ask the remaining formats if they can: the
         # extension might be missing, and this allows formats to provide
         # functionality for certain extensions, while giving preference
@@ -61,7 +61,7 @@ class DummyFormat(Format):
     def _can_write(self, request):
         # This method is called when the format manager is searching
         # for a format to write a certain image. It will first ask all
-        # formats that seem* to be able to write it whether they can.
+        # formats that *seem* to be able to write it whether they can.
         # If none can, it will ask the remaining formats if they can.
         #
         # Return True if the format can do it.

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -164,15 +164,13 @@ class FfmpegFormat(Format):
             return True
 
         # Read from file that we know?
-        for ext in self.extensions:
-            if request.filename.endswith('.' + ext):
-                return True
+        if request.filename.lower().endswith(self.extensions):
+            return True
 
     def _can_write(self, request):
         if request.mode[1] in (self.modes + '?'):
-            for ext in self.extensions:
-                if request.filename.endswith('.' + ext):
-                    return True
+            if request.filename.lower().endswith(self.extensions):
+                return True
 
     # --
 

--- a/imageio/plugins/fits.py
+++ b/imageio/plugins/fits.py
@@ -29,7 +29,9 @@ class FitsFormat(Format):
     """ Flexible Image Transport System (FITS) is an open standard defining a
     digital file format useful for storage, transmission and processing of
     scientific and other images. FITS is the most commonly used digital
-    file format in astronomy.  Requires the ``astropy`` package.
+    file format in astronomy.
+    
+    This format requires the ``astropy`` package.
 
     Parameters for reading
     ----------------------
@@ -74,9 +76,12 @@ class FitsFormat(Format):
     """
 
     def _can_read(self, request):
+        # We return True if ext matches, because this is the only plugin
+        # that can. If astropy is not installed, a useful error follows.
         return request.filename.lower().endswith(self.extensions)
 
     def _can_write(self, request):
+        # No write support
         return False
 
     # -- reader

--- a/imageio/plugins/fits.py
+++ b/imageio/plugins/fits.py
@@ -74,7 +74,7 @@ class FitsFormat(Format):
     """
 
     def _can_read(self, request):
-        return request.filename.lower().endswith(('.fits', '.fit', '.fts'))
+        return request.filename.lower().endswith(self.extensions)
 
     def _can_write(self, request):
         return False

--- a/imageio/plugins/freeimage.py
+++ b/imageio/plugins/freeimage.py
@@ -412,7 +412,7 @@ def _create_predefined_freeimage_formats():
 
 
 def create_freeimage_formats():
-    """ By default, imageio registeres a list of predefined formats
+    """ By default, imageio registers a list of predefined formats
     that freeimage can handle. If your version of imageio can handle
     more formats, you can call this function to register them.
     """

--- a/imageio/plugins/freeimage.py
+++ b/imageio/plugins/freeimage.py
@@ -39,19 +39,13 @@ class FreeimageFormat(Format):
     """
     
     _modes = 'i'
-    _CAN_WRITE = None  # not sure
     
     @property
     def fif(self):
         return self._fif  # Set when format is created
     
     def _can_read(self, request):
-        if request.mode[1] not in (self._modes + '?'):
-            return False
-        # We know from meta-info that we can
-        if (request.filename.lower().endswith(self.extensions)):
-            return True
-        # But we also ask freeimage if it can read it, maybe ext missing
+        # Ask freeimage if it can read it, maybe ext missing
         if fi.has_lib():
             if not hasattr(request, '_fif'):
                 try:
@@ -63,13 +57,7 @@ class FreeimageFormat(Format):
                 return True
     
     def _can_write(self, request):
-        if request.mode[1] not in (self._modes + '?'):
-            return False
-        # Of some formats we know we can write
-        exts = self.extensions
-        if request.filename.lower().endswith(exts) and self._CAN_WRITE:
-            return True
-        # But we also ask freeimage, because we are not aware of all formats
+        # Ask freeimage, because we are not aware of all formats
         if fi.has_lib():
             if not hasattr(request, '_fif'):
                 try:
@@ -165,8 +153,6 @@ class FreeimageBmpFormat(FreeimageFormat):
     
     """
     
-    _CAN_WRITE = True
-    
     class Writer(FreeimageFormat.Writer):
         def _open(self, flags=0, compression=False):
             # Build flags from kwargs
@@ -206,8 +192,6 @@ class FreeimagePngFormat(FreeimageFormat):
     interlaced : bool
         Save using Adam7 interlacing. Default False.
     """
-    
-    _CAN_WRITE = True
     
     class Reader(FreeimageFormat.Reader):
         def _open(self, flags=0, ignoregamma=False):
@@ -284,8 +268,6 @@ class FreeimageJpegFormat(FreeimageFormat):
         Save basic JPEG, without metadata or any markers. Default False.
     
     """
-    
-    _CAN_WRITE = True
     
     class Reader(FreeimageFormat.Reader):
         def _open(self, flags=0, exifrotate=True, quickread=False):

--- a/imageio/plugins/freeimage.py
+++ b/imageio/plugins/freeimage.py
@@ -18,7 +18,6 @@ from ._freeimage import fi, IO_FLAGS, FNAME_PER_PLATFORM  # noqa
 
 
 # todo: support files with only meta data
-# todo: multi-page files
 
 
 class FreeimageFormat(Format):
@@ -40,14 +39,20 @@ class FreeimageFormat(Format):
     """
     
     _modes = 'i'
+    _CAN_WRITE = None  # not sure
     
     @property
     def fif(self):
         return self._fif  # Set when format is created
     
     def _can_read(self, request):
-        modes = self._modes + '?'
-        if fi and request.mode[1] in modes:
+        if request.mode[1] not in (self._modes + '?'):
+            return False
+        # We know from meta-info that we can
+        if (request.filename.lower().endswith(self.extensions)):
+            return True
+        # But we also ask freeimage if it can read it, maybe ext missing
+        if fi.has_lib():
             if not hasattr(request, '_fif'):
                 try:
                     request._fif = fi.getFIF(request.filename, 'r', 
@@ -58,8 +63,14 @@ class FreeimageFormat(Format):
                 return True
     
     def _can_write(self, request):
-        modes = self._modes + '?'
-        if fi and request.mode[1] in modes:
+        if request.mode[1] not in (self._modes + '?'):
+            return False
+        # Of some formats we know we can write
+        exts = self.extensions
+        if request.filename.lower().endswith(exts) and self._CAN_WRITE:
+            return True
+        # But we also ask freeimage, because we are not aware of all formats
+        if fi.has_lib():
             if not hasattr(request, '_fif'):
                 try:
                     request._fif = fi.getFIF(request.filename, 'w')
@@ -153,7 +164,9 @@ class FreeimageBmpFormat(FreeimageFormat):
         PNG anyway.
     
     """
-
+    
+    _CAN_WRITE = True
+    
     class Writer(FreeimageFormat.Writer):
         def _open(self, flags=0, compression=False):
             # Build flags from kwargs
@@ -193,6 +206,8 @@ class FreeimagePngFormat(FreeimageFormat):
     interlaced : bool
         Save using Adam7 interlacing. Default False.
     """
+    
+    _CAN_WRITE = True
     
     class Reader(FreeimageFormat.Reader):
         def _open(self, flags=0, ignoregamma=False):
@@ -269,6 +284,8 @@ class FreeimageJpegFormat(FreeimageFormat):
         Save basic JPEG, without metadata or any markers. Default False.
     
     """
+    
+    _CAN_WRITE = True
     
     class Reader(FreeimageFormat.Reader):
         def _open(self, flags=0, exifrotate=True, quickread=False):
@@ -353,7 +370,71 @@ SPECIAL_CLASSES = {'jpeg': FreeimageJpegFormat,
 # rename TIFF to make way for the tiffile plugin
 NAME_MAP = {'TIFF': 'FI_TIFF'}
 
+# This is a dump of supported FreeImage formats on Linux fi verion 3.16.0
+# > imageio.plugins.freeimage.create_freeimage_formats()
+# > for i in sorted(imageio.plugins.freeimage.fiformats): print('%r,' % (i, ))
+fiformats = [
+    ('BMP', 0, 'Windows or OS/2 Bitmap', 'bmp'),
+    ('CUT', 21, 'Dr. Halo', 'cut'),
+    ('DDS', 24, 'DirectX Surface', 'dds'),
+    ('EXR', 29, 'ILM OpenEXR', 'exr'),
+    ('G3', 27, 'Raw fax format CCITT G.3', 'g3'),
+    ('GIF', 25, 'Graphics Interchange Format', 'gif'),
+    ('HDR', 26, 'High Dynamic Range Image', 'hdr'),
+    ('ICO', 1, 'Windows Icon', 'ico'),
+    ('IFF', 5, 'IFF Interleaved Bitmap', 'iff,lbm'),
+    ('J2K', 30, 'JPEG-2000 codestream', 'j2k,j2c'),
+    ('JNG', 3, 'JPEG Network Graphics', 'jng'),
+    ('JP2', 31, 'JPEG-2000 File Format', 'jp2'),
+    ('JPEG', 2, 'JPEG - JFIF Compliant', 'jpg,jif,jpeg,jpe'),
+    ('JPEG-XR', 36, 'JPEG XR image format', 'jxr,wdp,hdp'),
+    ('KOALA', 4, 'C64 Koala Graphics', 'koa'),
+    ('MNG', 6, 'Multiple-image Network Graphics', 'mng'),
+    ('PBM', 7, 'Portable Bitmap (ASCII)', 'pbm'),
+    ('PBMRAW', 8, 'Portable Bitmap (RAW)', 'pbm'),
+    ('PCD', 9, 'Kodak PhotoCD', 'pcd'),
+    ('PCX', 10, 'Zsoft Paintbrush', 'pcx'),
+    ('PFM', 32, 'Portable floatmap', 'pfm'),
+    ('PGM', 11, 'Portable Greymap (ASCII)', 'pgm'),
+    ('PGMRAW', 12, 'Portable Greymap (RAW)', 'pgm'),
+    ('PICT', 33, 'Macintosh PICT', 'pct,pict,pic'),
+    ('PNG', 13, 'Portable Network Graphics', 'png'),
+    ('PPM', 14, 'Portable Pixelmap (ASCII)', 'ppm'),
+    ('PPMRAW', 15, 'Portable Pixelmap (RAW)', 'ppm'),
+    ('PSD', 20, 'Adobe Photoshop', 'psd'),
+    ('RAS', 16, 'Sun Raster Image', 'ras'),
+    ('RAW', 34, 'RAW camera image', '3fr,arw,bay,bmq,cap,cine,cr2,crw,cs1,dc2,'
+     'dcr,drf,dsc,dng,erf,fff,ia,iiq,k25,kc2,kdc,mdc,mef,mos,mrw,nef,nrw,orf,'
+     'pef,ptx,pxn,qtk,raf,raw,rdc,rw2,rwl,rwz,sr2,srf,srw,sti'),
+    ('SGI', 28, 'SGI Image Format', 'sgi,rgb,rgba,bw'),
+    ('TARGA', 17, 'Truevision Targa', 'tga,targa'),
+    ('TIFF', 18, 'Tagged Image File Format', 'tif,tiff'),
+    ('WBMP', 19, 'Wireless Bitmap', 'wap,wbmp,wbm'),
+    ('WebP', 35, 'Google WebP image format', 'webp'),
+    ('XBM', 22, 'X11 Bitmap Format', 'xbm'),
+    ('XPM', 23, 'X11 Pixmap Format', 'xpm'),
+]
+
+
+def _create_predefined_freeimage_formats():
+    
+    for name, i, des, ext in fiformats:
+        name = NAME_MAP.get(name, name)
+        # Get class for format
+        FormatClass = SPECIAL_CLASSES.get(name.lower(), FreeimageFormat)
+        if FormatClass:
+            # Create Format and add
+            format = FormatClass(name, des, ext, FormatClass._modes)
+            format._fif = i
+            formats.add_format(format) 
+
+
 def create_freeimage_formats():
+    """ By default, imageio registeres a list of predefined formats
+    that freeimage can handle. If your version of imageio can handle
+    more formats, you can call this function to register them.
+    """
+    fiformats[:] = []
     
     # Freeimage available?
     if fi is None:  # pragma: no cover
@@ -369,6 +450,7 @@ def create_freeimage_formats():
             name = lib.FreeImage_GetFormatFromFIF(i).decode('ascii')
             des = lib.FreeImage_GetFIFDescription(i).decode('ascii')
             ext = lib.FreeImage_GetFIFExtensionList(i).decode('ascii')
+            fiformats.append((name, i, des, ext))
             name = NAME_MAP.get(name, name)
             # Get class for format
             FormatClass = SPECIAL_CLASSES.get(name.lower(), FreeimageFormat)
@@ -376,6 +458,7 @@ def create_freeimage_formats():
                 # Create Format and add
                 format = FormatClass(name, des, ext, FormatClass._modes)
                 format._fif = i
-                formats.add_format(format)
+                formats.add_format(format, overwrite=True)
 
-create_freeimage_formats()
+
+_create_predefined_freeimage_formats()

--- a/imageio/plugins/freeimagemulti.py
+++ b/imageio/plugins/freeimagemulti.py
@@ -124,8 +124,6 @@ class IcoFormat(FreeimageMulti):
     
     _fif = 1
     
-    _CAN_WRITE = True
-    
     class Reader(FreeimageMulti.Reader):
         def _open(self, flags=0, makealpha=False):
             # Build flags from kwargs
@@ -177,8 +175,6 @@ class GifFormat(FreeimageMulti):
     """
     
     _fif = 25
-    
-    _CAN_WRITE = True
     
     class Reader(FreeimageMulti.Reader):
         

--- a/imageio/plugins/freeimagemulti.py
+++ b/imageio/plugins/freeimagemulti.py
@@ -124,6 +124,8 @@ class IcoFormat(FreeimageMulti):
     
     _fif = 1
     
+    _CAN_WRITE = True
+    
     class Reader(FreeimageMulti.Reader):
         def _open(self, flags=0, makealpha=False):
             # Build flags from kwargs
@@ -175,6 +177,8 @@ class GifFormat(FreeimageMulti):
     """
     
     _fif = 25
+    
+    _CAN_WRITE = True
     
     class Reader(FreeimageMulti.Reader):
         

--- a/imageio/plugins/npz.py
+++ b/imageio/plugins/npz.py
@@ -37,16 +37,12 @@ class NpzFormat(Format):
     """
     
     def _can_read(self, request):
-        if request.filename.lower().endswith('.npz'):
-            return True  # We support any kind of image data
-        else:
-            return False
+        # We support any kind of image data
+        return request.filename.lower().endswith(self.extensions)
     
     def _can_write(self, request):
-        if request.filename.lower().endswith('.npz'):
-            return True  # We support any kind of image data
-        else:
-            return False
+        # We support any kind of image data
+        return request.filename.lower().endswith(self.extensions)
     
     # -- reader
     

--- a/imageio/plugins/simpleitk.py
+++ b/imageio/plugins/simpleitk.py
@@ -7,10 +7,8 @@
 
 from __future__ import absolute_import, print_function, division
 
-import sys
-
 from .. import formats
-from ..core import Format
+from ..core import Format, has_module
 
 _itk = None  # Defer loading to load_lib() function.
 
@@ -27,22 +25,6 @@ def load_lib():
                           "  http://simpleitk.org/ "
                           "for further instructions.")
     return _itk
-
-
-def has_lib():
-    if _itk is not None:
-        return True
-    else:
-        if sys.version_info > (3, ):
-            import importlib
-            return importlib.find_loader('SimpleITK') is not None
-        else:
-            import imp
-            try:
-                imp.find_module('SimpleITK')
-            except ImportError:
-                return False
-            return True
 
 
 # Split up in real ITK and all supported formats.
@@ -75,13 +57,13 @@ class ItkFormat(Format):
         # we only report that we can read if the library is installed.
         if request.filename.lower().endswith(ITK_FORMATS):
             return True
-        if has_lib():
+        if has_module('SimpleITK'):
             return request.filename.lower().endswith(ALL_FORMATS)
 
     def _can_write(self, request):
         if request.filename.lower().endswith(ITK_FORMATS):
             return True
-        if has_lib():
+        if has_module('SimpleITK'):
             return request.filename.lower().endswith(ALL_FORMATS)
 
     # -- reader

--- a/imageio/plugins/simpleitk.py
+++ b/imageio/plugins/simpleitk.py
@@ -27,8 +27,12 @@ def load_lib():
     return _itk
 
 
-ITK_FORMATS = ('.bmp', '.dicom', '.gdcm', '.gipl', '.ipl', '.jpeg', '.jpg',
-               '.mhd', '.nhdr', '.nrrd', '.png', '.tiff', '.tif', '.vtk')
+# Split up in real ITK and all supported formats. Right now we say we
+# can do all. But we could also only publish the ITK_FORMATS, yet check
+# on ALL_FORMATS in _can_read.
+ITK_FORMATS = ('.gipl', '.ipl', '.mhd', '.nhdr', '.nrrd', '.vtk', 
+               '.dicom', '.gdcm')
+ALL_FORMATS = ITK_FORMATS + ('.bmp', '.jpeg', '.jpg', '.png', '.tiff', '.tif')
 
 
 class ItkFormat(Format):
@@ -47,11 +51,11 @@ class ItkFormat(Format):
 
     def _can_read(self, request):
         # We support any kind of image data
-        return request.filename.lower().endswith(ITK_FORMATS)
+        return request.filename.lower().endswith(ALL_FORMATS)
 
     def _can_write(self, request):
         # We support any kind of image data
-        return request.filename.lower().endswith(ITK_FORMATS)
+        return request.filename.lower().endswith(ALL_FORMATS)
 
     # -- reader
 
@@ -101,5 +105,5 @@ class ItkFormat(Format):
 
 # Register
 title = "Insight Segmentation and Registration Toolkit (ITK) format"
-format = ItkFormat('itk', title, ' '.join(ITK_FORMATS), 'iIvV')
+format = ItkFormat('itk', title, ' '.join(ALL_FORMATS), 'iIvV')
 formats.add_format(format)

--- a/imageio/plugins/simpleitk.py
+++ b/imageio/plugins/simpleitk.py
@@ -36,11 +36,13 @@ def has_lib():
         if sys.version_info > (3, ):
             import importlib
             return importlib.find_loader('SimpleITK') is not None
-        try:
-            load_lib()
-        except ImportError:
-            return False
-        return True
+        else:
+            import imp
+            try:
+                imp.find_module('SimpleITK')
+            except ImportError:
+                return False
+            return True
 
 
 # Split up in real ITK and all supported formats.

--- a/imageio/plugins/swf.py
+++ b/imageio/plugins/swf.py
@@ -71,9 +71,8 @@ class SWFFormat(Format):
     
     def _can_write(self, request):
         if request.mode[1] in (self.modes + '?'):
-            for ext in self.extensions:
-                if request.filename.endswith('.' + ext):
-                    return True
+            if request.filename.lower().endswith(self.extensions):
+                return True
     
     # -- reader
     

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -157,11 +157,11 @@ class TiffFormat(Format):
 
     def _can_read(self, request):
         # We support any kind of image data
-        return request.filename.lower().endswith(TIFF_FORMATS)
+        return request.filename.lower().endswith(self.extensions)
 
     def _can_write(self, request):
         # We support any kind of image data
-        return request.filename.lower().endswith(TIFF_FORMATS)
+        return request.filename.lower().endswith(self.extensions)
 
     # -- reader
 
@@ -225,5 +225,5 @@ class TiffFormat(Format):
                     self._meta[key] = value
 
 # Register
-format = TiffFormat('tiff', "TIFF format", 'tif tiff stk lsm', 'iIvV')
+format = TiffFormat('tiff', "TIFF format", TIFF_FORMATS, 'iIvV')
 formats.add_format(format)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -290,11 +290,22 @@ def test_format_manager():
     raises(ValueError, formats.add_format, 678)  # must be Format
     raises(ValueError, formats.add_format, myformat)  # cannot add twice
     
+    # Adding a format with the same name
+    myformat2 = Format('test', 'other description', 'foo bar')
+    raises(ValueError, formats.add_format, myformat2)  # same name
+    formats.add_format(myformat2, True)  # overwrite
+    assert formats['test'] is not myformat
+    assert formats['test'] is myformat2
+    
     # Test searchinhg for read / write format
     F = formats.search_read_format(Request(fname, 'ri'))
     assert F is formats['PNG']
     F = formats.search_write_format(Request(fname, 'wi'))
     assert F is formats['PNG']
+    
+    # Test show (we assume it shows correctly)
+    formats.show()
+    
 #   # Potential
 #   bytes = b'x' * 300
 #   F = formats.search_read_format(Request(bytes, 'r?', dummy_potential=1))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -768,6 +768,12 @@ def test_util_image_as_uint8():
     assert res[0] == 0 and res[1] == 255
 
 
+def test_util_has_has_module():
+    
+    assert not core.has_module('this_module_does_not_exist')
+    assert core.has_module('sys')
+
+
 def test_functions():
     """ Test the user-facing API functions """
     

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,6 +27,12 @@ class MyFormat(Format):
     """ TEST DOCS """
     _closed = []
     
+    def _can_read(self, request):
+        return request.filename.lower().endswith(self.extensions + ('.haha', ))
+    
+    def _can_write(self, request):
+        return request.filename.lower().endswith(self.extensions + ('.haha', ))
+    
     class Reader(Format.Reader):
         _failmode = False
         _stream_mode = False
@@ -89,7 +95,7 @@ def test_format():
     assert F.name in repr(F)
     assert F.name in F.doc
     assert str(F) == F.doc
-    assert set(F.extensions) == set(['foo', 'bar', 'spam'])
+    assert set(F.extensions) == set(['.foo', '.bar', '.spam'])
     
     # Test setting extensions
     F1 = Format('test', '', 'foo bar spam')
@@ -97,7 +103,7 @@ def test_format():
     F3 = Format('test', '', ['foo', 'bar', 'spam'])
     F4 = Format('test', '', '.foo .bar .spam')
     for F in (F1, F2, F3, F4):
-        assert set(F.extensions) == set(['foo', 'bar', 'spam'])
+        assert set(F.extensions) == set(['.foo', '.bar', '.spam'])
     # Fail
     raises(ValueError, Format, 'test', '', 3)  # not valid ext
     raises(ValueError, Format, 'test', '', '', 3)  # not valid mode
@@ -238,6 +244,40 @@ def test_default_can_read_and_can_write():
     assert not F.can_write(Request(filename1 + '.foo', 'wi'))
 
 
+def test_format_selection():
+    
+    formats = imageio.formats
+    fname1 = get_remote_file('images/chelsea.png', test_dir)
+    fname2 = os.path.join(test_dir, 'test.selectext1')
+    fname3 = os.path.join(test_dir, 'test.haha')
+    open(fname2, 'wb')
+    open(fname3, 'wb')
+    
+    # Test searchinhg for read / write format
+    F = formats.search_read_format(Request(fname1, 'ri'))
+    assert F is formats['PNG']
+    F = formats.search_write_format(Request(fname1, 'wi'))
+    assert F is formats['PNG']
+    
+    # Now with custom format
+    format = MyFormat('test_selection', 'xx', 'selectext1', 'i')
+    formats.add_format(format)
+    
+    # Select this format for files it said it could handle in extensions
+    assert '.selectext1' in fname2
+    F = formats.search_read_format(Request(fname2, 'ri'))
+    assert F is format
+    F = formats.search_write_format(Request(fname2, 'ri'))
+    assert F is format
+    
+    # But this custom format also can deal with .haha files
+    assert '.haha' in fname3
+    F = formats.search_read_format(Request(fname3, 'ri'))
+    assert F is format
+    F = formats.search_write_format(Request(fname3, 'ri'))
+    assert F is format
+
+
 def test_format_manager():
     """ Test working of the format manager """
     
@@ -296,12 +336,6 @@ def test_format_manager():
     formats.add_format(myformat2, True)  # overwrite
     assert formats['test'] is not myformat
     assert formats['test'] is myformat2
-    
-    # Test searchinhg for read / write format
-    F = formats.search_read_format(Request(fname, 'ri'))
-    assert F is formats['PNG']
-    F = formats.search_write_format(Request(fname, 'wi'))
-    assert F is formats['PNG']
     
     # Test show (we assume it shows correctly)
     formats.show()


### PR DESCRIPTION
* The format manager first selects formats based on the extensions and modes of the formats. Then it asks these whether they can read/write. If none could, it asks the remaining formats if they can read/write. 
* This allows more flexibility (e.g. support more formats than published in the extensions)
* It also avoids calling freeimage's `_can_read` when reading/writing a file that is known to be supported by another format (e.g. video)
* Freeimage lazily loads its library at the moment that it really needs it. Together with the above, the freeimage lib is never used/downloaded if you only use it for video or another non-freeimage format. 

This could use an extra pair of eyes. @blink1073. Also cc @Zulko because he'd like this.

Slightly related to #93. Paving the way for #62. Also helps towards #33.
