### PR TITLE
fix for ffmpeg not properly terminating

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -425,7 +425,6 @@ class FfmpegFormat(Format):
                 self._frame_catcher.stop_me()
 
 
-
         def _load_infos(self):
             """ reads the FFMPEG info on the file and sets size fps
             duration and nframes. """

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -424,7 +424,6 @@ class FfmpegFormat(Format):
             if self._frame_catcher:
                 self._frame_catcher.stop_me()
 
-
         def _load_infos(self):
             """ reads the FFMPEG info on the file and sets size fps
             duration and nframes. """

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -414,25 +414,10 @@ class FfmpegFormat(Format):
                 return  # process already dead
             # Terminate process
             self._proc.terminate()
-            # Tell threads to stop when they have a chance. They are probably
-            # blocked on reading from their file, but let's play it safe.
-            if self._stderr_catcher:
-                self._stderr_catcher.stop_me()
-            if self._frame_catcher:
-                self._frame_catcher.stop_me()
-            # Close stdin as another way to tell ffmpeg that we're done. Don't
-            # close other streams, because it causes issue #174
-            try:
-                self._proc.stdin.close()
-            except Exception:  # pragma: no cover
-                pass
-            # Wait for it to close (but do not get stuck)
-            etime = time.time() + timeout
-            while time.time() < etime:
-                time.sleep(0.01)
-                if self._proc.poll() is not None:
-                    return
-            # self._proc.kill()  # probably not needed ...
+            # Terminate process
+            # Using kill since self._proc.terminate() does not seem
+            # to work for ffmpeg, leaves processes hanging
+            self._proc.kill()
 
         def _load_infos(self):
             """ reads the FFMPEG info on the file and sets size fps

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -413,8 +413,6 @@ class FfmpegFormat(Format):
             if self._proc.poll() is not None:
                 return  # process already dead
             # Terminate process
-            self._proc.terminate()
-            # Terminate process
             # Using kill since self._proc.terminate() does not seem
             # to work for ffmpeg, leaves processes hanging
             self._proc.kill()

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -374,6 +374,7 @@ def show_in_visvis():
         t.SetData(reader.get_next_data())
         vv.processEvents()
 
+
 def test_reverse_read(tmpdir):
     # Ensure we can read a file in reverse without error.
 
@@ -391,6 +392,7 @@ def test_reverse_read(tmpdir):
         print("reading", i)
         W.get_data(i)
     W.close()
+
 
 if __name__ == '__main__':
     run_tests_if_main()

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -384,7 +384,7 @@ def test_reverse_read(tmpdir):
     tmpf = tmpdir.join('test.mp4')
     W = imageio.get_writer(str(tmpf))
     for i in range(300):
-        W.append_data(np.zeros((10, 10, 3), np.uint8))
+        W.append_data(np.zeros((16, 16, 3), np.uint8))
     W.close()
 
     W = imageio.get_reader(str(tmpf))

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -374,6 +374,24 @@ def show_in_visvis():
         t.SetData(reader.get_next_data())
         vv.processEvents()
 
+def test_reverse_read(tmpdir):
+    # Ensure we can read a file in reverse without error.
+    # This can catch a bug if ffmpeg is not closed properly since
+    # reading in reverse required closing & opening with seeking.
+    # Note that before the bug was fixes this would just hang
+    # after having too many ffmpeg processes left open.
+
+    tmpf = tmpdir.join('test.mp4')
+    W = imageio.get_writer(str(tmpf))
+    for i in range(300):
+        W.append_data(np.zeros((10, 10, 3), np.uint8))
+    W.close()
+
+    W = imageio.get_reader(str(tmpf))
+    for i in range(len(W)-1, 0, -1):
+        print "reading", i
+        W.get_data(i)
+    W.close()
 
 if __name__ == '__main__':
     run_tests_if_main()

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -377,13 +377,13 @@ def show_in_visvis():
 def test_reverse_read(tmpdir):
     # Ensure we can read a file in reverse without error.
 
-    tmpf = tmpdir.join('test.mp4')
+    tmpf = tmpdir.join('test_vid.mp4')
     W = imageio.get_writer(str(tmpf))
     # May need to set this to 300 to check for hanging ffmpeg
     # processes, but it can take a while and might cause problems
     # for CI testing.
     for i in range(20):
-        W.append_data(np.zeros((16, 16, 3), np.uint8))
+        W.append_data(np.zeros((64, 64, 3), np.uint8))
     W.close()
 
     W = imageio.get_reader(str(tmpf))

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -381,10 +381,7 @@ def test_reverse_read(tmpdir):
 
     tmpf = tmpdir.join('test_vid.mp4')
     W = imageio.get_writer(str(tmpf))
-    # May need to set this to 300 to check for hanging ffmpeg
-    # processes, but it can take a while and might cause problems
-    # for CI testing.
-    for i in range(20):
+    for i in range(300):
         W.append_data(np.zeros((64, 64, 3), np.uint8))
     W.close()
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -376,6 +376,7 @@ def show_in_visvis():
 
 
 def test_reverse_read(tmpdir):
+    need_internet()
     # Ensure we can read a file in reverse without error.
 
     tmpf = tmpdir.join('test_vid.mp4')

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -376,20 +376,19 @@ def show_in_visvis():
 
 def test_reverse_read(tmpdir):
     # Ensure we can read a file in reverse without error.
-    # This can catch a bug if ffmpeg is not closed properly since
-    # reading in reverse required closing & opening with seeking.
-    # Note that before the bug was fixes this would just hang
-    # after having too many ffmpeg processes left open.
 
     tmpf = tmpdir.join('test.mp4')
     W = imageio.get_writer(str(tmpf))
-    for i in range(300):
+    # May need to set this to 300 to check for hanging ffmpeg
+    # processes, but it can take a while and might cause problems
+    # for CI testing.
+    for i in range(20):
         W.append_data(np.zeros((16, 16, 3), np.uint8))
     W.close()
 
     W = imageio.get_reader(str(tmpf))
     for i in range(len(W)-1, 0, -1):
-        print "reading", i
+        print("reading", i)
         W.get_data(i)
     W.close()
 


### PR DESCRIPTION
Fix to completely terminate ffmpeg using proc.kill() since proc.terminate() does not seem to work for ffmpeg. Should address #212 
All ffmpeg tests still pass on my system (OS X) so hopefully this is a fix that works on all platforms.
This fix also substantially improves the performance of the ffmpeg reader when having to reinitialize since not there is no wait for the process to die.