### PR TITLE
Ffmpeg read & write bug fixes

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -333,7 +333,7 @@ class FfmpegFormat(Format):
             elif index >= self._meta['nframes']:
                 raise IndexError('Reached end of video')
             else:
-                if (index < self._pos) or (index > self._pos+100):
+                if (index < self._pos) or (index > self._pos+100): # May want to reduce from 100
                     self._reinitialize(index)
                 else:
                     self._skip_frames(index-self._pos-1)
@@ -381,9 +381,10 @@ class FfmpegFormat(Format):
                 offset = min(1, starttime)
 
                 # Create input args -> start time
-                iargs = ['-ss', "%.03f" % (starttime-offset),
+                # Need minimum 6 significant digits for high fps videos
+                iargs = ['-ss', "%.06f" % (starttime),
                          '-i', self._filename,
-                         '-ss', "%.03f" % offset]
+                         ]
 
                 # Output args, for writing to pipe
                 oargs = ['-f', 'image2pipe',
@@ -394,6 +395,7 @@ class FfmpegFormat(Format):
                 # Create process
                 cmd = [self._exe]
                 cmd += iargs + oargs + ['-']
+                print(cmd)
                 self._proc = sp.Popen(cmd, stdin=sp.PIPE,
                                       stdout=sp.PIPE, stderr=sp.PIPE)
 

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -381,7 +381,8 @@ class FfmpegFormat(Format):
                 offset = min(1, starttime)
 
                 # Create input args -> start time
-                # Need minimum 6 significant digits for high fps videos
+                # Need minimum 6 significant digits accurate frame seeking
+                # and to support higher fps videos
                 iargs = ['-ss', "%.06f" % (starttime),
                          '-i', self._filename,
                          ]
@@ -395,7 +396,6 @@ class FfmpegFormat(Format):
                 # Create process
                 cmd = [self._exe]
                 cmd += iargs + oargs + ['-']
-                print(cmd)
                 self._proc = sp.Popen(cmd, stdin=sp.PIPE,
                                       stdout=sp.PIPE, stderr=sp.PIPE)
 

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -382,7 +382,10 @@ class FfmpegFormat(Format):
                 # Create input args -> start time
                 # Need minimum 6 significant digits accurate frame seeking
                 # and to support higher fps videos
-                iargs = ['-ss', "%.06f" % (starttime),
+                # Also appears this epsilon below is needed to ensure frame
+                # accurate seeking in some cases
+                epsilon = -1/self._meta['fps']*0.1
+                iargs = ['-ss', "%.06f" % (starttime+epsilon),
                          '-i', self._filename,
                          ]
 

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -687,7 +687,6 @@ class FfmpegFormat(Format):
                     # May need a way to find range for any codec.
                     quality = int(quality*30)+1
                     cmd += ['-qscale:v', str(quality)]  # for others
-            cmd += ['-r', "%d" % fps]
 
             # Note, for most codecs, the image dimensions must be divisible by
             # 16 the default for the macro_block_size is 16. Check if image is

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -378,7 +378,6 @@ class FfmpegFormat(Format):
                 self._initialize()
             else:
                 starttime = index / self._meta['fps']
-                offset = min(1, starttime)
 
                 # Create input args -> start time
                 # Need minimum 6 significant digits accurate frame seeking

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -333,7 +333,7 @@ class FfmpegFormat(Format):
             elif index >= self._meta['nframes']:
                 raise IndexError('Reached end of video')
             else:
-                if (index < self._pos) or (index > self._pos+100): # May want to reduce from 100
+                if (index < self._pos) or (index > self._pos+100):
                     self._reinitialize(index)
                 else:
                     self._skip_frames(index-self._pos-1)


### PR DESCRIPTION
FFMPEG writer had 2 -r flags setting the frame rate. Removed 2nd one since it was overriding first one and it was outputting decimal rather than float causing incorrect frame rates to be created. Before this bug fix creating videos at frame rates like 29.97 fps would end up being 29 fps.

FFMPEG reader does not need two -ss flags to seek to specific time anymore. Now ffpmeg can do frame accurate seeking more efficiently with one call (see https://trac.ffmpeg.org/wiki/Seeking). I had to also increase the number of significant digits to seek time to ensure it accurately seeks but now we can directly go to the desired frame rather than seek to nearby frame and read forward to desired frame. Before this bug fix reading videos with frame rates like 30 fps and seeking to a specific frame often at times off by one especially when going backwards in index.