### PR TITLE
imageio.imwrite was failing with tifffile plugin. 

### DIFF
--- a/imageio/plugins/_tifffile.py
+++ b/imageio/plugins/_tifffile.py
@@ -280,7 +280,7 @@ class TiffWriter(object):
 
     def save(self, data, photometric=None, planarconfig=None, resolution=None,
              description=None, volume=False, writeshape=False, compress=0,
-             extratags=()):
+             extratags=(), **kwargs):
         """Write image data to TIFF file.
 
         Image data are written in one stripe per plane.

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -68,4 +68,11 @@ def test_tifffile_reading_writing():
     raises(IndexError, R.get_data, -1)
     raises(IndexError, R.get_data, 3)
 
+    # Ensure imwrite write works round trip
+    filename3 = os.path.join(test_dir, 'test_tiff2.tiff')
+    R = imageio.imread(filename1)
+    imageio.imwrite(filename3, R)
+    R2 = imageio.imread(filename3)
+    assert (R == R2).all()
+
 run_tests_if_main()


### PR DESCRIPTION
Extra keyword arguments were being supplied to the _tifffile save function via the metadata.

I added a test that captures this error.

To fix the error I added **kwargs to the save function to ignore the extra meta data. This may not be the ideal fix, I'm not sure if the meta data needs to be re-mapped to the keys in save since some seem to be similar to the keys in the save function (ie is_contig, planar_configuration and planarconfig,  compression and compress, ...).

For reference, here is the original error this addresses:

  File "cmd_image.py", line 64, in process
    imageio.imwrite(outf, im)
  File "imageio/imageio/core/functions.py", line 219, in imwrite
    writer.append_data(im)
  File "imageio/imageio/core/format.py", line 466, in append_data
    return self._append_data(im, total_meta)
  File "imageio/imageio/plugins/tifffile.py", line 218, in _append_data
    self._tf.save(np.asanyarray(im), **meta)
TypeError: save() got an unexpected keyword argument 'is_contig'