### PR TITLE
Drop support for EOL Python 2.6, 3.2 and 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pychache__
 *.dll
 *.dylib
 .*.swp
+
+# IDE
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ matrix:
         - python: "3.6"
           env: TEST_UNIT=0 TEST_STYLE=1
         #
-        - python: "2.6"
-          env: TEST_UNIT=1
         - python: "2.7"
           env: TEST_UNIT=1 TEST_INSTALL=1
         - python: "3.4"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Website: http://imageio.github.io
 Imageio is a Python library that provides an easy interface to read and
 write a wide range of image data, including animated images, video,
 volumetric data, and scientific formats. It is cross-platform, runs on
-Python 2.7 and 3.x, and is easy to install.
+Python 2.7 and 3.4+, and is easy to install.
 </p>
 
 <h2>Example</h2>
@@ -46,7 +46,7 @@ As a user, you just have to remember a handfull of functions:
     <li>Simple interface via a consise set of functions.</li>
     <li>Easy to <a href='http://imageio.readthedocs.org/en/latest/installation.html'>install</a> using conda or pip.</li>    
     <li>Few dependencies (only Numpy).</li>
-    <li>Pure Python, runs on Python 2.7, 3.x, and Pypy</li>
+    <li>Pure Python, runs on Python 2.7, 3.4+, and Pypy</li>
     <li>Cross platform, runs on Windows, Linux, OS X (Raspberry Pi planned)</li>
     <li>Lots of supported <a href='http://imageio.readthedocs.org/en/latest/formats.html'>formats</a>.</li>
     <li>Can read from file names, file objects, zipfiles, http/ftp, and raw bytes.</li>
@@ -80,7 +80,7 @@ for maximum test coverage (100% for the core, >95% for each plugin).
 
 Minimal requirements:
 <ul>
-    <li>Python 3.x, 2.7</li>
+    <li>Python 3.4+, 2.7</li>
     <li>Numpy</li>
     <li>Pillow</li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Website: http://imageio.github.io
 Imageio is a Python library that provides an easy interface to read and
 write a wide range of image data, including animated images, video,
 volumetric data, and scientific formats. It is cross-platform, runs on
-Python 2.x and 3.x, and is easy to install.
+Python 2.7 and 3.x, and is easy to install.
 </p>
 
 <h2>Example</h2>
@@ -44,7 +44,7 @@ As a user, you just have to remember a handfull of functions:
     <li>Simple interface via a consise set of functions.</li>
     <li>Easy to <a href='http://imageio.readthedocs.org/en/latest/installation.html'>install</a> using conda or pip.</li>    
     <li>Few dependencies (only Numpy).</li>
-    <li>Pure Python, runs on Python 2.6+, 3.x, and Pypy</li>
+    <li>Pure Python, runs on Python 2.7, 3.x, and Pypy</li>
     <li>Cross platform, runs on Windows, Linux, OS X (Raspberry Pi planned)</li>
     <li>Lots of supported <a href='http://imageio.readthedocs.org/en/latest/formats.html'>formats</a>.</li>
     <li>Can read from file names, file objects, zipfiles, http/ftp, and raw bytes.</li>
@@ -78,7 +78,7 @@ for maximum test coverage (100% for the core, >95% for each plugin).
 
 Minimal requirements:
 <ul>
-    <li>Python 3.x, 2.7 or 2.6</li>
+    <li>Python 3.x, 2.7</li>
     <li>Numpy</li>
     <li>Pillow</li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # IMAGEIO
 
