### PR TITLE
New plugins for grabbing screenshots and image data from clipboard

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -49,6 +49,19 @@ Iterate over frames in a movie
         print('Mean of frame %i is %1.1f' % (i, im.mean()))
 
 
+Grab screenshot or image from the clipboard
+-------------------------------------------
+
+(Screenshots are supported on Windows and OS X, clipboard on Windows only.)
+
+.. code-block:: python
+    
+    import imageio
+    
+    im_screen = imageio.imread('<screen>')
+    im_clipboard = imageio.imread('<clipboard>')
+
+
 Grab frames from your webcam
 ----------------------------
 

--- a/imageio/core/functions.py
+++ b/imageio/core/functions.py
@@ -33,12 +33,31 @@ be used to read/write data and meta data in a more controlled manner.
 This also allows specific scientific formats to be exposed in a way
 that best suits that file-format.
 
+----
 
-.. note::
-    
-    Some of these functions were renamed in v1.1 to realize a more clear
-    and consistent API. The old functions are still available for
-    backward compatibility (and will be in the foreseeable future).
+Supported resource URI's:
+
+All functions described here accept a URI to describe the resource to
+read from or write to. These can be a wide range of things. (Imageio
+takes care of handling the URI so that plugins can access the data in
+an easy way.)
+
+For reading and writing:
+
+* a normal filename, e.g. ``'c:\\foo\\bar.png'``
+* a file in a zipfile, e.g. ``'c:\\foo\\bar.zip\\eggs.png'``
+* a file object with a ``read()`` / ``write()`` method.
+
+For reading:
+
+* an http/ftp address, e.g. ``'http://example.com/foo.png'``
+* the raw bytes of an image file
+* ``get_reader("<video0>")`` to grab images from a (web) camera.
+* ``imread("<screen>")`` to grab a screenshot (on Windows or OS X).
+* ``imread("<clipboard>")`` to grab an image from the clipboard (on Windows).
+
+For writing one can also use ``'<bytes>'`` or ``imageio.RETURN_BYTES`` to
+make a write function return the bytes instead of writing to a file.
 
 """
 
@@ -80,9 +99,8 @@ def get_reader(uri, format=None, mode='?', **kwargs):
     Parameters
     ----------
     uri : {str, bytes, file}
-        The resource to load the image from. This can be a normal
-        filename, a file in a zipfile, an http/ftp address, a file
-        object, or the raw bytes of an image file.
+        The resource to load the image from, e.g. a filename, http address or
+        file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
         the appropriate for you based on the filename and its contents.
@@ -120,10 +138,8 @@ def get_writer(uri, format=None, mode='?', **kwargs):
     Parameters
     ----------
     uri : {str, file}
-        The resource to write the image to. This can be a normal
-        filename, a file in a zipfile, a file object, or
-        ``imageio.RETURN_BYTES``, in which case the raw bytes are
-        returned.
+        The resource to write the image to, e.g. a filename or file object,
+        see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
         the appropriate for you based on the filename.
@@ -170,9 +186,8 @@ def imread(uri, format=None, **kwargs):
     Parameters
     ----------
     uri : {str, bytes, file}
-        The resource to load the image from. This can be a normal
-        filename, a file in a zipfile, an http/ftp address, a file
-        object, or the raw bytes.
+        The resource to load the image from, e.g. a filename, http address or
+        file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
         the appropriate for you based on the filename and its contents.
@@ -195,10 +210,8 @@ def imwrite(uri, im, format=None, **kwargs):
     Parameters
     ----------
     uri : {str, file}
-        The resource to write the image to. This can be a normal
-        filename, a file in a zipfile, a file object, or
-        ``imageio.RETURN_BYTES``, in which case the raw bytes are
-        returned.
+        The resource to write the image to, e.g. a filename or file object,
+        see the docs for more info.
     im : numpy.ndarray
         The image data. Must be NxM, NxMx3 or NxMx4.
     format : str
@@ -240,9 +253,8 @@ def mimread(uri, format=None, memtest=True, **kwargs):
     Parameters
     ----------
     uri : {str, bytes, file}
-        The resource to load the images from. This can be a normal
-        filename, a file in a zipfile, an http/ftp address, a file
-        object, or the raw bytes.
+        The resource to load the images from, e.g. a filename, http address or
+        file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
         the appropriate for you based on the filename and its contents.
@@ -284,10 +296,8 @@ def mimwrite(uri, ims, format=None, **kwargs):
     Parameters
     ----------
     uri : {str, file}
-        The resource to write the images to. This can be a normal
-        filename, a file in a zipfile, a file object, or
-        ``imageio.RETURN_BYTES``, in which case the raw bytes are
-        returned.
+        The resource to write the images to, e.g. a filename or file object,
+        see the docs for more info.
     ims : sequence of numpy arrays
         The image data. Each array must be NxM, NxMx3 or NxMx4.
     format : str
@@ -339,9 +349,8 @@ def volread(uri, format=None, **kwargs):
     Parameters
     ----------
     uri : {str, bytes, file}
-        The resource to load the volume from. This can be a normal
-        filename, a file in a zipfile, an http/ftp address, a file
-        object, or the raw bytes.
+        The resource to load the volume from, e.g. a filename, http address or
+        file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
         the appropriate for you based on the filename and its contents.
@@ -364,10 +373,8 @@ def volwrite(uri, im, format=None, **kwargs):
     Parameters
     ----------
     uri : {str, file}
-        The resource to write the image to. This can be a normal
-        filename, a file in a zipfile, a file object, or
-        ``imageio.RETURN_BYTES``, in which case the raw bytes are
-        returned.
+        The resource to write the image to, e.g. a filename or file object,
+        see the docs for more info.
     vol : numpy.ndarray
         The image data. Must be NxMxL (or NxMxLxK if each voxel is a tuple).
     format : str
@@ -410,9 +417,8 @@ def mvolread(uri, format=None, memtest=True, **kwargs):
     Parameters
     ----------
     uri : {str, bytes, file}
-        The resource to load the volumes from. This can be a normal
-        filename, a file in a zipfile, an http/ftp address, a file
-        object, or the raw bytes.
+        The resource to load the volumes from, e.g. a filename, http address or
+        file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
         the appropriate for you based on the filename and its contents.
@@ -453,10 +459,8 @@ def mvolwrite(uri, ims, format=None, **kwargs):
     Parameters
     ----------
     uri : {str, file}
-        The resource to write the volumes to. This can be a normal
-        filename, a file in a zipfile, a file object, or
-        ``imageio.RETURN_BYTES``, in which case the raw bytes are
-        returned.
+        The resource to write the volumes to, e.g. a filename or file object,
+        see the docs for more info.
     ims : sequence of numpy arrays
         The image data. Each array must be NxMxL (or NxMxLxK if each
         voxel is a tuple).

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -26,6 +26,8 @@ URI_ZIPPED = 4
 URI_HTTP = 5
 URI_FTP = 6
 
+SPECIAL_READ_URIS = '<video', '<screen>', '<clipboard>'
+
 # The user can use this string in a write call to get the data back as bytes.
 RETURN_BYTES = '<bytes>'
 
@@ -148,7 +150,7 @@ class Request(object):
             elif uri.startswith('file://'):
                 self._uri_type = URI_FILENAME
                 self._filename = uri[7:]
-            elif uri.startswith('<video') and is_read_request:
+            elif uri.startswith(SPECIAL_READ_URIS) and is_read_request:
                 self._uri_type = URI_BYTES
                 self._filename = uri
             elif uri.startswith(RETURN_BYTES) and is_write_request:

--- a/imageio/plugins/__init__.py
+++ b/imageio/plugins/__init__.py
@@ -83,6 +83,7 @@ For the Format.Writer class:
 # First import plugins that we want to take precedence over freeimage
 from . import tifffile
 from . import pillow
+from . import grab
 
 from . import freeimage
 from . import freeimagemulti

--- a/imageio/plugins/grab.py
+++ b/imageio/plugins/grab.py
@@ -120,7 +120,7 @@ class ClipboardGrabFormat(BaseGrabFormat):
         pil_im = ImageGrab.grabclipboard()
         if pil_im is None:
             raise RuntimeError('There seems to be no image data on the '
-                                'clipboard now.')
+                               'clipboard now.')
         im = np.asarray(pil_im)
         return im, {}
 

--- a/imageio/plugins/grab.py
+++ b/imageio/plugins/grab.py
@@ -1,0 +1,135 @@
+"""
+PIL-based formats to take screenshots and grab from the clipboard.
+"""
+
+from __future__ import absolute_import, print_function, division
+
+import sys
+import threading
+
+import numpy as np
+
+from .. import formats
+from ..core import Format
+
+
+class BaseGrabFormat(Format):
+    """ Base format for grab formats.
+    """
+    
+    _pillow_imported = False
+    _ImageGrab = None
+    
+    def __init__(self, *args, **kwargs):
+        super(BaseGrabFormat, self).__init__(*args, **kwargs)
+        self._lock = threading.RLock()
+    
+    def _can_write(self, request):
+        return False
+    
+    def _init_pillow(self):
+        with self._lock:
+            if not self._pillow_imported:
+                self._pillow_imported = True  # more like tried to import
+                import PIL
+                if not hasattr(PIL, 'PILLOW_VERSION'):
+                    raise ImportError('Imageio Pillow requires '
+                                      'Pillow, not PIL!')
+                from PIL import ImageGrab
+                self._ImageGrab = ImageGrab
+            elif self._ImageGrab is None:
+                raise RuntimeError('Imageio grab plugin requires Pillow lib.')
+            ImageGrab = self._ImageGrab
+        return ImageGrab
+    
+    class Reader(Format.Reader):
+        
+        def _open(self):
+            pass
+        
+        def _close(self):
+            pass
+        
+        def _get_data(self, index):
+            return self.format._get_data(index)
+
+
+class ScreenGrabFormat(BaseGrabFormat):
+    """ The ScreenGrabFormat provided a means to grab screenshots using
+    the uri of "<screen>".
+    
+    This functionality is provided via Pillow. Note that "<screen>" is
+    only supported on Windows and OS X.
+    
+    Parameters for reading
+    ----------------------
+    No parameters.
+    """
+    
+    def _can_read(self, request):
+        if request.mode[1] not in 'i?':
+            return False
+
+        if not (sys.platform.startswith('win') or
+                sys.platform.startswith('darwin')):
+            return False  # not supported on Linux by Pillow
+        
+        if request.filename != '<screen>':
+            return False
+        
+        self._init_pillow()
+        return True
+    
+    def _get_data(self, index):
+        ImageGrab = self._init_pillow()
+        
+        pil_im = ImageGrab.grab()
+        assert pil_im is not None
+        im = np.asarray(pil_im)
+        return im, {}
+
+
+class ClipboardGrabFormat(BaseGrabFormat):
+    """ The ClipboardGrabFormat provided a means to grab image data from
+    the clipboard, using the uri "<clipboard>"
+    
+    This functionality is provided via Pillow. Note that "<clipboard>" is
+    only supported on Windows.
+    
+    Parameters for reading
+    ----------------------
+    No parameters.
+    """
+    
+    def _can_read(self, request):
+        if request.mode[1] not in 'i?':
+            return False
+
+        if not sys.platform.startswith('win'):
+            return False  # not supported on Linux or OS X by Pillow
+        
+        if request.filename != '<clipboard>':
+            return False
+        
+        self._init_pillow()
+        return True
+    
+    def _get_data(self, index):
+        ImageGrab = self._init_pillow()
+        
+        pil_im = ImageGrab.grabclipboard()
+        if pil_im is None:
+            raise RuntimeError('There seems to be no image data on the '
+                                'clipboard now.')
+        im = np.asarray(pil_im)
+        return im, {}
+
+
+# Register. You register an *instance* of a Format class.
+format = ScreenGrabFormat('screengrab',
+                          'Grab screenshots (Windows and OS X only)', [], 'i')
+formats.add_format(format)
+
+format = ClipboardGrabFormat('clipboardgrab',
+                             'Grab from clipboard (Windows only)', [], 'i')
+formats.add_format(format)

--- a/imageio/plugins/grab.py
+++ b/imageio/plugins/grab.py
@@ -32,12 +32,12 @@ class BaseGrabFormat(Format):
             if not self._pillow_imported:
                 self._pillow_imported = True  # more like tried to import
                 import PIL
-                if not hasattr(PIL, 'PILLOW_VERSION'):
+                if not hasattr(PIL, 'PILLOW_VERSION'):  # pragma: no cover
                     raise ImportError('Imageio Pillow requires '
                                       'Pillow, not PIL!')
                 from PIL import ImageGrab
                 self._ImageGrab = ImageGrab
-            elif self._ImageGrab is None:
+            elif self._ImageGrab is None:  # pragma: no cover
                 raise RuntimeError('Imageio grab plugin requires Pillow lib.')
             ImageGrab = self._ImageGrab
         return ImageGrab

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -46,12 +46,12 @@ class PillowFormat(Format):
             if not self._pillow_imported:
                 self._pillow_imported = True  # more like tried to import
                 import PIL
-                if not hasattr(PIL, 'PILLOW_VERSION'):
+                if not hasattr(PIL, 'PILLOW_VERSION'):  # pragma: no cover
                     raise ImportError('Imageio Pillow requires '
                                       'Pillow, not PIL!')
                 from PIL import Image
                 self._Image = Image
-            elif self._Image is None:
+            elif self._Image is None:  # pragma: no cover
                 raise RuntimeError('Imageio Pillow plugin requires '
                                    'Pillow lib.')
             Image = self._Image

--- a/imageio/plugins/pillow_info.py
+++ b/imageio/plugins/pillow_info.py
@@ -10,7 +10,7 @@ if run as a script.
 """
 
 
