### PR TITLE
Partial fix for saving exr images

### DIFF
--- a/imageio/plugins/_freeimage.py
+++ b/imageio/plugins/_freeimage.py
@@ -957,24 +957,16 @@ class FIBitmap(FIBaseBitmap):
         wrapped_array = self._wrap_bitmap_bits_in_array(w_shape, dtype, True)
         # swizzle the color components and flip the scanlines to go to
         # FreeImage's BGR[A] and upside-down internal memory format
-        if len(shape) == 3:
+        if len(shape) == 3 and isle and dtype.type == numpy.uint8:
             R = array[:, :, 0]
             G = array[:, :, 1]
             B = array[:, :, 2]
-        
-            if isle:
-                if dtype.type == numpy.uint8:
-                    wrapped_array[0] = n(B)
-                    wrapped_array[1] = n(G)
-                    wrapped_array[2] = n(R)
-                elif dtype.type == numpy.uint16:
-                    wrapped_array[0] = n(R)
-                    wrapped_array[1] = n(G)
-                    wrapped_array[2] = n(B)
-                #
-                if shape[2] == 4:
-                    A = array[:, :, 3]
-                    wrapped_array[3] = n(A)
+            wrapped_array[0] = n(B)
+            wrapped_array[1] = n(G)
+            wrapped_array[2] = n(R)
+            if shape[2] == 4:
+                A = array[:, :, 3]
+                wrapped_array[3] = n(A)
         else:
             wrapped_array[:] = n(array)
         if self._need_finish:

--- a/imageio/plugins/_freeimage.py
+++ b/imageio/plugins/_freeimage.py
@@ -957,6 +957,9 @@ class FIBitmap(FIBaseBitmap):
         wrapped_array = self._wrap_bitmap_bits_in_array(w_shape, dtype, True)
         # swizzle the color components and flip the scanlines to go to
         # FreeImage's BGR[A] and upside-down internal memory format
+        # The BGR[A] order is only used for 8bits per channel images
+        # on little endian machines. For everything else RGB[A] is
+        # used.
         if len(shape) == 3 and isle and dtype.type == numpy.uint8:
             R = array[:, :, 0]
             G = array[:, :, 1]

--- a/imageio/plugins/_freeimage.py
+++ b/imageio/plugins/_freeimage.py
@@ -953,7 +953,7 @@ class FIBitmap(FIBaseBitmap):
             n_channels = shape[0]
         
         def n(arr):  # normalise to freeimage's in-memory format
-            return arr.T[:, ::-1]
+            return arr[::-1].T
         wrapped_array = self._wrap_bitmap_bits_in_array(w_shape, dtype, True)
         # swizzle the color components and flip the scanlines to go to
         # FreeImage's BGR[A] and upside-down internal memory format


### PR DESCRIPTION
Just had a quick look at bug #144
It seems to me like the old code shouldn't work at all for big endian systems or images in formats other than uint8 or uint16.
Or am I missing something?

The exr images are now saved upside down though :(
I'm guessing freeimage doesn't like the scanline swap for some formats?