### PR TITLE
Fix findlib test on Debian

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -92,8 +92,8 @@ def test_findlib():
     if not sys.platform.startswith('linux'):
         return
     
-    # Candidate libs for common lib
-    dirs, paths = core.findlib.generate_candidate_libs(['libpython'])
+    # Candidate libs for common lib (note, this runs only on linux)
+    dirs, paths = core.findlib.generate_candidate_libs(['libc'])
     assert paths
     
     # Candidate libs for common freeimage


### PR DESCRIPTION
@ghisvail this should fix the `test_findlib()` mentioned in #151