### PR TITLE
Feature/lytro lfr plugin

### DIFF
--- a/imageio/plugins/__init__.py
+++ b/imageio/plugins/__init__.py
@@ -106,6 +106,8 @@ from . import fits  # depends on astropy
 from . import simpleitk  # depends on SimpleITK
 from . import gdal  # depends on gdal
 
+from . import lytro
+
 from . import example
 
 # Sort

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -391,15 +391,15 @@ class LytroLfrFormat(LytroFormat):
 
 
 # Create the formats
-SPECIAL_CLASSES = {'lytro-raw': LytroRawFormat,
-                   'lytro-lfr': LytroLfrFormat
+SPECIAL_CLASSES = {'lytro-lfr': LytroLfrFormat,
+                    'lytro-raw': LytroRawFormat
                    }
 
 # Supported Formats.
 # Only single image files supported.
 file_formats = [
-    ('LYTRO-RAW', 'Lytro Illum raw image file', 'raw', 'i'),
-    ('LYTRO-LFR', 'Lytro Illum lfr image file', 'lfr', 'i')
+    ('LYTRO-LFR', 'Lytro Illum lfr image file', 'lfr', 'i'),
+    ('LYTRO-RAW', 'Lytro Illum raw image file', 'raw', 'i')
 ]
 
 

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -129,7 +129,7 @@ class LytroRawFormat(LytroFormat):
 
         # Normalize data to 1.0 as 64-bit float.
         # Division is by 1023 as the Lytro saves 10-bit raw data.
-        return np.divide(image, 1023).astype(np.float64)
+        return np.divide(image, 1023.0).astype(np.float64)
 
     # -- reader
 

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -195,7 +195,8 @@ class LytroRawFormat(LytroFormat):
 class LytroLfrFormat(LytroFormat):
     """ This is the Lytro Illum LFR format.
     The lfr is a image and meta data container format as used by the
-    Lytro Illum light field camera. The format will read the specified lfr file.
+    Lytro Illum light field camera.
+    The format will read the specified lfr file.
     This format does not support writing.
 
     Parameters for reading

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -1,0 +1,333 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015, imageio contributors
+# imageio is distributed under the terms of the (new) BSD License.
+
+""" Lytro Illum Plugin.
+    Plugin to read Lytro Illum .lfr and .raw files as produced
+    by the Lytro Illum light field camera.
+"""
+
+from __future__ import absolute_import, print_function, division
+import os
+import json
+
+import numpy as np
+
+from .. import formats
+from ..core import Format
+
+
+
+# Sensor size of Lytro Illum Lightfieldcamera
+LYTRO_IMAGE_SIZE = (5368, 7728)
+
+# Parameter of file format
+HEADER_LENGTH = 12
+SIZE_LENGTH = 4  # = 16 - header_length
+SHA1_LENGTH = 45  # = len("sha1-") + (160 / 4)
+PADDING_LENGTH = 35  # = (4 * 16) - header_length - size_length - sha1_length
+
+FILE_HEADER = b'\x89LFP\x0D\x0A\x1A\x0A\x00\x00\x00\x01'
+CHUNK_HEADER = b'\x89LFC\x0D\x0A\x1A\x0A\x00\x00\x00\x00'
+META_HEADER = b'\x89LFM\x0D\x0A\x1A\x0A\x00\x00\x00\x00'
+
+
+
+class LytroFormat(Format):
+    """ The dummy format is an example format that does nothing.
+    It will never indicate that it can read or write a file. When
+    explicitly asked to read, it will simply read the bytes. When
+    explicitly asked to write, it will raise an error.
+
+    This documentation is shown when the user does ``help('thisformat')``.
+
+    Parameters for reading
+    ----------------------
+    Specify arguments in numpy doc style here.
+
+    Parameters for saving
+    ---------------------
+    Specify arguments in numpy doc style here.
+
+    """
+
+    # Only single images are supported.
+    _modes = 'i'
+
+    def _can_read(self, request):
+        # This method is called when the format manager is searching
+        # for a format to read a certain image. Return True if this format
+        # can do it.
+        #
+        # The format manager is aware of the extensions and the modes
+        # that each format can handle. It will first ask all formats
+        # that *seem* to be able to read it whether they can. If none
+        # can, it will ask the remaining formats if they can: the
+        # extension might be missing, and this allows formats to provide
+        # functionality for certain extensions, while giving preference
+        # to other plugins.
+        #
+        # If a format says it can, it should live up to it. The format
+        # would ideally check the request.firstbytes and look for a
+        # header of some kind.
+        #
+        # The request object has:
+        # request.filename: a representation of the source (only for reporting)
+        # request.firstbytes: the first 256 bytes of the file.
+        # request.mode[0]: read or write mode
+        # request.mode[1]: what kind of data the user expects: one of 'iIvV?'
+
+        if request.mode[1] in (self.modes + '?'):
+            if request.filename.lower().endswith(self.extensions):
+                return True
+
+    def _can_write(self, request):
+        # This method is called when the format manager is searching
+        # for a format to write a certain image. It will first ask all
+        # formats that *seem* to be able to write it whether they can.
+        # If none can, it will ask the remaining formats if they can.
+        #
+        # Return True if the format can do it.
+
+        # In most cases, this code does suffice:
+        # if request.mode[1] in (self.modes + '?'):
+        #     if request.filename.lower().endswith(self.extensions):
+        #         return True
+        return False
+
+    # -- writer
+
+    class Writer(Format.Writer):
+
+        def _open(self, flags=0):
+            # Specify kwargs here. Optionally, the user-specified kwargs
+            # can also be accessed via the request.kwargs object.
+            #
+            # The request object provides two ways to write the data.
+            # Use just one:
+            #  - Use request.get_file() for a file object (preferred)
+            #  - Use request.get_local_filename() for a file on the system
+            self._fp = self.request.get_file()
+
+        def _close(self):
+            # Close the reader.
+            # Note that the request object will close self._fp
+            pass
+
+        def _append_data(self, im, meta):
+            # Process the given data and meta data.
+            raise RuntimeError('The lytro format cannot write image data.')
+
+        def set_meta_data(self, meta):
+            # Process the given meta data (global for all images)
+            # It is not mandatory to support this.
+            raise RuntimeError('The lytro format cannot write meta data.')
+
+class LytroRawFormat(LytroFormat):
+    """ The dummy format is an example format that does nothing.
+    It will never indicate that it can read or write a file. When
+    explicitly asked to read, it will simply read the bytes. When
+    explicitly asked to write, it will raise an error.
+
+    This documentation is shown when the user does ``help('thisformat')``.
+
+    Parameters for reading
+    ----------------------
+    Specify arguments in numpy doc style here.
+
+    Parameters for saving
+    ---------------------
+    Specify arguments in numpy doc style here.
+
+    """
+
+    # -- reader
+
+    class Reader(Format.Reader):
+
+        def _open(self, some_option=False, length=1):
+            # Specify kwargs here. Optionally, the user-specified kwargs
+            # can also be accessed via the request.kwargs object.
+            #
+            # The request object provides two ways to get access to the
+            # data. Use just one:
+            #  - Use request.get_file() for a file object (preferred)
+            #  - Use request.get_local_filename() for a file on the system
+            # self._fp = self.request.get_file()
+            self._fp = open(self.request.get_local_filename(), 'rb')
+            self._length = length  # passed as an arg in this case for testing
+            self._data = None
+
+        def _close(self):
+            # Close the reader.
+            # Note that the request object will close self._fp
+            pass
+
+        def _get_length(self):
+            # Return the number of images. Can be np.inf
+            return self._length
+
+        def _get_data(self, index):
+            # Return the data and meta data for the given index
+            if index not in [0, 'None']:
+                raise IndexError('Lytro file contains only one dataset')
+
+            # Read all bytes
+            if self._data is None:
+                self._data = self._fp.read()
+
+            # Read bytes from string and convert to uint16
+            raw = np.fromstring(self._data, dtype=np.uint8).astype(np.uint16)
+
+            # Do bit rearrangement
+            t0 = raw[0::5]
+            t1 = raw[1::5]
+            t2 = raw[2::5]
+            t3 = raw[3::5]
+            lsb = raw[4::5]
+
+            t0 = np.left_shift(t0, 2) + np.bitwise_and(lsb, 3)
+            t1 = np.left_shift(t1, 2) \
+                 + np.right_shift(np.bitwise_and(lsb, 12), 2)
+            t2 = np.left_shift(t2, 2) \
+                 + np.right_shift(np.bitwise_and(lsb, 48), 4)
+            t3 = np.left_shift(t3, 2) \
+                 + np.right_shift(np.bitwise_and(lsb, 192), 6)
+
+            image = np.zeros(LYTRO_IMAGE_SIZE, dtype=np.uint16)
+            image[:, 0::4] = t0.reshape(
+                (LYTRO_IMAGE_SIZE[0], LYTRO_IMAGE_SIZE[1] // 4))
+            image[:, 1::4] = t1.reshape(
+                (LYTRO_IMAGE_SIZE[0], LYTRO_IMAGE_SIZE[1] // 4))
+            image[:, 2::4] = t2.reshape(
+                (LYTRO_IMAGE_SIZE[0], LYTRO_IMAGE_SIZE[1] // 4))
+            image[:, 3::4] = t3.reshape(
+                (LYTRO_IMAGE_SIZE[0], LYTRO_IMAGE_SIZE[1] // 4))
+
+            # Return array and dummy meta data
+            return image, self._get_meta_data(index=0)
+
+        def _get_meta_data(self, index):
+            # Get the meta data for the given index. If index is None, it
+            # should return the global meta data.
+
+            if index not in [0, None]:
+                raise IndexError(
+                    'Lytro meta data file contains only one dataset')
+
+            # Try to read meta data from meta data file corresponding
+            # to the raw data file, extension in [.txt, .TXT, .json, .JSON]
+            filename_base = os.path.splitext(
+                self.request.get_local_filename())[0]
+
+            meta_data = None
+
+            for ext in ['.txt', '.TXT', '.json', '.JSON']:
+                if os.path.isfile(filename_base + ext):
+                    meta_data = json.load(open(filename_base + ext))
+
+            if meta_data is not None:
+                return meta_data
+
+            else:
+                print("No metadata file found for provided raw file.")
+                return {}
+
+class LytroLfrFormat(LytroFormat):
+    """ The dummy format is an example format that does nothing.
+    It will never indicate that it can read or write a file. When
+    explicitly asked to read, it will simply read the bytes. When
+    explicitly asked to write, it will raise an error.
+
+    This documentation is shown when the user does ``help('thisformat')``.
+
+    Parameters for reading
+    ----------------------
+    Specify arguments in numpy doc style here.
+
+    Parameters for saving
+    ---------------------
+    Specify arguments in numpy doc style here.
+
+    """
+
+    # -- reader
+
+    class Reader(Format.Reader):
+
+        def _open(self, some_option=False, length=1):
+            # Specify kwargs here. Optionally, the user-specified kwargs
+            # can also be accessed via the request.kwargs object.
+            #
+            # The request object provides two ways to get access to the
+            # data. Use just one:
+            #  - Use request.get_file() for a file object (preferred)
+            #  - Use request.get_local_filename() for a file on the system
+            self._fp = self.request.get_file()
+            self._length = length  # passed as an arg in this case for testing
+            self._data = None
+
+        def _close(self):
+            # Close the reader.
+            # Note that the request object will close self._fp
+            pass
+
+        def _get_length(self):
+            # Return the number of images. Can be np.inf
+            return self._length
+
+        def _get_data(self, index):
+            # Return the data and meta data for the given index
+            if index >= self._length:
+                raise IndexError('Image index %i > %i' % (index, self._length))
+            # Read all bytes
+            if self._data is None:
+                self._data = self._fp.read()
+            # Put in a numpy array
+            im = np.frombuffer(self._data, 'uint8')
+            im.shape = len(im), 1
+            # Return array and dummy meta data
+            return im, {}
+
+        def _get_meta_data(self, index):
+            # Get the meta data for the given index. If index is None, it
+            # should return the global meta data.
+            return {}  # This format does not support meta data
+
+
+
+
+## Create the formats
+
+SPECIAL_CLASSES = {'lytro-raw': LytroRawFormat,
+                   'lytro-lfr': LytroLfrFormat
+                   }
+
+# Supported Formats.
+# Only single image files supported.
+file_formats = [
+    ('LYTRO-RAW', 'Lytro Illum raw image file', 'raw', 'i'),
+    ('LYTRO-LFR', 'Lytro Illum lfr image file', 'lfr', 'i')
+]
+#
+# fiformats = LytroFormat('lytro-lfr',  # short name
+#                      'Lytro raw lfr data format.',  # one line descr.
+#                      '.lfr .raw',  # list of extensions
+#                      'i'  # modes, characters in iIvV
+#                      )
+
+# formats.add_format(format)
+
+
+def _create_predefined_freeimage_formats():
+    for name, des, ext, i in file_formats:
+        # Get format class for format
+        FormatClass = SPECIAL_CLASSES.get(name.lower(), LytroFormat)
+        if FormatClass:
+            # Create Format and add
+            format = FormatClass(name, des, ext, i)
+            formats.add_format(format)
+
+
+# Register all created formats.
+_create_predefined_freeimage_formats()

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -10,9 +10,12 @@
 #
 #
 # This code is based on work by
-# David Uhlig and his lfr_reader (https://www.iiit.kit.edu/uhlig.php)
-# Donald Dansereau and his Matlab LF Toolbox (http://dgd.vision/Tools/LFToolbox/)
-# and Behnam Esfahbod and his Python LFP-Reader (https://github.com/behnam/python-lfp-reader/)
+# David Uhlig and his lfr_reader
+#   (https://www.iiit.kit.edu/uhlig.php)
+# Donald Dansereau and his Matlab LF Toolbox
+#   (http://dgd.vision/Tools/LFToolbox/)
+# and Behnam Esfahbod and his Python LFP-Reader
+#   (https://github.com/behnam/python-lfp-reader/)
 
 
 from __future__ import absolute_import, print_function, division
@@ -79,6 +82,7 @@ class LytroFormat(Format):
             # It is not mandatory to support this.
             raise RuntimeError('The lytro format cannot write meta data.')
 
+
 class LytroRawFormat(LytroFormat):
     """ This is the Lytro Illum RAW format.
     The raw format is a 10bit image format as used by the Lytro Illum
@@ -104,12 +108,12 @@ class LytroRawFormat(LytroFormat):
         lsb = array[4::5]
 
         t0 = np.left_shift(t0, 2) + np.bitwise_and(lsb, 3)
-        t1 = np.left_shift(t1, 2) \
-             + np.right_shift(np.bitwise_and(lsb, 12), 2)
-        t2 = np.left_shift(t2, 2) \
-             + np.right_shift(np.bitwise_and(lsb, 48), 4)
-        t3 = np.left_shift(t3, 2) \
-             + np.right_shift(np.bitwise_and(lsb, 192), 6)
+        t1 = np.left_shift(t1, 2) + np.right_shift(
+            np.bitwise_and(lsb, 12), 2)
+        t2 = np.left_shift(t2, 2) + np.right_shift(
+            np.bitwise_and(lsb, 48), 4)
+        t3 = np.left_shift(t3, 2) + np.right_shift(
+            np.bitwise_and(lsb, 192), 6)
 
         image = np.zeros(LYTRO_IMAGE_SIZE, dtype=np.uint16)
         image[:, 0::4] = t0.reshape(

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -204,7 +204,11 @@ class LytroRawFormat(LytroFormat):
             image[:, 3::4] = t3.reshape(
                 (LYTRO_IMAGE_SIZE[0], LYTRO_IMAGE_SIZE[1] // 4))
 
-            # Return array and dummy meta data
+            # Normalize data to 1.0 as 64-bit float.
+            # Division is by 1023 as the Lytro saves 10-bit raw data.
+            image = np.divide(image, 1023).astype(np.float64)
+            
+            # Return image and meta data
             return image, self._get_meta_data(index=0)
 
         def _get_meta_data(self, index):

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -160,7 +160,7 @@ class LytroRawFormat(LytroFormat):
             raw = np.frombuffer(self._data, dtype=np.uint8).astype(np.uint16)
 
             # Rearrange bits
-            img = LytroRawFormat._rearrange_bits(raw)
+            img = LytroRawFormat.rearrange_bits(raw)
 
             # Return image and meta data
             return img, self._get_meta_data(index=0)

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -124,20 +124,17 @@ class LytroFormat(Format):
             raise RuntimeError('The lytro format cannot write meta data.')
 
 class LytroRawFormat(LytroFormat):
-    """ The dummy format is an example format that does nothing.
-    It will never indicate that it can read or write a file. When
-    explicitly asked to read, it will simply read the bytes. When
-    explicitly asked to write, it will raise an error.
+    """ This is the Lytro Illum RAW format.
+    The raw format is a 10bit image format as used by the Lytro Illum
+    light field camera. The format will read the specified raw file and will
+    try to load a .txt or .json file with the associated meta data.
+    This format does not support writing.
 
-    This documentation is shown when the user does ``help('thisformat')``.
+
 
     Parameters for reading
     ----------------------
-    Specify arguments in numpy doc style here.
-
-    Parameters for saving
-    ---------------------
-    Specify arguments in numpy doc style here.
+    None
 
     """
 
@@ -207,7 +204,7 @@ class LytroRawFormat(LytroFormat):
             # Normalize data to 1.0 as 64-bit float.
             # Division is by 1023 as the Lytro saves 10-bit raw data.
             image = np.divide(image, 1023).astype(np.float64)
-            
+
             # Return image and meta data
             return image, self._get_meta_data(index=0)
 

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -260,6 +260,9 @@ class LytroLfrFormat(LytroFormat):
                     self.serial_numbers = json.loads(
                         serial_numbers.decode('ASCII'))
 
+                    # Add private meta data to meta data dict
+                    self.metadata['privateMetadata'] = self.serial_numbers
+
             except KeyError:
                 raise RuntimeError(
                     "The specified file is not a valid LFR file.")

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -397,9 +397,10 @@ class LytroLfrFormat(LytroFormat):
 
 
 # Create the formats
-SPECIAL_CLASSES = {'lytro-lfr': LytroLfrFormat,
-                    'lytro-raw': LytroRawFormat
-                   }
+SPECIAL_CLASSES = {
+    'lytro-lfr': LytroLfrFormat,
+    'lytro-raw': LytroRawFormat
+}
 
 # Supported Formats.
 # Only single image files supported.

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -53,12 +53,6 @@ class LytroFormat(Format):
     # Only single images are supported.
     _modes = 'i'
 
-    def _can_read(self, request):
-        # Check if mode and extensions are supported by the format
-        if request.mode[1] in (self.modes + '?'):
-            if request.filename.lower().endswith(self.extensions):
-                return True
-
     def _can_write(self, request):
         # Writing of Lytro RAW and LFR files is not supported
         return False
@@ -98,6 +92,12 @@ class LytroRawFormat(LytroFormat):
     None
 
     """
+
+    def _can_read(self, request):
+        # Check if mode and extensions are supported by the format
+        if request.mode[1] in (self.modes + '?'):
+            if request.filename.lower().endswith('.raw'):
+                return True
 
     @staticmethod
     def rearrange_bits(array):
@@ -206,6 +206,12 @@ class LytroLfrFormat(LytroFormat):
     None
 
     """
+
+    def _can_read(self, request):
+        # Check if mode and extensions are supported by the format
+        if request.mode[1] in (self.modes + '?'):
+            if request.filename.lower().endswith('.lfr'):
+                return True
 
     # -- reader
 

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -47,7 +47,6 @@ class LytroFormat(Format):
     The subclasses LytroLfrFormat and LytroRawFormat implement
     the Lytro-LFR and Lytro-RAW format respectively.
     Writing is not supported.
-
     """
 
     # Only single images are supported.
@@ -90,7 +89,6 @@ class LytroRawFormat(LytroFormat):
     Parameters for reading
     ----------------------
     None
-
     """
 
     def _can_read(self, request):
@@ -204,7 +202,6 @@ class LytroLfrFormat(LytroFormat):
     Parameters for reading
     ----------------------
     None
-
     """
 
     def _can_read(self, request):
@@ -344,7 +341,6 @@ class LytroLfrFormat(LytroFormat):
                     Size of data chunk.
                 sha1 : str
                     Sha1 value of chunk.
-
             """
             # Read and check header of chunk
             header_chunk = self._file.read(HEADER_LENGTH)

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -4,7 +4,6 @@ from __future__ import division
 import numpy as np
 import json
 
-
 from pytest import raises
 from imageio.testing import run_tests_if_main, need_internet
 import imageio

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -1,8 +1,9 @@
 """ Test npz plugin functionality.
 """
-
+from __future__ import division
 import numpy as np
 import json
+
 
 from pytest import raises
 from imageio.testing import run_tests_if_main, need_internet

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -1,0 +1,458 @@
+""" Test npz plugin functionality.
+"""
+
+import numpy as np
+import json
+
+from pytest import raises
+from imageio.testing import run_tests_if_main, need_internet
+import imageio
+from imageio.core import get_remote_file, Request
+
+
+# Set file names for test images in imageio-binaries repo
+LFR_FILENAME = 'images/Ankylosaurus_&_Stegosaurus.LFR'
+THUMB_FILENAME = 'images/Ankylosaurus_&_Stegosaurus_Thumbnail.png'
+RAW_FILENAME = 'images/lenslet_whiteimage.RAW'
+RAW_META_FILENAME = 'images/lenslet_whiteimage.TXT'
+PNG_FILENAME = 'images/chelsea.png'
+
+
+def test_lytro_lfr_format():
+    """
+    Test basic read/write properties of LytroLfrFormat
+    """
+    # Get test images
+    need_internet()
+    lfr_file = get_remote_file(LFR_FILENAME)
+    raw_file = get_remote_file(RAW_FILENAME)
+    png_file = get_remote_file(PNG_FILENAME)
+
+    # Test lytro lfr format
+    format = imageio.formats['lytro-lfr']
+    assert format.name == 'LYTRO-LFR'
+    assert format.__module__.endswith('lytro')
+
+    # Test can read
+    assert format.can_read(Request(lfr_file, 'ri'))
+
+    # Test cannot read, cannot write
+    assert not format.can_read(Request(lfr_file, 'rv'))
+    assert not format.can_read(Request(lfr_file, 'rI'))
+    assert not format.can_read(Request(lfr_file, 'rV'))
+    assert not format.can_read(Request(raw_file, 'ri'))
+    assert not format.can_read(Request(png_file, 'ri'))
+
+    assert not format.can_write(Request(lfr_file, 'wi'))
+    assert not format.can_write(Request(raw_file, 'wi'))
+    assert not format.can_write(Request(png_file, 'wi'))
+
+
+def test_lytro_raw_format():
+    """
+    Test basic read/write properties of LytroRawFormat
+    """
+    # Get test images
+    need_internet()
+    lfr_file = get_remote_file(LFR_FILENAME)
+    raw_file = get_remote_file(RAW_FILENAME)
+    png_file = get_remote_file(PNG_FILENAME)
+
+    # Test lytro raw format
+    format = imageio.formats['lytro-raw']
+    assert format.name == 'LYTRO-RAW'
+    assert format.__module__.endswith('lytro')
+
+    # Test can read, cannot write
+    assert format.can_read(Request(raw_file, 'ri'))
+
+    # Test cannot read, cannot write
+    assert not format.can_read(Request(raw_file, 'rv'))
+    assert not format.can_read(Request(raw_file, 'rI'))
+    assert not format.can_read(Request(raw_file, 'rV'))
+    assert not format.can_read(Request(lfr_file, 'ri'))
+    assert not format.can_read(Request(png_file, 'ri'))
+
+    assert not format.can_write(Request(raw_file, 'wi'))
+    assert not format.can_write(Request(lfr_file, 'wi'))
+    assert not format.can_write(Request(png_file, 'wi'))
+
+
+def test_lytro_lfr_reading():
+    """ Test reading of lytro .lfr file
+    """
+    # Get test images
+    need_internet()
+    lfr_file = get_remote_file(LFR_FILENAME)
+    thumb_file = get_remote_file(THUMB_FILENAME)
+
+    # Read image and thumbnail
+    img = imageio.imread(lfr_file, format='lytro-lfr')
+    thumb_gt = imageio.imread(thumb_file)
+
+    # Test image shape and some pixel values
+    # Pixel values are extracted from the Matlab reference implementation
+    assert img.shape == (5368, 7728)
+    assert round(img[14, 32], 15) == 0.100684261974585
+    assert round(img[1531, 95], 15) == 0.250244379276637
+    assert round(img[1619, 94], 15) == 0.286412512218964
+    assert round(img[1619, 3354], 15) == 0.345063538611926
+    assert round(img[1747, 3660], 15) == 0.222873900293255
+    assert round(img[1813, 5789], 15) == 0.079178885630499
+    assert round(img[4578, 7352], 15) == 0.256109481915934
+    assert round(img[5086, 7568], 15) == 0.106549364613881
+    assert round(img[4951, 2025], 15) == 0.348973607038123
+
+    # Test extracted thumbnail against downloaded one
+    assert np.array_equal(img._meta['thumbnail']['image'], thumb_gt)
+
+    # Test metadata and privateMetadata against ground truth data
+    metadata_gt = {
+        "image": {
+            "width": 7728,
+            "orientation": 1,
+            "modulationExposureBias": 0.2689966559410095,
+            "pixelPacking": {
+                "bitsPerPixel": 10,
+                "endianness": "little"
+            },
+            "limitExposureBias": 0.0,
+            "height": 5368,
+            "pixelFormat": {
+                "white": {
+                    "gr": 1023,
+                    "r": 1023,
+                    "b": 1023,
+                    "gb": 1023
+                },
+                "black": {
+                    "gr": 64,
+                    "r": 64,
+                    "b": 64,
+                    "gb": 64
+                },
+                "rightShift": 0
+            },
+            "iso": 80,
+            "originOnSensor": {
+                "x": 0,
+                "y": 0
+            },
+            "mosaic": {
+                "tile": "r,gr:gb,b",
+                "upperLeftPixel": "gr"
+            },
+            "color": {
+                "whiteBalanceGain": {
+                    "gr": 1.0,
+                    "r": 1.378859281539917,
+                    "b": 1.1484659910202026,
+                    "gb": 1.0
+                },
+                "ccm": [
+                    2.2271547317504883,
+                    -1.055293321609497,
+                    -0.1718614399433136,
+                    -0.4269128441810608,
+                    1.7458617687225342,
+                    -0.3189488351345062,
+                    -0.20497213304042816,
+                    -0.7469924688339233,
+                    1.9519646167755127
+                ]
+            }
+        },
+        "generator": "lightning",
+        "schema": "http://schema.lytro.com/lfp/lytro_illum_public/"
+                  + "1.3.5/lytro_illum_public_schema.json",
+        "camera": {
+            "make": "Lytro, Inc.",
+            "model": "ILLUM",
+            "firmware": "1.1.1 (23)"
+        },
+        "devices": {
+            "clock": {
+                "zuluTime": "2015-05-17T13:31:37.412Z",
+                "isTimeValid": True
+            },
+            "sensor": {
+                "pixelPitch": 1.4e-06,
+                "normalizedResponses": [
+                    {
+                        "b": 0.7344976663589478,
+                        "gb": 1.0,
+                        "cct": 5100,
+                        "gr": 1.0,
+                        "r": 0.7761663198471069
+                    }
+                ],
+                "perCcm": [
+                    {
+                        "ccm": [
+                            2.006272077560425,
+                            -0.5362802147865295,
+                            -0.46999192237854004,
+                            -0.6019303798675537,
+                            1.836044430732727,
+                            -0.23411400616168976,
+                            -0.8173090815544128,
+                            -1.6435128450393677,
+                            3.4608218669891357
+                        ],
+                        "cct": 2850.0
+                    },
+                    {
+                        "ccm": [
+                            2.4793264865875244,
+                            -1.2747985124588013,
+                            -0.20452789962291718,
+                            -0.5189455151557922,
+                            1.6118407249450684,
+                            -0.09289517253637314,
+                            -0.3602483570575714,
+                            -1.0115599632263184,
+                            2.3718082904815674
+                        ],
+                        "cct": 4150.0
+                    },
+                    {
+                        "ccm": [
+                            2.1902196407318115,
+                            -1.0231428146362305,
+                            -0.16707684099674225,
+                            -0.4134329855442047,
+                            1.7654914855957031,
+                            -0.3520585000514984,
+                            -0.18222910165786743,
+                            -0.7082417607307434,
+                            1.8904708623886108
+                        ],
+                        "cct": 6500.0
+                    }
+                ],
+                "pixelWidth": 7728,
+                "bitsPerPixel": 10,
+                "mosaic": {
+                    "tile": "r,gr:gb,b",
+                    "upperLeftPixel": "gr"
+                },
+                "pixelHeight": 5368,
+                "baseIso": 80,
+                "analogGain": {
+                    "gr": 1.0,
+                    "r": 1.0,
+                    "b": 1.0,
+                    "gb": 1.0
+                }
+            },
+            "shutter": {
+                "mechanism": "focalPlaneCurtain",
+                "frameExposureDuration": 0.000784054514952004,
+                "pixelExposureDuration": 0.000784054514952004,
+                "maxSyncSpeed": 0.004
+            },
+            "mla": {
+                "config": "com.lytro.mla.3",
+                "rotation": -0.0005426123971119523,
+                "tiling": "hexUniformRowMajor",
+                "scaleFactor": {
+                    "x": 1.0,
+                    "y": 1.0003429651260376
+                },
+                "lensPitch": 2e-05,
+                "sensorOffset": {
+                    "x": 8.421777725219726e-06,
+                    "y": -9.545820355415345e-07,
+                    "z": 3.7e-05
+                }
+            },
+            "lens": {
+                "fNumber": 2.199776378914589,
+                "exitPupilOffset": {
+                    "z": 0.09728562164306641
+                },
+                "zoomStep": -297,
+                "focusStep": 309,
+                "opticalCenterOffset": {
+                    "x": 1.48461913340725e-05,
+                    "y": 3.083264164160937e-05
+                },
+                "focalLength": 0.024199465511189833,
+                "infinityLambda": 33.89023289728373
+            },
+            "battery": {
+                "make": "Lytro",
+                "chargeLevel": 8,
+                "model": "B01-3760",
+                "cycleCount": 5
+            },
+            "accelerometer": {
+                "samples": [
+                    {
+                        "x": -0.3689117431640625,
+                        "y": 9.022918701171875,
+                        "time": 0.0,
+                        "z": -1.339324951171875
+                    }
+                ]
+            }
+        },
+        "settings": {
+            "exposure": {
+                "bracketCount": 3,
+                "compensation": 0.30000001192092896,
+                "mode": "program",
+                "meter": {
+                    "mode": "evaluative",
+                    "roiMode": "af",
+                    "roi": [
+                        {
+                            "top": 0.0,
+                            "left": 0.0,
+                            "bottom": 1.0,
+                            "right": 1.0
+                        }
+                    ]
+                },
+                "bracketEnable": False,
+                "bracketStep": 1.0,
+                "bracketOffset": 0.0,
+                "aeLock": False
+            },
+            "whiteBalance": {
+                "tint": -76.0,
+                "mode": "auto",
+                "cct": 6199
+            },
+            "shutter": {
+                "selfTimerEnable": False,
+                "selfTimerDuration": 2.0,
+                "driveMode": "single"
+            },
+            "focus": {
+                "afActuationMode": "single",
+                "mode": "auto",
+                "ringLock": False,
+                "bracketCount": 3,
+                "bracketEnable": False,
+                "afDriveMode": "single",
+                "bracketStep": 3.0,
+                "bracketOffset": 0.0,
+                "roi": [
+                    {
+                        "top": 0.0,
+                        "left": 0.0,
+                        "bottom": 1.0,
+                        "right": 1.0
+                    }
+                ],
+                "captureLambda": -4.0
+            },
+            "zoom": {
+                "ringLock": False
+            },
+            "flash": {
+                "mode": "unknown",
+                "exposureCompensation": 0.0,
+                "zoomMode": "auto",
+                "curtainTriggerSync": "front",
+                "afAssistMode": "auto"
+            },
+            "depth": {
+                "assist": "on",
+                "histogram": "on",
+                "overlay": "on"
+            }
+        },
+        "algorithms": {
+            "awb": {
+                "roi": "fullFrame",
+                "computed": {
+                    "cct": 6199,
+                    "gain": {
+                        "gr": 1.0,
+                        "r": 1.378859281539917,
+                        "b": 1.1484659910202026,
+                        "gb": 1.0
+                    }
+                }
+            },
+            "ae": {
+                "computed": {
+                    "ev": 1.0
+                },
+                "roi": "followAf",
+                "mode": "live"
+            },
+            "af": {
+                "computed": {
+                    "focusStep": 309
+                },
+                "roi": "focusRoi"
+            }
+        },
+        "picture": {
+            "totalFrames": 1,
+            "frameIndex": 0,
+            "dcfDirectory": "100PHOTO",
+            "dcfFile": "IMG_0813"
+        }
+    }
+    private_metadata_gt = {
+        "generator": "lightning",
+        "schema": "http://schema.lytro.com/lfp/lytro_illum_private/"
+                  + "1.1.1/lytro_illum_private_schema.json",
+        "devices": {
+            "sensor": {
+                "serialNumber": "0C220593"
+            }
+        },
+        "camera": {
+            "serialNumber": "B5143909630"
+        }
+    }
+
+    assert img._meta['metadata'] == metadata_gt
+    assert img._meta['privateMetadata'] == private_metadata_gt
+
+    # Test fail
+    test_reader = imageio.read(lfr_file, 'lytro-lfr')
+    raises(IndexError, test_reader.get_data, -1)
+    raises(IndexError, test_reader.get_data, 3)
+
+
+def test_lytro_raw_reading():
+    """ Test reading of lytro .raw file
+    """
+    # Get test images
+    need_internet()
+    raw_file = get_remote_file(RAW_FILENAME)
+    raw_meta_file = get_remote_file(RAW_META_FILENAME)
+
+    # Read image and metadata file
+    img = imageio.imread(raw_file, format='lytro-raw')
+    meta_gt = json.load(open(raw_meta_file))
+
+    # Test image shape and some pixel values
+    # Pixel values are extracted from the Matlab reference implementation
+    assert img.shape == (5368, 7728)
+    assert round(img[24, 48], 15) == 0.738025415444770
+    assert round(img[3692, 86], 15) == 0.132942326490714
+    assert round(img[258, 1658], 15) == 0.687194525904203
+    assert round(img[1349, 6765], 15) == 0.113391984359726
+    assert round(img[210, 6761], 15) == 0.162267839687195
+    assert round(img[5231, 6459], 15) == 0.784946236559140
+    assert round(img[5213, 7477], 15) == 0.095796676441838
+    assert round(img[2745, 3789], 15) == 0.760508308895406
+    assert round(img[1428, 4192], 15) == 0.621700879765396
+
+    # Test extracted metadata against extracted metadata from .txt file
+    assert img._meta == meta_gt
+
+    # Test fail
+    test_reader = imageio.read(raw_file, 'lytro-raw')
+    raises(IndexError, test_reader.get_data, -1)
+    raises(IndexError, test_reader.get_data, 3)
+
+
+run_tests_if_main()


### PR DESCRIPTION
# Description

This PR adds a plugin to read Lytro ``.lfr`` and ``.raw`` files as provided by the [Lytro Illum](https://en.wikipedia.org/wiki/Lytro#Lytro_ILLUM) light field camera.

The ``.lfr`` format is a container format containing raw 10bit image data and metadata.
The ``.raw`` format is a 10bit raw image format.

# Why is this useful?

The Lytro Illum is a light field camera that aimed for consumer market but is now mostly used in the scientific community as a reference implementation of a light field camera. Lytro provides closed-source software to extract and decode the light field images from the camera.

For scientific use, reading the raw ``.lfr`` and ``.raw`` format is necessary, e.g. to test and compare new decoding algorithms.

As of now, there is no public Python module capable of reading the ``.lfr`` and ``.raw`` data provided by the Lytro Illum camera. The most videly spread (open-source) software to read and decode lightfields is the [MATLAB Light Field Toolbox](https://de.mathworks.com/matlabcentral/fileexchange/49683-light-field-toolbox-v0-4) by Donald Dansereau.

# Type of change

- [x] Add Lytro lfr and raw plugin (``plugins/lytro.py``)
- [x] Add plugin loading to ``plugins/__init__.py``

# What about testing?

I'm struggling with writing a test for the plugin and I am unsure how to go about this.
First problem:
The ``.lfr`` and ``.raw`` files of the Lytro Illum camera are about 50mb in size. Adding them to the ``imageio-binaries/image`` project would increase its size drastically.

Second:
How would I go about testing the correct behavior of the plugin as there is no data to compare the read images with? Is there more to test then that there are no errors when reading an example file?


# Checklist:

- [x] Code follows PEP guidellines
- [x] Add unit test for the lytro plugin