### PR TITLE
Disable travis tests for gdal to prevent segfaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,9 +83,10 @@ install:
         pip install -q coveralls;
       fi;
     # Install optional dependencies
+    # We do NOT conda install gdal, because it causes segfaults
     - if [ "${TEST_FULL}" == "1" ]; then
        easy_install -q simpleitk; true;
-       conda install -y gdal astropy;
+       conda install -y astropy;
       fi;
     # Install imageio, use installed version on only one machine
     - if [ "${TEST_INSTALL}" == "1" ]; then


### PR DESCRIPTION
cc @blink1073 

Even if gdal tests are skipped, the segfault occurs. Maybe it already happens when imported? Or maybe gdal tries to open a file that it should not? This could do with some more research, but for now I just don't install gdal on Travis.