### PR TITLE
ffmpeg: better regexp to find fps

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -483,10 +483,10 @@ class FfmpegFormat(Format):
             line = videolines[0]
             
             # get the frame rate
-            match = re.search("( [0-9]*.| )[0-9]* (tbr|fps)", line)
+            matches = re.findall(" ([0-9]+\.?[0-9]*) (tbr|fps)", line)
             fps = 0
-            if match is not None:  # Can happen, see #171, assume nframes = inf
-                fps = float(line[match.start():match.end()].split(' ')[1])
+            if matches:  # Can be empty, see #171, assume nframes = inf
+                fps = float(matches[0][0].strip())
             self._meta['fps'] = fps
 
             # get the size of the original stream, of the form 460x320 (w x h)


### PR DESCRIPTION
Fixes #206

@kuchi might want to double-check. The old regexp seems a bit odd/broken, but maybe I miss something?

The new regexp tests for a number, optionally followed by a dot and more numbers, followed by a space and then either 'fps' or 'tbr'.