### PR TITLE
Fix bug where the ffmpeg plugin fails on certain video files

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -819,7 +819,8 @@ class StreamCatcher(threading.Thread):
                     header = b'\n'.join(self._lines)
                     self._header += header.decode('utf-8', 'ignore')
                     self._lines = []
-            self._lines = limit_lines(self._lines)
+            if self._header:
+                self._lines = limit_lines(self._lines)
 
 
 # Register. You register an *instance* of a Format class.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ Release:
   * git tag the release
   * Upload to Pypi:
     * python setup.py register
-    * python setup.py sdist_all upload
+    * python setup.py sdist bdist_wheel_all upload
   * Update, build and upload conda package
 
 After release:
@@ -221,11 +221,13 @@ class bdist_wheel_all(bdist_wheel):
         
         # Create archives
         dist_files = self.distribution.dist_files
+        while dist_files:
+            dist_files.pop()
         pyver = 'cp26.cp27.cp33.cp34.cp35'
         for plat in ['win64', 'osx64']:
             fname = self._create_wheels_for_platform(resource_dir,
                                                      plat, pyver)
-        dist_files.append(('bdist_wheel', 'any', 'dist/'+fname))
+            dist_files.append(('bdist_wheel', 'any', 'dist/'+fname))
 
         # Clean up
         shutil.rmtree(build_dir)


### PR DESCRIPTION
When trying to open a video that contains a lot of metadata, the ffmpeg plugin will limit the number of lines in the caught header, resulting in some of the required metadata being lost.

To reproduce, download and extract [many_chapters.zip](https://github.com/imageio/imageio/files/87004/many_chapters.zip) and run

    import imageio
    reader = imageio.get_reader("many_chapters.mp4")

Expected behaviour: the ffmpeg plugin opens the file without issue.
Actual behaviour: IndexError in [imageio/plugins/ffmpeg.py:461](https://github.com/imageio/imageio/blob/872a317b6d69a1d65ec07561754e88f797461fae/imageio/plugins/ffmpeg.py#L461) due to the "Duration: " line having been thrown away.

My proposed fix is to just wait until the header has been set before limiting the subsequent lines.
