### PR TITLE
New ffmpeg exes + support to use ffmpeg from conda

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -29,12 +29,12 @@ from ..core import (Format, get_remote_file, string_types, read_n_bytes,
                     InternetNotAllowedError, NeedDownloadError)
 
 FNAME_PER_PLATFORM = {
-    'osx32': 'ffmpeg.osx',
-    'osx64': 'ffmpeg.osx',
-    'win32': 'ffmpeg.win32.exe',
-    'win64': 'ffmpeg.win32.exe',
-    'linux32': 'ffmpeg.linux32',
-    'linux64': 'ffmpeg.linux64',
+    'osx32': 'ffmpeg-osx-v3.3.1',
+    'osx64': 'ffmpeg-osx-v3.3.1',
+    'win32': 'ffmpeg-win32-v3.2.4.exe',
+    'win64': 'ffmpeg-win32-v3.2.4.exe',
+    'linux32': 'ffmpeg-linux32-v3.3.1',
+    'linux64': 'ffmpeg-linux64-v3.3.1',
 }
 
 

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -544,13 +544,14 @@ class FfmpegFormat(Format):
                 else:
                     s = read_n_bytes(self._proc.stdout, framesize)
                 # Check
-                assert len(s) == framesize
+                if len(s) != framesize:
+                    raise RuntimeError('Frame is %i bytes, but expected %i.' % (len(s), framesize))
             except Exception as err:
                 self._terminate()
                 err1 = str(err)
                 err2 = self._stderr_catcher.get_text(0.4)
-                fmt = 'Could not read frame:\n%s\n=== stderr ===\n%s'
-                raise CannotReadFrameError(fmt % (err1, err2))
+                fmt = 'Could not read frame %i:\n%s\n=== stderr ===\n%s'
+                raise CannotReadFrameError(fmt % (self._pos, err1, err2))
             return s
 
         def _skip_frames(self, n=1):

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -496,7 +496,7 @@ class FfmpegFormat(Format):
 
             # get the output line that speaks about video
             videolines = [l for l in lines if l.lstrip().startswith('Stream ')
-                                           and ' Video: ' in l]
+                          and ' Video: ' in l]
             line = videolines[0]
             
             # get the frame rate
@@ -548,7 +548,8 @@ class FfmpegFormat(Format):
                     s = read_n_bytes(self._proc.stdout, framesize)
                 # Check
                 if len(s) != framesize:
-                    raise RuntimeError('Frame is %i bytes, but expected %i.' % (len(s), framesize))
+                    raise RuntimeError('Frame is %i bytes, but expected %i.' %
+                                       (len(s), framesize))
             except Exception as err:
                 self._terminate()
                 err1 = str(err)
@@ -908,10 +909,8 @@ def get_output_video_line(lines):
     in_output = False
     for line in lines:
         sline = line.lstrip()
-        if line.startswith(b'Output '):
+        if sline.startswith(b'Output '):
             in_output = True
-        elif len(sline) == len(line):
-            in_output = False
         elif in_output:
             if sline.startswith(b'Stream ') and b' Video:' in sline:
                 return line


### PR DESCRIPTION
Fixes #219 
Relates to #252

I uploaded new ffmpeg binaries to our special repo that contains binaries and images. This updates the refs to make the download mechanism use these. Also added functionality to find the ffmpeg provided by the conda-forge ffmpeg package.

@Zulko might want to know about this.

I tested that the new binaries work well on Linux and Windows. I was not able to do so on OSX because my OSX VM is sort of broken (or perhaps too old). If someone can give that a go (before or after I merge this), that would be great. Just pull these changes and try running:
```py
import imageio
with imageio.get_reader('imageio:cockatoo.mp4') as reader:
    for im in reader:
        print(im.shape)
```
and you should get a bunch of `(720, 1280, 3)`.
