### PR TITLE
Update conda in travis and appveyor - fix appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
     - REDIRECT_TO=/dev/stdout  # change to /dev/null to silence Travis
     # Install miniconda
     - if [ "${TEST_UNIT}" == "1" ]; then
-        wget -q http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh -O miniconda.sh;
+        wget -q http://repo.continuum.io/miniconda/Miniconda3-4.0.5-Linux-x86_64.sh -O miniconda.sh;
         chmod +x miniconda.sh;
         ./miniconda.sh -b -p ~/anaconda &> ${REDIRECT_TO};
         export PATH=~/anaconda/bin:$PATH;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,12 +12,12 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34-conda32"
-      PYTHON_VERSION: "3.4"
+    - PYTHON: "C:\\Python35-conda32"
+      PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python34-conda64"
-      PYTHON_VERSION: "3.4"
+    - PYTHON: "C:\\Python35-conda64"
+      PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
 
 install:

--- a/make/install_python.ps1
+++ b/make/install_python.ps1
@@ -96,10 +96,10 @@ function InstallPip ($python_home) {
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -eq "3.4") {
-        $filename = "Miniconda3-3.5.5-Windows-" + $platform_suffix + ".exe"
+    if ($python_version -eq "3.5") {
+        $filename = "Miniconda3-4.0.5-Windows-" + $platform_suffix + ".exe"
     } else {
-        $filename = "Miniconda-3.5.5-Windows-" + $platform_suffix + ".exe"
+        $filename = "Miniconda2-4.0.5-Windows-" + $platform_suffix + ".exe"
     }
     $url = $MINICONDA_URL + $filename
 
@@ -176,7 +176,7 @@ function InstallMinicondaPip ($python_home) {
 function InstallMinicondaNumpy ($python_home) {
     $conda_path = $python_home + "\Scripts\conda.exe"
     Write-Host "Installing numpy..."
-    $args = "install --yes numpy"
+    $args = "install --yes numpy msvc_runtime"
     Write-Host $conda_path $args
     Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
 }


### PR DESCRIPTION
This updates the conda version used on both Travis and Appeveyor. Let's also try make Appveyor work again.

See https://github.com/matplotlib/matplotlib/issues/6115 for what looks like the same issue.