-[![Build status](https://ci.appveyor.com/api/projects/status/4wjqg4o5r2q53iwt/branch/master?svg=true)](https://ci.appveyor.com/project/almarklein/imageio/branch/master)
+[![PyPI Version](https://img.shields.io/pypi/v/imageio.svg)](https://pypi.python.org/pypi/imageio/)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/imageio.svg)](https://pypi.python.org/pypi/imageio/)
+[![Build Status](https://ci.appveyor.com/api/projects/status/4wjqg4o5r2q53iwt/branch/master?svg=true)](https://ci.appveyor.com/project/almarklein/imageio/branch/master)
 [![Build Status](https://travis-ci.org/imageio/imageio.svg?branch=master)](https://travis-ci.org/imageio/imageio)
 [![Coverage Status](https://coveralls.io/repos/imageio/imageio/badge.png?branch=master)](https://coveralls.io/r/imageio/imageio?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/imageio/badge/?version=latest)](https://imageio.readthedocs.org)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,8 +2,8 @@ Installing imageio
 ==================
 
 Imageio is written in pure Python, so installation is easy. 
-Imageio works on Python 2.6 and up (including Python 3). It also works
-on Pypy. Imageio depends on Numpy and Pillow. For some formats, imageio needs
+Imageio works on Python 2.7 and up. It also works on Pypy.
+Imageio depends on Numpy and Pillow. For some formats, imageio needs
 additional libraries/executables (e.g. ffmpeg), which imageio helps you
 download and store in a folder in your application data.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,7 @@ Installing imageio
 ==================
 
 Imageio is written in pure Python, so installation is easy. 
-Imageio works on Python 2.7 and up. It also works on Pypy.
+Imageio works on Python 2.7 and 3.4+. It also works on Pypy.
 Imageio depends on Numpy and Pillow. For some formats, imageio needs
 additional libraries/executables (e.g. ffmpeg), which imageio helps you
 download and store in a folder in your application data.

--- a/imageio/__init__.py
+++ b/imageio/__init__.py
@@ -8,8 +8,8 @@
 """ 
 Imageio is a Python library that provides an easy interface to read and
 write a wide range of image data, including animated images, volumetric
-data, and scientific formats. It is cross-platform, runs on Python 2.x
-and 3.x, and is easy to install.
+data, and scientific formats. It is cross-platform, runs on Python 2.7
+and 3.4+, and is easy to install.
 
 Main website: http://imageio.github.io
 """

--- a/imageio/core/fetching.py
+++ b/imageio/core/fetching.py
@@ -238,6 +238,6 @@ def _sizeof_fmt(num):
         quotient = float(num) / 1024 ** exponent
         unit = units[exponent]
         num_decimals = decimals[exponent]
-        format_string = '{0:.%sf} {1}' % (num_decimals)
+        format_string = '{0:.%sf} {1}' % num_decimals
         return format_string.format(quotient, unit)
     return '0 bytes' if num == 0 else '1 byte'

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -86,17 +86,17 @@ def image_as_uint(im, bitdepth=None):
         im = im.astype(np.float64) * (np.power(2.0, bitdepth)-1)
     elif im.dtype == np.uint16 and bitdepth == 8:
         warn('Lossy conversion from uint16 to uint8, '
-             'loosing 8 bits of resolution')
+             'losing 8 bits of resolution')
         im = np.right_shift(im, 8)
     elif im.dtype == np.uint32:
         warn('Lossy conversion from uint32 to {}, '
-             'loosing {} bits of resolution'.format(out_type.__name__,
-                                                    32-bitdepth))
+             'losing {} bits of resolution'.format(out_type.__name__,
+                                                   32-bitdepth))
         im = np.right_shift(im, 32-bitdepth)
     elif im.dtype == np.uint64:
         warn('Lossy conversion from uint64 to {}, '
-             'loosing {} bits of resolution'.format(out_type.__name__,
-                                                    64-bitdepth))
+             'looing {} bits of resolution'.format(out_type.__name__,
+                                                   64-bitdepth))
         im = np.right_shift(im, 64-bitdepth)
     else:
         mi = np.nanmin(im)

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -95,7 +95,7 @@ def image_as_uint(im, bitdepth=None):
         im = np.right_shift(im, 32-bitdepth)
     elif im.dtype == np.uint64:
         warn('Lossy conversion from uint64 to {}, '
-             'looing {} bits of resolution'.format(out_type.__name__,
+             'losing {} bits of resolution'.format(out_type.__name__,
                                                    64-bitdepth))
         im = np.right_shift(im, 64-bitdepth)
     else:

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -498,9 +498,8 @@ def resource_dirs():
     directory (for frozen apps), and may include additional directories
     in the future.
     """
-    dirs = []
+    dirs = [resource_package_dir()]
     # Resource dir baked in the package.
-    dirs.append(resource_package_dir())
     # Appdata directory
     try:
         dirs.append(appdata_dir('imageio'))

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -81,7 +81,7 @@ def image_as_uint(im, bitdepth=None):
         return im
     if (dtype_str.startswith('float') and
        np.nanmin(im) >= 0 and np.nanmax(im) <= 1):
-        warn('Lossy conversion from {0} to {1}, range [0, 1]'.format(
+        warn('Lossy conversion from {} to {}, range [0, 1]'.format(
              dtype_str, out_type.__name__))
         im = im.astype(np.float64) * (np.power(2.0, bitdepth)-1)
     elif im.dtype == np.uint16 and bitdepth == 8:
@@ -89,14 +89,14 @@ def image_as_uint(im, bitdepth=None):
              'loosing 8 bits of resolution')
         im = np.right_shift(im, 8)
     elif im.dtype == np.uint32:
-        warn('Lossy conversion from uint32 to {0}, '
-             'loosing {1} bits of resolution'.format(out_type.__name__,
-                                                     32-bitdepth))
+        warn('Lossy conversion from uint32 to {}, '
+             'loosing {} bits of resolution'.format(out_type.__name__,
+                                                    32-bitdepth))
         im = np.right_shift(im, 32-bitdepth)
     elif im.dtype == np.uint64:
-        warn('Lossy conversion from uint64 to {0}, '
-             'loosing {1} bits of resolution'.format(out_type.__name__,
-                                                     64-bitdepth))
+        warn('Lossy conversion from uint64 to {}, '
+             'loosing {} bits of resolution'.format(out_type.__name__,
+                                                    64-bitdepth))
         im = np.right_shift(im, 64-bitdepth)
     else:
         mi = np.nanmin(im)
@@ -107,8 +107,8 @@ def image_as_uint(im, bitdepth=None):
             raise ValueError('Maximum image value is not finite')
         if ma == mi:
             raise ValueError('Max value == min value, ambiguous given dtype')
-        warn('Conversion from {0} to {1}, '
-             'range [{2}, {3}]'.format(dtype_str, out_type.__name__, mi, ma))
+        warn('Conversion from {} to {}, '
+             'range [{}, {}]'.format(dtype_str, out_type.__name__, mi, ma))
         # Now make float copy before we scale
         im = im.astype('float64')
         # Scale the values between 0 and 1 then multiply by the max value

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -208,13 +208,10 @@ def asarray(a):
     return np.asarray(a)
 
 
-try:
-    from collections import OrderedDict as _dict
-except ImportError:
-    _dict = dict
+from collections import OrderedDict
 
 
-class Dict(_dict):
+class Dict(OrderedDict):
     """ A dict in which the keys can be get and set as if they were
     attributes. Very convenient in combination with autocompletion.
     
@@ -224,7 +221,7 @@ class Dict(_dict):
     class (such as 'items' and 'copy') cannot be get/set as attributes.
     """
     
-    __reserved_names__ = dir(_dict())  # Also from OrderedDict
+    __reserved_names__ = dir(OrderedDict())  # Also from OrderedDict
     __pure_names__ = dir(dict())
     
     def __getattribute__(self, key):
@@ -240,7 +237,7 @@ class Dict(_dict):
         if key in Dict.__reserved_names__:
             # Either let OrderedDict do its work, or disallow
             if key not in Dict.__pure_names__:
-                return _dict.__setattr__(self, key, val)
+                return OrderedDict.__setattr__(self, key, val)
             else:
                 raise AttributeError('Reserved name, this key can only ' +
                                      'be set via ``d[%r] = X``' % key)

--- a/imageio/plugins/_dicom.py
+++ b/imageio/plugins/_dicom.py
@@ -338,9 +338,9 @@ class SimpleDicomReader(object):
         else:
             # http://www.dicomlibrary.com/dicom/transfer-syntax/
             t, extra_info = TransferSyntaxUID, ''
-            if t >= '1.2.840.10008.1.2.4.50' and t < '1.2.840.10008.1.2.4.99':
+            if '1.2.840.10008.1.2.4.50' <= t < '1.2.840.10008.1.2.4.99':
                 extra_info = ' (JPEG)'
-            if t >= '1.2.840.10008.1.2.4.90' and t < '1.2.840.10008.1.2.4.99':
+            if '1.2.840.10008.1.2.4.90' <= t < '1.2.840.10008.1.2.4.99':
                 extra_info = ' (JPEG 2000)'
             if t == '1.2.840.10008.1.2.5':
                 extra_info = ' (RLE)'

--- a/imageio/plugins/_freeimage.py
+++ b/imageio/plugins/_freeimage.py
@@ -1086,7 +1086,7 @@ class FIBitmap(FIBaseBitmap):
         realwidth = pitch // nchannels
         # Apply padding for pitch if necessary
         extra = realwidth - array.shape[-2]
-        assert extra >= 0 and extra < 10
+        assert 0 <= extra < 10
         # Make sort of Fortran, also take padding (i.e. pitch) into account
         newshape = array.shape[-1], realwidth, nchannels
         array2 = numpy.zeros(newshape, array.dtype)

--- a/imageio/plugins/_swf.py
+++ b/imageio/plugins/_swf.py
@@ -195,7 +195,7 @@ def bits2int(bb, n=8):
         value = tmp.rjust(8, '0') + value
 
     # Make decimal
-    return(int(value[:n], 2))
+    return int(value[:n], 2)
 
 
 def get_type_and_len(bb):

--- a/imageio/plugins/_swf.py
+++ b/imageio/plugins/_swf.py
@@ -722,7 +722,7 @@ def checkImages(images):  # pragma: no cover
                 images2.append(im) # Ok
             elif im.dtype in [np.float32, np.float64]:
                 theMax = im.max()
-                if theMax > 128 and theMax < 300:
+                if 128 < theMax < 300:
                     pass # assume 0:255
                 else:
                     im = im.copy()

--- a/imageio/plugins/_tifffile.py
+++ b/imageio/plugins/_tifffile.py
@@ -2676,7 +2676,7 @@ class TiffPage(object):
                     byte_counts[j] = b
                     offsets[j] = o
                 j += 1
-            elif b > 0 and o <= 0:
+            elif b > 0 >= o:
                 raise ValueError("invalid offset")
             else:
                 warnings.warn("empty byte count")

--- a/imageio/plugins/_tifffile.py
+++ b/imageio/plugins/_tifffile.py
@@ -4946,7 +4946,7 @@ def sequence(value):
         len(value)
         return value
     except TypeError:
-        return (value,)
+        return value,
 
 
 def product(iterable):

--- a/imageio/plugins/_tifffile.py
+++ b/imageio/plugins/_tifffile.py
@@ -6249,10 +6249,6 @@ def askopenfilename(**kwargs):
 
 def main(argv=None):
     """Command line usage main function."""
-    if float(sys.version[0:3]) < 2.7:
-        print("This script requires Python version 2.7 or better.")
-        print("This is Python version %s" % sys.version)
-        return 0
     if argv is None:
         argv = sys.argv
 

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -775,7 +775,7 @@ class FfmpegFormat(Format):
                 logging.warning(
                     "IMAGEIO FFMPEG_WRITER WARNING: input image is not"
                     " divisible by macro_block_size={}, resizing from {} "
-                    "to {2} to ensure video compatibility with most codecs "
+                    "to {} to ensure video compatibility with most codecs "
                     "and players. To prevent resizing, make your input "
                     "image divisible by the macro_block_size or set the "
                     "macro_block_size to None (risking incompatibility). You "

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -771,10 +771,10 @@ class FfmpegFormat(Format):
                 if self._size[0] % macro_block_size > 0:
                     out_h += macro_block_size - \
                         (self._size[0] % macro_block_size)
-                cmd += ['-vf', 'scale={0}:{1}'.format(out_w, out_h)]
+                cmd += ['-vf', 'scale={}:{}'.format(out_w, out_h)]
                 logging.warning(
                     "IMAGEIO FFMPEG_WRITER WARNING: input image is not"
-                    " divisible by macro_block_size={0}, resizing from {1} "
+                    " divisible by macro_block_size={}, resizing from {} "
                     "to {2} to ensure video compatibility with most codecs "
                     "and players. To prevent resizing, make your input "
                     "image divisible by the macro_block_size or set the "

--- a/imageio/testing.py
+++ b/imageio/testing.py
@@ -136,7 +136,7 @@ def test_style():
     for dir, dirnames, filenames in os.walk(ROOT_DIR):
         dir = os.path.relpath(dir, ROOT_DIR)
         # Skip this dir?
-        exclude_dirs = set(['.git', 'docs', 'build', 'dist', '__pycache__'])
+        exclude_dirs = {'.git', 'docs', 'build', 'dist', '__pycache__'}
         if exclude_dirs.intersection(dir.split(os.path.sep)):
             continue
         # Check all files ...

--- a/setup.py
+++ b/setup.py
@@ -103,13 +103,12 @@ for more information.
 """
 
 # Prepare resources dir
-package_data = []
-package_data.append('resources/shipped_resources_go_here')
-package_data.append('resources/*.*')
-package_data.append('resources/images/*.*')
-package_data.append('resources/freeimage/*.*')
-package_data.append('resources/ffmpeg/*.*')
-package_data.append('resources/avbin/*.*')
+package_data = ['resources/shipped_resources_go_here',
+                'resources/*.*',
+                'resources/images/*.*',
+                'resources/freeimage/*.*',
+                'resources/ffmpeg/*.*',
+                'resources/avbin/*.*']
 
 
 def _set_crossplatform_resources(resource_dir):

--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,7 @@ setup(
     
     platforms = 'any',
     provides = ['imageio'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*',
     install_requires = ['numpy', 'pillow'],
     extras_require = {'fits': ['astropy'],
                       'gdal': ['gdal'],
@@ -239,11 +240,13 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         ],
     )

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ setup(
     
     platforms = 'any',
     provides = ['imageio'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires = ['numpy', 'pillow'],
     extras_require = {'fits': ['astropy'],
                       'gdal': ['gdal'],
@@ -242,8 +242,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ __doc__ = ''
 docStatus = 0 # Not started, in progress, done
 initFile = os.path.join(THIS_DIR, 'imageio',  '__init__.py')
 for line in open(initFile).readlines():
-    if (line.startswith('__version__')):
+    if line.startswith('__version__'):
         exec(line.strip())
     elif line.startswith('"""'):
         if docStatus == 0:

--- a/tests/test_avbin.py
+++ b/tests/test_avbin.py
@@ -136,7 +136,7 @@ def test_read_format():
     for i in range(10):
         im = reader.get_next_data()
         assert im.shape == (720, 1280, 3)
-        assert mean(im) > 100 and mean(im) < 115
+        assert 100 < mean(im) < 115
 
 
 def test_stream():

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -2,7 +2,6 @@
 """
 import os
 import shutil
-import sys
 
 import pytest
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -13,10 +13,8 @@ from imageio.core import get_remote_file, NeedDownloadError, util
 
 
 NOINET = os.getenv('IMAGEIO_NO_INTERNET', '').lower() in ('1', 'true', 'yes')
-PY26 = sys.version_info[0] < 3 and sys.version_info[1] < 7
 
 
-@pytest.mark.xfail(PY26, reason="Python version below 2.7")
 @pytest.mark.xfail(NOINET, reason="Internet not allowed")
 def test_download_ffmpeg():
     # 1st remove ffmpeg binary
@@ -42,7 +40,6 @@ def test_download_ffmpeg():
         raise Exception("Binary should have been downloaded.")
 
 
-@pytest.mark.xfail(PY26, reason="Python version below 2.7")
 @pytest.mark.xfail(NOINET, reason="Internet not allowed")
 def test_remove_ffmpeg():
     # 1st download it
@@ -68,7 +65,6 @@ def test_remove_ffmpeg():
     imageio.__main__.download_bin(["ffmpeg"])
 
 
-@pytest.mark.xfail(PY26, reason="Python version below 2.7")
 @pytest.mark.xfail(NOINET, reason="Internet not allowed")
 def test_download_package_dir():
     # test for downloading a binary

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -268,7 +268,7 @@ def test_request_save_sources():
 
 def test_request_file_no_seek():
     
-    class File():
+    class File:
         
         def read(self, n):
             return b'\x00' * n

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -420,7 +420,7 @@ def test_util_progres_bar(sleep=0):
 
 
 def test_util_image_as_uint():
-    ''' Tests the various type conversions when writing to uint'''
+    """ Tests the various type conversions when writing to uint"""
     raises(ValueError, core.image_as_uint, 4)
     raises(ValueError, core.image_as_uint, "not an image")
     raises(ValueError, core.image_as_uint, np.array([0, 1]), bitdepth=13)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -95,7 +95,7 @@ def test_format():
     assert F.name in repr(F)
     assert F.name in F.doc
     assert str(F) == F.doc
-    assert set(F.extensions) == set(['.foo', '.bar', '.spam'])
+    assert set(F.extensions) == {'.foo', '.bar', '.spam'}
     
     # Test setting extensions
     F1 = Format('test', '', 'foo bar spam')
@@ -103,7 +103,7 @@ def test_format():
     F3 = Format('test', '', ['foo', 'bar', 'spam'])
     F4 = Format('test', '', '.foo .bar .spam')
     for F in (F1, F2, F3, F4):
-        assert set(F.extensions) == set(['.foo', '.bar', '.spam'])
+        assert set(F.extensions) == {'.foo', '.bar', '.spam'}
     # Fail
     raises(ValueError, Format, 'test', '', 3)  # not valid ext
     raises(ValueError, Format, 'test', '', '', 3)  # not valid mode

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -85,7 +85,7 @@ def test_namespace():
     # Check that there are no extra names
     extra_names = has_names.difference(need_names)
     extra_names.discard('testing')  # can be there during testing
-    assert extra_names == set(['core', 'plugins', 'show_formats'])
+    assert extra_names == {'core', 'plugins', 'show_formats'}
 
 
 def test_import_nothing():
@@ -144,7 +144,7 @@ def test_import_dependencies():
             print(modname, mod.__file__)
     
     # Check that only imageio is left
-    assert extra_modules == set(['imageio'])
+    assert extra_modules == {'imageio'}
 
 
 run_tests_if_main()


### PR DESCRIPTION
Also some minor tidy-ups, add version badges to the README, and add `python_requires` to setup.py to help pip.

This also drops support for Python 3.2 and 3.3. They were listed in setup.py's classifiers, but were not tested. Both are EOL and little used.

Here's the pip installs for imageio from PyPI for the last month (via `pypinfo --percent --pip --markdown imageio pyversion`)

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   58.4% |         20,500 |
| 3.6            |   21.0% |          7,377 |
| 3.5            |   17.0% |          5,973 |
| 3.4            |    3.4% |          1,200 |
| 3.7            |    0.1% |             29 |
| 2.6            |    0.0% |              6 |
| 3.3            |    0.0% |              4 |