### PR TITLE
Add Single 3D/4D volume file support (.mha and .nii)

### DIFF
--- a/imageio/plugins/simpleitk.py
+++ b/imageio/plugins/simpleitk.py
@@ -28,7 +28,7 @@ def load_lib():
 
 
 # Split up in real ITK and all supported formats.
-ITK_FORMATS = ('.gipl', '.ipl', '.mhd', '.nhdr', '.nrrd', '.vtk')
+ITK_FORMATS = ('.gipl', '.ipl', '.mha', '.mhd', '.nhdr', '.nii', '.nrrd', '.vtk')
 ALL_FORMATS = ITK_FORMATS + ('.bmp', '.jpeg', '.jpg', '.png', '.tiff', '.tif',
                              '.dicom', '.gdcm')
 


### PR DESCRIPTION
fixes #14 and #29

Using SimpleITK and adding the following file extensions adds NIFTI and MetaImage format that is in a single file format.