### PR TITLE
Fix for Issue #242, saving empty animated image

### DIFF
--- a/imageio/core/functions.py
+++ b/imageio/core/functions.py
@@ -298,6 +298,10 @@ def mimwrite(uri, ims, format=None, **kwargs):
         to see what arguments are available for a particular format.
     """ 
     
+    #Ensure non empty sequence
+    if len(ims) == 0:
+        raise ValueError('Numpy sequence must not be empty.')
+    
     # Get writer
     writer = get_writer(uri, format, 'I', **kwargs)
     with writer:


### PR DESCRIPTION
Fix for #242,  simple length check on the input sequence. 

I've never heard of a gif file with no data, but I think if someone wanted that, they could make their own file trivially 😏.