### PR TITLE
Let Pillow do the de-paletting when transparency is involved

### DIFF
--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -316,6 +316,19 @@ def test_animated_gif():
     assert isinstance(imageio.read(fname).get_meta_data(), dict)
 
 
+def test_images_with_transparency():
+    # Not alpha channel, but transparent pixels, see issue #245 and #246
+    need_internet()
+    
+    fname = get_remote_file('images/imageio_issue245.gif')
+    im = imageio.imread(fname)
+    assert im.shape == (24, 30, 4)
+    
+    fname = get_remote_file('images/imageio_issue246.png')
+    im = imageio.imread(fname)
+    assert im.shape == (24, 30, 4)
+
+
 if __name__ == '__main__':
     # test_png()
     # test_animated_gif()


### PR DESCRIPTION
To clarify, when a paletted image has transparency in the form of  a specific index set to be transparent, rather than having actual RGBA palette values, Pillow reports its `palette.mode` to be `RGBA`. This PR lets Pillow do the de-paletting (converting to RGBA) in this case by testing `im.info['transparency']`.

Fixes #246, and relates to #210 and #245.

Todo: at test for his case