-def generate_info():
+def generate_info():  # pragma: no cover
     from urllib.request import urlopen
     import PIL
     from PIL import Image
@@ -124,8 +124,8 @@ pillow_formats = [
     ('IM', 'IFUNC Image Memory', '.im'),
     ('IMT', 'IM Tools', ''),
     ('IPTC', 'IPTC/NAA', '.iim'),
-    ('JPEG', 'JPEG (ISO 10918)', '.jfif .jpeg .jpg .jpe'),
-    ('JPEG2000', 'JPEG 2000 (ISO 15444)', '.jpf .j2c .jpc .jp2 .j2k .jpx'),
+    ('JPEG', 'JPEG (ISO 10918)', '.jfif .jpe .jpg .jpeg'),
+    ('JPEG2000', 'JPEG 2000 (ISO 15444)', '.jp2 .j2k .jpc .jpf .jpx .j2c'),
     ('MCIDAS', 'McIdas area file', ''),
     ('MIC', 'Microsoft Image Composer', '.mic'),
     ('MPEG', 'MPEG', '.mpg .mpeg'),
@@ -135,14 +135,13 @@ pillow_formats = [
     ('PCX', 'Paintbrush', '.pcx'),
     ('PIXAR', 'PIXAR raster image', '.pxr'),
     ('PNG', 'Portable network graphics', '.png'),
-    ('PPM', 'Pbmplus image', '.ppm .pgm .pbm'),
+    ('PPM', 'Pbmplus image', '.pbm .pgm .ppm'),
     ('PSD', 'Adobe Photoshop', '.psd'),
-    ('SGI', 'SGI Image File Format', '.rgb .sgi .bw .rgba'),
+    ('SGI', 'SGI Image File Format', '.bw .rgb .rgba .sgi'),
     ('SPIDER', 'Spider 2D image', ''),
     ('SUN', 'Sun Raster File', '.ras'),
     ('TGA', 'Targa', '.tga'),
     ('TIFF', 'Adobe TIFF', '.tif .tiff'),
-    ('WEBP', 'WebP image', '.webp'),
     ('WMF', 'Windows Metafile', '.wmf .emf'),
     ('XBM', 'X11 Bitmap', '.xbm'),
     ('XPM', 'X11 Pixel Map', '.xpm'),
@@ -317,9 +316,6 @@ u"""*This is a copy from the Pillow docs.*
     **background**
         Default background color (a palette color index).
     
-    **duration**
-        Time between frames in an animation (in milliseconds).
-    
     **transparency**
         Transparency color index. This key is omitted if the image is not
         transparent.
@@ -328,8 +324,8 @@ u"""*This is a copy from the Pillow docs.*
         Version (either ``GIF87a`` or ``GIF89a``).
     
     **duration**
-        May not be present. The time to display each frame of the GIF, in
-        milliseconds.
+        May not be present. The time to display the current frame
+        of the GIF, in milliseconds.
     
     **loop**
         May not be present. The number of times the GIF should loop.
@@ -343,20 +339,41 @@ u"""*This is a copy from the Pillow docs.*
     
     ``im.seek()`` raises an ``EOFError`` if you try to seek after the last frame.
     
-    Saving sequences
-    ~~~~~~~~~~~~~~~~
+    Saving
+    ~~~~~~
     
-    When calling :py:meth:`~PIL.Image.Image.save`, if a multiframe image is used,
-    by default only the first frame will be saved. To save all frames, the
-    ``save_all`` parameter must be present and set to ``True``. To append
-    additional frames when saving, the ``append_images`` parameter works with
-    ``save_all`` to append a list of images containing the extra frames::
+    When calling :py:meth:`~PIL.Image.Image.save`, the following options
+    are available::
     
         im.save(out, save_all=True, append_images=[im1, im2, ...])
     
-    If present, the ``loop`` parameter can be used to set the number of times
-    the GIF should loop, and the ``duration`` parameter can set the number of
-    milliseconds between each frame.
+    **save_all**
+        If present and true, all frames of the image will be saved. If
+        not, then only the first frame of a multiframe image will be saved.
+    
+    **append_images**
+        A list of images to append as additional frames. Each of the
+        images in the list can be single or multiframe images.
+    
+    **duration**
+        The display duration of each frame of the multiframe gif, in
+        milliseconds. Pass a single integer for a constant duration, or a
+        list or tuple to set the duration for each frame separately.
+    
+    **loop**
+        Integer number of times the GIF should loop.
+    
+    **optimize**
+        If present and true, attempt to compress the palette by
+        eliminating unused colors. This is only useful if the palette can
+        be compressed to the next smaller power of 2 elements.
+    
+    **palette** 
+        Use the specified palette for the saved image. The palette should
+        be a bytes or bytearray object containing the palette entries in
+        RGBRGB... form. It should be no more than 768 bytes. Alternately,
+        the palette can be passed in as an
+        :py:class:`PIL.ImagePalette.ImagePalette` object.
     
     Reading local images
     ~~~~~~~~~~~~~~~~~~~~
@@ -797,12 +814,14 @@ u"""*This is a copy from the Pillow docs.*
 
     
     PIL identifies and reads PSD files written by Adobe Photoshop 2.5 and 3.0.
+    
     """,
 'SGI':
 u"""*This is a copy from the Pillow docs.*
 
     
-    PIL reads uncompressed ``L``, ``RGB``, and ``RGBA`` files.
+    Pillow reads and writes uncompressed ``L``, ``RGB``, and ``RGBA`` files.
+    
     """,
 'SPIDER':
 u"""*This is a copy from the Pillow docs.*
@@ -842,8 +861,8 @@ u"""*This is a copy from the Pillow docs.*
     For more information about the SPIDER image processing package, see the
     `SPIDER homepage`_ at `Wadsworth Center`_.
     
-    .. _SPIDER homepage: http://spider.wadsworth.org/spider_doc/spider/docs/spider.html
-    .. _Wadsworth Center: http://www.wadsworth.org/
+    .. _SPIDER homepage: https://spider.wadsworth.org/spider_doc/spider/docs/spider.html
+    .. _Wadsworth Center: https://www.wadsworth.org/
     """,
 'SUN':
 u"""No docs for SUN.""",
@@ -980,30 +999,6 @@ u"""*This is a copy from the Pillow docs.*
         :py:class:`~PIL.TiffImagePlugin.IFDRational`. Resolution implies
         an equal x and y resolution, dpi also implies a unit of inches.
     
-    """,
-'WEBP':
-u"""*This is a copy from the Pillow docs.*
-
-    
-    PIL reads and writes WebP files. The specifics of PIL's capabilities with this
-    format are currently undocumented.
-    
-    The :py:meth:`~PIL.Image.Image.save` method supports the following options:
-    
-    **lossless**
-        If present and true, instructs the WEBP writer to use lossless compression.
-    
-    **quality**
-        Integer, 1-100, Defaults to 80. Sets the quality level for
-        lossy compression.
-    
-    **icc_procfile**
-        The ICC Profile to include in the saved file. Only supported if
-        the system webp library was built with webpmux support.
-    
-    **exif**
-        The exif data to include in the saved file. Only supported if
-        the system webp library was built with webpmux support.
     """,
 'WMF':
 u"""*This is a copy from the Pillow docs.*

--- a/tests/test_grab.py
+++ b/tests/test_grab.py
@@ -1,0 +1,68 @@
+import numpy as np
+
+from pytest import raises
+from imageio.testing import run_tests_if_main
+
+import imageio
+
+
+def test_grab_plugin_load():
+    
+    reader = imageio.get_reader('<screen>')
+    assert reader.format.name == 'SCREENGRAB'
+    
+    reader = imageio.get_reader('<clipboard>')
+    assert reader.format.name == 'CLIPBOARDGRAB'
+
+    with raises(ValueError):
+        imageio.get_writer('<clipboard>')
+    with raises(ValueError):
+        imageio.get_writer('<screen>')
+    
+
+def test_grab_simulated():
+    # Hard to test for real, if only because its only fully suppored on
+    # Windows, but we can monkey patch so we can test all the imageio bits.
+    from PIL import ImageGrab
+    
+    _grab = getattr(ImageGrab, 'grab', None)
+    _grabclipboard = getattr(ImageGrab, '_grabclipboard', None)
+    
+    ImageGrab.grab = lambda: np.zeros((8, 8, 3), np.uint8)
+    ImageGrab.grabclipboard = lambda: np.zeros((9, 9, 3), np.uint8)
+    
+    try:
+        
+        im = imageio.imread('<screen>')
+        assert im.shape == (8, 8, 3)
+        
+        reader = imageio.get_reader('<screen>')
+        im1 = reader.get_data(0)
+        im2 = reader.get_data(0)
+        im3 = reader.get_data(1)
+        assert im1.shape == (8, 8, 3)
+        assert im2.shape == (8, 8, 3)
+        assert im3.shape == (8, 8, 3)
+        
+        im = imageio.imread('<clipboard>')
+        assert im.shape == (9, 9, 3)
+        
+        reader = imageio.get_reader('<clipboard>')
+        im1 = reader.get_data(0)
+        im2 = reader.get_data(0)
+        im3 = reader.get_data(1)
+        assert im1.shape == (9, 9, 3)
+        assert im2.shape == (9, 9, 3)
+        assert im3.shape == (9, 9, 3)
+        
+        # Grabbing from clipboard can fail if there is no image data to grab
+        ImageGrab.grabclipboard = lambda: None
+        with raises(RuntimeError):
+            im = imageio.imread('<clipboard>')
+    
+    finally:
+        ImageGrab.grab = _grab
+        ImageGrab.grabclipboard = _grabclipboard
+
+
+run_tests_if_main()

--- a/tests/test_grab.py
+++ b/tests/test_grab.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 
 from pytest import raises
@@ -27,9 +29,11 @@ def test_grab_simulated():
     
     _grab = getattr(ImageGrab, 'grab', None)
     _grabclipboard = getattr(ImageGrab, '_grabclipboard', None)
+    _plat = sys.platform
     
     ImageGrab.grab = lambda: np.zeros((8, 8, 3), np.uint8)
     ImageGrab.grabclipboard = lambda: np.zeros((9, 9, 3), np.uint8)
+    sys.platform = 'win32'
     
     try:
         
@@ -63,6 +67,6 @@ def test_grab_simulated():
     finally:
         ImageGrab.grab = _grab
         ImageGrab.grabclipboard = _grabclipboard
-
+        sys.platform = _plat
 
 run_tests_if_main()


### PR DESCRIPTION
Fixes #179 

Relatively easy to add because Pillow supports it. Windows (and OSX for screenshots) only, unfortunately.

