### PR TITLE
Proposed solution for issue 287 (prevent duplicate frames from webcam)

### DIFF
--- a/imageio/__main__.py
+++ b/imageio/__main__.py
@@ -118,7 +118,7 @@ def remove_bin(plugin_names=["all"]):
                 plgdir = op.join(rd, rsub)
                 try:
                     shutil.rmtree(plgdir)
-                except:
+                except Exception:
                     not_removed.append(plgdir)
     if not_removed:
         nrs = ",".join(not_removed)

--- a/imageio/plugins/_tifffile.py
+++ b/imageio/plugins/_tifffile.py
@@ -4049,7 +4049,7 @@ def read_sem_metadata(fh, byteorder, dtype, count):
                 if number != v:
                     value = number
                     unit = u
-            except:
+            except Exception:
                 number = astype(value, (int, float))
                 if number != value:
                     value = number

--- a/imageio/testing.py
+++ b/imageio/testing.py
@@ -30,6 +30,7 @@ STYLE_IGNORES = ['E226',
                  'E266',  # too many leading '#' for block comment
                  'E402',  # module level import not at top of file
                  'E731',  # do not assign a lambda expression, use a def
+                 'E741',
                  'W291', 
                  'W293',
                  'W503',  # line break before binary operator

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -38,7 +38,7 @@ def test_download_ffmpeg():
     # 4th check if download succeeded
     try:
         get_remote_file(fname=fname, auto=False)
-    except:
+    except Exception:
         raise Exception("Binary should have been downloaded.")
 
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -348,11 +348,23 @@ def test_framecatcher():
     assert T._frame is None  # get_frame() would stall
     file.write_and_rewind(b'x' * 20)
     time.sleep(0.2)  # Let it read the rest
-    assert T.get_frame() == b'x' * N
+    frame, is_new = T.get_frame()
+    assert frame == b'x' * N
+    assert is_new, 'is_new should be True the first time a frame is retrieved'
+
+    # Read frame that has not been updated
+    frame, is_new = T.get_frame()
+    assert frame == b'x' * N, 'frame content should be the same as before'
+    assert not is_new, (
+        'is_new should be False if the frame has already been retrieved')
+
     # Read frame when we pass plenty of data
     file.write_and_rewind(b'y' * N * 3)
     time.sleep(0.2)
-    assert T.get_frame() == b'y' * N
+    frame, is_new = T.get_frame()
+    assert frame == b'y' * N
+    assert is_new, 'is_new should be True again if the frame has been updated'
+
     # Close
     file.close()
 
@@ -413,6 +425,25 @@ def test_webcam_parse_device_names():
 
     # Assert that the device_names list has the correct length
     assert len(device_names) == number_of_video_devices_in_sample
+
+
+def test_webcam_get_next_data():
+    try:
+        reader = imageio.get_reader('<video0>')
+    except IndexError:
+        skip('no web cam')
+
+    # Get a number of frames and check for if they are new
+    counter_new_frames = 0
+    number_of_iterations = 100
+    for i in range(number_of_iterations):
+        frame = reader.get_next_data()
+        if frame.meta['new']:
+            counter_new_frames += 1
+
+    assert counter_new_frames < number_of_iterations, (
+        'assuming the loop is faster than the webcam, '
+        'not all frames can be new')
 
 
 def show_in_console():

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -37,7 +37,7 @@ def test_get_exe_env():
     os.environ['IMAGEIO_FFMPEG_EXE'] = path
     try:
         path2 = imageio.plugins.ffmpeg.get_exe()
-    except:
+    except Exception:
         path2 = "none"
         pass
     # cleanup

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -428,10 +428,12 @@ def test_webcam_parse_device_names():
 
 
 def test_webcam_get_next_data():
+    need_internet()
+
     try:
         reader = imageio.get_reader('<video0>')
     except IndexError:
-        skip('no web cam')
+        skip('no webcam')
 
     # Get a number of frames and check for if they are new
     counter_new_frames = 0
@@ -442,8 +444,8 @@ def test_webcam_get_next_data():
             counter_new_frames += 1
 
     assert counter_new_frames < number_of_iterations, (
-        'assuming the loop is faster than the webcam, '
-        'not all frames can be new')
+        'assuming the loop is faster than the webcam, the number of unique '
+        'frames should be smaller than the number of iterations')
 
 
 def show_in_console():


### PR DESCRIPTION
Proposed solution for issue #287.

Adds a `_frame_is_new` attribute to the `FrameCatcher`, to indicate whether a returned frame is new.

The value of `_frame_is_new`  finally ends up in the `Image` meta dict, so it can be checked by a user if necessary, e.g:

```
image = reader.get_next_data()
if  image.meta['new']:
    update_stuff(image)

```

Also see implementation example in test.