### PR TITLE
Increase the timeout interval to 10 seconds

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -490,7 +490,7 @@ class FfmpegFormat(Format):
             duration and nframes. """
 
             # Wait for the catcher to get the meta information
-            etime = time.time() + 4.0
+            etime = time.time() + 10.0
             while (not self._stderr_catcher.header) and time.time() < etime:
                 time.sleep(0.01)
 


### PR DESCRIPTION
On some VMs with low amount of resources, the timeout of 4 seconds might not be enough, and this could result in unstable operation.