### PR TITLE
Feature/lytro lfp plugin

### DIFF
--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -31,21 +31,24 @@ from ..core import Format
 from .. import imread
 
 
-# Sensor size of Lytro Illum light field camera sensor
-LYTRO_IMAGE_SIZE = (5368, 7728)
+# Sensor size of Lytro Illum resp. Lytro F01 light field camera sensor
+LYTRO_ILLUM_IMAGE_SIZE = (5368, 7728)
+LYTRO_F01_IMAGE_SIZE = (3280, 3280)
 
 # Parameter of lfr file format
 HEADER_LENGTH = 12
 SIZE_LENGTH = 4  # = 16 - header_length
 SHA1_LENGTH = 45  # = len("sha1-") + (160 / 4)
 PADDING_LENGTH = 35  # = (4*16) - header_length - size_length - sha1_length
-DATA_CHUNKS = 11
+DATA_CHUNKS_ILLUM = 11
+DATA_CHUNKS_F01 = 3
 
 
 class LytroFormat(Format):
     """ Base class for Lytro format.
-    The subclasses LytroLfrFormat and LytroRawFormat implement
-    the Lytro-LFR and Lytro-RAW format respectively.
+    The subclasses LytroLfrFormat, LytroLfpFormat, LytroIllumRawFormat and
+    LytroF01RawFormat implement the Lytro-LFR, Lytro-LFP and Lytro-RAW format
+    for the Illum and original F01 camera respectively.
     Writing is not supported.
     """
 
@@ -53,7 +56,7 @@ class LytroFormat(Format):
     _modes = 'i'
 
     def _can_write(self, request):
-        # Writing of Lytro RAW and LFR files is not supported
+        # Writing of Lytro files is not supported
         return False
 
     # -- writer
@@ -78,7 +81,7 @@ class LytroFormat(Format):
             raise RuntimeError('The lytro format cannot write meta data.')
 
 
-class LytroRawFormat(LytroFormat):
+class LytroIllumRawFormat(LytroFormat):
     """ This is the Lytro Illum RAW format.
     The raw format is a 10bit image format as used by the Lytro Illum
     light field camera. The format will read the specified raw file and will
@@ -115,18 +118,18 @@ class LytroRawFormat(LytroFormat):
         t3 = np.left_shift(t3, 2) + np.right_shift(
             np.bitwise_and(lsb, 192), 6)
 
-        image = np.zeros(LYTRO_IMAGE_SIZE, dtype=np.uint16)
+        image = np.zeros(LYTRO_ILLUM_IMAGE_SIZE, dtype=np.uint16)
         image[:, 0::4] = t0.reshape(
-            (LYTRO_IMAGE_SIZE[0], LYTRO_IMAGE_SIZE[1] // 4))
+            (LYTRO_ILLUM_IMAGE_SIZE[0], LYTRO_ILLUM_IMAGE_SIZE[1] // 4))
         image[:, 1::4] = t1.reshape(
-            (LYTRO_IMAGE_SIZE[0], LYTRO_IMAGE_SIZE[1] // 4))
+            (LYTRO_ILLUM_IMAGE_SIZE[0], LYTRO_ILLUM_IMAGE_SIZE[1] // 4))
         image[:, 2::4] = t2.reshape(
-            (LYTRO_IMAGE_SIZE[0], LYTRO_IMAGE_SIZE[1] // 4))
+            (LYTRO_ILLUM_IMAGE_SIZE[0], LYTRO_ILLUM_IMAGE_SIZE[1] // 4))
         image[:, 3::4] = t3.reshape(
-            (LYTRO_IMAGE_SIZE[0], LYTRO_IMAGE_SIZE[1] // 4))
+            (LYTRO_ILLUM_IMAGE_SIZE[0], LYTRO_ILLUM_IMAGE_SIZE[1] // 4))
 
         # Normalize data to 1.0 as 64-bit float.
-        # Division is by 1023 as the Lytro saves 10-bit raw data.
+        # Division is by 1023 as the Lytro Illum saves 10-bit raw data.
         return np.divide(image, 1023.0).astype(np.float64)
 
     # -- reader
@@ -160,7 +163,7 @@ class LytroRawFormat(LytroFormat):
             raw = np.frombuffer(self._data, dtype=np.uint8).astype(np.uint16)
 
             # Rearrange bits
-            img = LytroRawFormat.rearrange_bits(raw)
+            img = LytroIllumRawFormat.rearrange_bits(raw)
 
             # Return image and meta data
             return img, self._get_meta_data(index=0)
@@ -305,7 +308,7 @@ class LytroLfrFormat(LytroFormat):
             """
             chunk_header = b'\x89LFC\x0D\x0A\x1A\x0A\x00\x00\x00\x00'
 
-            for i in range(0, DATA_CHUNKS):
+            for i in range(0, DATA_CHUNKS_ILLUM):
                 data_pos, size, sha1 = self._get_chunk(chunk_header)
                 self._chunks[sha1] = (data_pos, size)
 
@@ -377,7 +380,297 @@ class LytroLfrFormat(LytroFormat):
             # Read bytes from string and convert to uint16
             raw = np.frombuffer(self.raw_image_data, dtype=np.uint8).astype(
                 np.uint16)
-            im = LytroRawFormat.rearrange_bits(raw)
+            im = LytroIllumRawFormat.rearrange_bits(raw)
+
+            # Return array and dummy meta data
+            return im, self.metadata
+
+        def _get_meta_data(self, index):
+            # Get the meta data for the given index. If index is None,
+            # it returns the global meta data.
+            if index not in [0, None]:
+                raise IndexError(
+                    'Lytro meta data file contains only one dataset')
+
+            return self.metadata
+
+
+class LytroF01RawFormat(LytroFormat):
+    """ This is the Lytro RAW format for the original F01 Lytro camera.
+    The raw format is a 12bit image format as used by the Lytro F01
+    light field camera. The format will read the specified raw file and will
+    try to load a .txt or .json file with the associated meta data.
+    This format does not support writing.
+
+
+    Parameters for reading
+    ----------------------
+    None
+
+    """
+
+    def _can_read(self, request):
+        # Check if mode and extensions are supported by the format
+        if request.mode[1] in (self.modes + '?'):
+            if request.filename.lower().endswith('.raw'):
+                return True
+
+    @staticmethod
+    def rearrange_bits(array):
+        # Do bit rearrangement for the 12-bit lytro raw format
+        # Normalize output to 1.0 as float64
+        t0 = array[0::3]
+        t1 = array[1::3]
+        t2 = array[2::3]
+
+        a0 = np.left_shift(t0, 4) + np.right_shift(
+            np.bitwise_and(t1, 240), 4)
+        a1 = np.left_shift(np.bitwise_and(t1, 15), 8) + t2
+
+        image = np.zeros(LYTRO_F01_IMAGE_SIZE, dtype=np.uint16)
+        image[:, 0::2] = a0.reshape(
+            (LYTRO_F01_IMAGE_SIZE[0], LYTRO_F01_IMAGE_SIZE[1] // 2))
+        image[:, 1::2] = a1.reshape(
+            (LYTRO_F01_IMAGE_SIZE[0], LYTRO_F01_IMAGE_SIZE[1] // 2))
+
+        # Normalize data to 1.0 as 64-bit float.
+        # Division is by 4095 as the Lytro F01 saves 12-bit raw data.
+        return np.divide(image, 4095.0).astype(np.float64)
+
+    # -- reader
+
+    class Reader(Format.Reader):
+
+        def _open(self):
+            self._file = self.request.get_file()
+            self._data = None
+
+        def _close(self):
+            # Close the reader.
+            # Note that the request object will close self._file
+            del self._data
+
+        def _get_length(self):
+            # Return the number of images.
+            return 1
+
+        def _get_data(self, index):
+            # Return the data and meta data for the given index
+
+            if index not in [0, 'None']:
+                raise IndexError('Lytro file contains only one dataset')
+
+            # Read all bytes
+            if self._data is None:
+                self._data = self._file.read()
+
+            # Read bytes from string and convert to uint16
+            raw = np.frombuffer(self._data, dtype=np.uint8).astype(np.uint16)
+
+            # Rearrange bits
+            img = LytroF01RawFormat.rearrange_bits(raw)
+
+            # Return image and meta data
+            return img, self._get_meta_data(index=0)
+
+        def _get_meta_data(self, index):
+            # Get the meta data for the given index. If index is None, it
+            # should return the global meta data.
+
+            if index not in [0, None]:
+                raise IndexError(
+                    'Lytro meta data file contains only one dataset')
+
+            # Try to read meta data from meta data file corresponding
+            # to the raw data file, extension in [.txt, .TXT, .json, .JSON]
+            filename_base = os.path.splitext(
+                self.request.get_local_filename())[0]
+
+            meta_data = None
+
+            for ext in ['.txt', '.TXT', '.json', '.JSON']:
+                if os.path.isfile(filename_base + ext):
+                    meta_data = json.load(open(filename_base + ext))
+
+            if meta_data is not None:
+                return meta_data
+
+            else:
+                print("No metadata file found for provided raw file.")
+                return {}
+
+
+class LytroLfpFormat(LytroFormat):
+    """ This is the Lytro Illum LFP format.
+    The lfp is a image and meta data container format as used by the
+    Lytro F01 light field camera.
+    The format will read the specified lfp file.
+    This format does not support writing.
+
+    Parameters for reading
+    ----------------------
+    None
+    """
+
+    def _can_read(self, request):
+        # Check if mode and extensions are supported by the format
+        if request.mode[1] in (self.modes + '?'):
+            if request.filename.lower().endswith('.lfp'):
+                return True
+
+    # -- reader
+
+    class Reader(Format.Reader):
+
+        def _open(self):
+            self._file = self.request.get_file()
+            self._data = None
+            self._chunks = {}
+            self.metadata = {}
+            self._content = None
+
+            self._find_header()
+            self._find_meta()
+            self._find_chunks()
+
+            try:
+                # Get sha1 dict and check if it is in dictionary of data chunks
+                chunk_dict = self._content['picture']['frameArray'][0]['frame']
+                if chunk_dict['metadataRef'] in self._chunks and \
+                        chunk_dict['imageRef'] in self._chunks and \
+                        chunk_dict['privateMetadataRef'] in self._chunks:
+
+                    # Read raw image data byte buffer
+                    data_pos, size = self._chunks[chunk_dict['imageRef']]
+                    self._file.seek(data_pos, 0)
+                    self.raw_image_data = self._file.read(size)
+
+                    # Read meta data
+                    data_pos, size = self._chunks[chunk_dict['metadataRef']]
+                    self._file.seek(data_pos, 0)
+                    metadata = self._file.read(size)
+                    # Add metadata to meta data dict
+                    self.metadata['metadata'] = json.loads(
+                        metadata.decode('ASCII'))
+
+                    # Read private metadata
+                    data_pos, size = self._chunks[
+                        chunk_dict['privateMetadataRef']]
+                    self._file.seek(data_pos, 0)
+                    serial_numbers = self._file.read(size)
+                    self.serial_numbers = json.loads(
+                        serial_numbers.decode('ASCII'))
+                    # Add private metadata to meta data dict
+                    self.metadata['privateMetadata'] = self.serial_numbers
+
+            except KeyError:
+                raise RuntimeError(
+                    "The specified file is not a valid LFP file.")
+
+        def _close(self):
+            # Close the reader.
+            # Note that the request object will close self._file
+            del self._data
+
+        def _get_length(self):
+            # Return the number of images. Can be np.inf
+            return 1
+
+        def _find_header(self):
+            """
+            Checks if file has correct header and skip it.
+            """
+            file_header = b'\x89LFP\x0D\x0A\x1A\x0A\x00\x00\x00\x01'
+
+            # Read and check header of file
+            header = self._file.read(HEADER_LENGTH)
+            if header != file_header:
+                raise RuntimeError("The LFP file header is invalid.")
+
+            # Read first bytes to skip header
+            self._file.read(SIZE_LENGTH)
+
+        def _find_chunks(self):
+            """
+            Gets start position and size of data chunks in file.
+            """
+            chunk_header = b'\x89LFC\x0D\x0A\x1A\x0A\x00\x00\x00\x00'
+
+            for i in range(0, DATA_CHUNKS_F01):
+                data_pos, size, sha1 = self._get_chunk(chunk_header)
+                self._chunks[sha1] = (data_pos, size)
+
+        def _find_meta(self):
+            """
+            Gets a data chunk that contains information over content
+            of other data chunks.
+            """
+            meta_header = b'\x89LFM\x0D\x0A\x1A\x0A\x00\x00\x00\x00'
+
+            data_pos, size, sha1 = self._get_chunk(meta_header)
+
+            # Get content
+            self._file.seek(data_pos, 0)
+            data = self._file.read(size)
+            self._content = json.loads(data.decode('ASCII'))
+            data = self._file.read(5) # skip 5
+
+        def _get_chunk(self, header):
+            """
+            Checks if chunk has correct header and skips it.
+            Finds start position and length of next chunk and reads
+            sha1-string that identifies the following data chunk.
+
+            Parameters
+            ----------
+            header : bytes
+                Byte string that identifies start of chunk.
+
+            Returns
+            -------
+                data_pos : int
+                    Start position of data chunk in file.
+                size : int
+                    Size of data chunk.
+                sha1 : str
+                    Sha1 value of chunk.
+            """
+            # Read and check header of chunk
+            header_chunk = self._file.read(HEADER_LENGTH)
+            if header_chunk != header:
+                raise RuntimeError("The LFP chunk header is invalid.")
+
+            data_pos = None
+            sha1 = None
+
+            # Read size
+            size = struct.unpack(">i", self._file.read(SIZE_LENGTH))[0]
+            if size > 0:
+                # Read sha1
+                sha1 = str(self._file.read(SHA1_LENGTH).decode('ASCII'))
+                # Skip fixed null chars
+                self._file.read(PADDING_LENGTH)
+                # Find start of data and skip data
+                data_pos = self._file.tell()
+                self._file.seek(size, 1)
+                # Skip extra null chars
+                ch = self._file.read(1)
+                while ch == b'\0':
+                    ch = self._file.read(1)
+                self._file.seek(-1, 1)
+
+            return data_pos, size, sha1
+
+        def _get_data(self, index):
+            # Return the data and meta data for the given index
+            if index not in [0, None]:
+                raise IndexError(
+                    'Lytro lfp file contains only one dataset')
+
+            # Read bytes from string and convert to uint16
+            raw = np.frombuffer(self.raw_image_data, dtype=np.uint8).astype(
+                np.uint16)
+            im = LytroF01RawFormat.rearrange_bits(raw)
 
             # Return array and dummy meta data
             return im, self.metadata
@@ -395,14 +688,18 @@ class LytroLfrFormat(LytroFormat):
 # Create the formats
 SPECIAL_CLASSES = {
     'lytro-lfr': LytroLfrFormat,
-    'lytro-raw': LytroRawFormat
+    'lytro-illum-raw': LytroIllumRawFormat,
+    'lytro-lfp': LytroLfpFormat,
+    'lytro-f01-raw': LytroF01RawFormat
 }
 
 # Supported Formats.
 # Only single image files supported.
 file_formats = [
     ('LYTRO-LFR', 'Lytro Illum lfr image file', 'lfr', 'i'),
-    ('LYTRO-RAW', 'Lytro Illum raw image file', 'raw', 'i')
+    ('LYTRO-ILLUM-RAW', 'Lytro Illum raw image file', 'raw', 'i'),
+    ('LYTRO-LFP', 'Lytro F01 lfp image file', 'lfp', 'i'),
+    ('LYTRO-F01-RAW', 'Lytro F01 raw image file', 'raw', 'i')
 ]
 
 

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -613,7 +613,7 @@ class LytroLfpFormat(LytroFormat):
             self._file.seek(data_pos, 0)
             data = self._file.read(size)
             self._content = json.loads(data.decode('ASCII'))
-            data = self._file.read(5) # skip 5
+            data = self._file.read(5)  # Skip 5
 
         def _get_chunk(self, header):
             """

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -12,11 +12,13 @@ from imageio.core import get_remote_file, Request
 
 # Set file names for test images in imageio-binaries repo
 LFR_FILENAME = 'images/Ankylosaurus_&_Stegosaurus.LFR'
-THUMB_FILENAME = 'images/Ankylosaurus_&_Stegosaurus_Thumbnail.png'
-RAW_FILENAME = 'images/lenslet_whiteimage.RAW'
-RAW_META_FILENAME = 'images/lenslet_whiteimage.TXT'
+THUMB_FILENAME = 'images/Ankylosaurus_&_Stegosaurus_Thumbnail.jpg'
+RAW_ILLUM_FILENAME = 'images/lenslet_whiteimage.RAW'
+RAW_ILLUM_META_FILENAME = 'images/lenslet_whiteimage.TXT'
+LFP_FILENAME = 'images/Guitar.lfp'
+RAW_F0_FILENAME = 'images/IMG_0001__frame.raw'
+RAW_F0_META_FILENAME = 'images/IMG_0001__frame.json'
 PNG_FILENAME = 'images/chelsea.png'
-
 
 def test_lytro_lfr_format():
     """
@@ -25,7 +27,9 @@ def test_lytro_lfr_format():
     # Get test images
     need_internet()
     lfr_file = get_remote_file(LFR_FILENAME)
-    raw_file = get_remote_file(RAW_FILENAME)
+    raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
+    lfp_file = get_remote_file(LFP_FILENAME)
+    raw_f01_file= get_remote_file(RAW_F0_FILENAME)
     png_file = get_remote_file(PNG_FILENAME)
 
     # Test lytro lfr format
@@ -40,41 +44,121 @@ def test_lytro_lfr_format():
     assert not format.can_read(Request(lfr_file, 'rv'))
     assert not format.can_read(Request(lfr_file, 'rI'))
     assert not format.can_read(Request(lfr_file, 'rV'))
-    assert not format.can_read(Request(raw_file, 'ri'))
+    assert not format.can_read(Request(lfp_file, 'ri'))
+    assert not format.can_read(Request(raw_illum_file, 'ri'))
+    assert not format.can_read(Request(raw_f01_file, 'ri'))
     assert not format.can_read(Request(png_file, 'ri'))
 
     assert not format.can_write(Request(lfr_file, 'wi'))
-    assert not format.can_write(Request(raw_file, 'wi'))
+    assert not format.can_write(Request(lfp_file, 'wi'))
+    assert not format.can_write(Request(raw_f01_file, 'wi'))
+    assert not format.can_write(Request(raw_illum_file, 'wi'))
     assert not format.can_write(Request(png_file, 'wi'))
 
 
-def test_lytro_raw_format():
+def test_lytro_illum_raw_format():
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
     need_internet()
     lfr_file = get_remote_file(LFR_FILENAME)
-    raw_file = get_remote_file(RAW_FILENAME)
+    raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
+    lfp_file = get_remote_file(LFP_FILENAME)
+    raw_f01_file= get_remote_file(RAW_F0_FILENAME)
     png_file = get_remote_file(PNG_FILENAME)
 
     # Test lytro raw format
-    format = imageio.formats['lytro-raw']
-    assert format.name == 'LYTRO-RAW'
+    format = imageio.formats['lytro-illum-raw']
+    assert format.name == 'LYTRO-ILLUM-RAW'
     assert format.__module__.endswith('lytro')
 
     # Test can read, cannot write
-    assert format.can_read(Request(raw_file, 'ri'))
+    assert format.can_read(Request(raw_illum_file, 'ri'))
 
     # Test cannot read, cannot write
-    assert not format.can_read(Request(raw_file, 'rv'))
-    assert not format.can_read(Request(raw_file, 'rI'))
-    assert not format.can_read(Request(raw_file, 'rV'))
+    assert not format.can_read(Request(raw_illum_file, 'rv'))
+    assert not format.can_read(Request(raw_illum_file, 'rI'))
+    assert not format.can_read(Request(raw_illum_file, 'rV'))
     assert not format.can_read(Request(lfr_file, 'ri'))
+    assert not format.can_read(Request(lfp_file, 'ri'))
     assert not format.can_read(Request(png_file, 'ri'))
 
-    assert not format.can_write(Request(raw_file, 'wi'))
+    assert not format.can_write(Request(raw_illum_file, 'wi'))
     assert not format.can_write(Request(lfr_file, 'wi'))
+    assert not format.can_write(Request(lfp_file, 'wi'))
+    assert not format.can_write(Request(raw_f01_file, 'wi'))
+    assert not format.can_write(Request(png_file, 'wi'))
+
+
+def test_lytro_f01_raw_format():
+    """
+    Test basic read/write properties of LytroRawFormat
+    """
+    # Get test images
+    need_internet()
+    lfr_file = get_remote_file(LFR_FILENAME)
+    raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
+    lfp_file = get_remote_file(LFP_FILENAME)
+    raw_f01_file= get_remote_file(RAW_F0_FILENAME)
+    png_file = get_remote_file(PNG_FILENAME)
+
+    # Test lytro raw format
+    format = imageio.formats['lytro-illum-raw']
+    assert format.name == 'LYTRO-ILLUM-RAW'
+    assert format.__module__.endswith('lytro')
+
+    # Test can read, cannot write
+    assert format.can_read(Request(raw_f01_file, 'ri'))
+
+    # Test cannot read, cannot write
+    assert not format.can_read(Request(raw_f01_file, 'rv'))
+    assert not format.can_read(Request(raw_f01_file, 'rI'))
+    assert not format.can_read(Request(raw_f01_file, 'rV'))
+    assert not format.can_read(Request(lfr_file, 'ri'))
+    assert not format.can_read(Request(lfp_file, 'ri'))
+    assert not format.can_read(Request(png_file, 'ri'))
+
+    assert not format.can_write(Request(raw_f01_file, 'wi'))
+    assert not format.can_write(Request(lfr_file, 'wi'))
+    assert not format.can_write(Request(lfp_file, 'wi'))
+    assert not format.can_write(Request(raw_illum_file, 'wi'))
+    assert not format.can_write(Request(png_file, 'wi'))
+
+
+def test_lytro_lfp_format():
+    """
+    Test basic read/write properties of LytroRawFormat
+    """
+    # Get test images
+    need_internet()
+    lfr_file = get_remote_file(LFR_FILENAME)
+    raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
+    lfp_file = get_remote_file(LFP_FILENAME)
+    raw_f01_file= get_remote_file(RAW_F0_FILENAME)
+    png_file = get_remote_file(PNG_FILENAME)
+
+    # Test lytro raw format
+    format = imageio.formats['lytro-lfp']
+    assert format.name == 'LYTRO-LFP'
+    assert format.__module__.endswith('lytro')
+
+    # Test can read, cannot write
+    assert format.can_read(Request(lfp_file, 'ri'))
+
+    # Test cannot read, cannot write
+    assert not format.can_read(Request(lfp_file, 'rv'))
+    assert not format.can_read(Request(lfp_file, 'rI'))
+    assert not format.can_read(Request(lfp_file, 'rV'))
+    assert not format.can_read(Request(lfr_file, 'ri'))
+    assert not format.can_read(Request(raw_f01_file, 'ri'))
+    assert not format.can_read(Request(raw_illum_file, 'ri'))
+    assert not format.can_read(Request(png_file, 'ri'))
+
+    assert not format.can_write(Request(lfp_file, 'wi'))
+    assert not format.can_write(Request(lfr_file, 'wi'))
+    assert not format.can_write(Request(raw_f01_file, 'wi'))
+    assert not format.can_write(Request(raw_illum_file, 'wi'))
     assert not format.can_write(Request(png_file, 'wi'))
 
 
@@ -421,16 +505,357 @@ def test_lytro_lfr_reading():
     raises(IndexError, test_reader.get_data, 3)
 
 
-def test_lytro_raw_reading():
+def test_lytro_lfp_reading():
+    """ Test reading of lytro .lfr file
+    """
+    # Get test images
+    need_internet()
+    lfp_file = get_remote_file(LFP_FILENAME)
+
+    # Read image and thumbnail
+    img = imageio.imread(lfp_file, format='lytro-lfp')
+    thumb_gt = imageio.imread(lfp_file)
+
+    # Test image shape and some pixel values
+    # Pixel values are extracted from the Matlab reference implementation
+    assert img.shape == (3280, 3280)
+    assert round(img[171, 94], 15) == 0.284249084249084
+    assert round(img[701, 292], 15) == 0.289865689865690
+    assert round(img[1280, 94], 15) == 0.065201465201465
+    assert round(img[2364, 2640], 15) == 0.056166056166056
+    assert round(img[2733, 1549], 15) == 0.100366300366300
+    assert round(img[2739, 2585], 15) == 0.078388278388278
+    assert round(img[1032, 2230], 15) == 0.354578754578755
+    assert round(img[1480, 1758], 15) == 0.098656898656899
+
+    # Test extracted thumbnail against downloaded one
+    # assert np.array_equal(img._meta['thumbnail']['image'], thumb_gt)
+
+    # Test metadata and privateMetadata against ground truth data
+    # metadata_gt = {
+    #     "image": {
+    #         "width": 7728,
+    #         "orientation": 1,
+    #         "modulationExposureBias": 0.2689966559410095,
+    #         "pixelPacking": {
+    #             "bitsPerPixel": 10,
+    #             "endianness": "little"
+    #         },
+    #         "limitExposureBias": 0.0,
+    #         "height": 5368,
+    #         "pixelFormat": {
+    #             "white": {
+    #                 "gr": 1023,
+    #                 "r": 1023,
+    #                 "b": 1023,
+    #                 "gb": 1023
+    #             },
+    #             "black": {
+    #                 "gr": 64,
+    #                 "r": 64,
+    #                 "b": 64,
+    #                 "gb": 64
+    #             },
+    #             "rightShift": 0
+    #         },
+    #         "iso": 80,
+    #         "originOnSensor": {
+    #             "x": 0,
+    #             "y": 0
+    #         },
+    #         "mosaic": {
+    #             "tile": "r,gr:gb,b",
+    #             "upperLeftPixel": "gr"
+    #         },
+    #         "color": {
+    #             "whiteBalanceGain": {
+    #                 "gr": 1.0,
+    #                 "r": 1.378859281539917,
+    #                 "b": 1.1484659910202026,
+    #                 "gb": 1.0
+    #             },
+    #             "ccm": [
+    #                 2.2271547317504883,
+    #                 -1.055293321609497,
+    #                 -0.1718614399433136,
+    #                 -0.4269128441810608,
+    #                 1.7458617687225342,
+    #                 -0.3189488351345062,
+    #                 -0.20497213304042816,
+    #                 -0.7469924688339233,
+    #                 1.9519646167755127
+    #             ]
+    #         }
+    #     },
+    #     "generator": "lightning",
+    #     "schema": "http://schema.lytro.com/lfp/lytro_illum_public/"
+    #               + "1.3.5/lytro_illum_public_schema.json",
+    #     "camera": {
+    #         "make": "Lytro, Inc.",
+    #         "model": "ILLUM",
+    #         "firmware": "1.1.1 (23)"
+    #     },
+    #     "devices": {
+    #         "clock": {
+    #             "zuluTime": "2015-05-17T13:31:37.412Z",
+    #             "isTimeValid": True
+    #         },
+    #         "sensor": {
+    #             "pixelPitch": 1.4e-06,
+    #             "normalizedResponses": [
+    #                 {
+    #                     "b": 0.7344976663589478,
+    #                     "gb": 1.0,
+    #                     "cct": 5100,
+    #                     "gr": 1.0,
+    #                     "r": 0.7761663198471069
+    #                 }
+    #             ],
+    #             "perCcm": [
+    #                 {
+    #                     "ccm": [
+    #                         2.006272077560425,
+    #                         -0.5362802147865295,
+    #                         -0.46999192237854004,
+    #                         -0.6019303798675537,
+    #                         1.836044430732727,
+    #                         -0.23411400616168976,
+    #                         -0.8173090815544128,
+    #                         -1.6435128450393677,
+    #                         3.4608218669891357
+    #                     ],
+    #                     "cct": 2850.0
+    #                 },
+    #                 {
+    #                     "ccm": [
+    #                         2.4793264865875244,
+    #                         -1.2747985124588013,
+    #                         -0.20452789962291718,
+    #                         -0.5189455151557922,
+    #                         1.6118407249450684,
+    #                         -0.09289517253637314,
+    #                         -0.3602483570575714,
+    #                         -1.0115599632263184,
+    #                         2.3718082904815674
+    #                     ],
+    #                     "cct": 4150.0
+    #                 },
+    #                 {
+    #                     "ccm": [
+    #                         2.1902196407318115,
+    #                         -1.0231428146362305,
+    #                         -0.16707684099674225,
+    #                         -0.4134329855442047,
+    #                         1.7654914855957031,
+    #                         -0.3520585000514984,
+    #                         -0.18222910165786743,
+    #                         -0.7082417607307434,
+    #                         1.8904708623886108
+    #                     ],
+    #                     "cct": 6500.0
+    #                 }
+    #             ],
+    #             "pixelWidth": 7728,
+    #             "bitsPerPixel": 10,
+    #             "mosaic": {
+    #                 "tile": "r,gr:gb,b",
+    #                 "upperLeftPixel": "gr"
+    #             },
+    #             "pixelHeight": 5368,
+    #             "baseIso": 80,
+    #             "analogGain": {
+    #                 "gr": 1.0,
+    #                 "r": 1.0,
+    #                 "b": 1.0,
+    #                 "gb": 1.0
+    #             }
+    #         },
+    #         "shutter": {
+    #             "mechanism": "focalPlaneCurtain",
+    #             "frameExposureDuration": 0.000784054514952004,
+    #             "pixelExposureDuration": 0.000784054514952004,
+    #             "maxSyncSpeed": 0.004
+    #         },
+    #         "mla": {
+    #             "config": "com.lytro.mla.3",
+    #             "rotation": -0.0005426123971119523,
+    #             "tiling": "hexUniformRowMajor",
+    #             "scaleFactor": {
+    #                 "x": 1.0,
+    #                 "y": 1.0003429651260376
+    #             },
+    #             "lensPitch": 2e-05,
+    #             "sensorOffset": {
+    #                 "x": 8.421777725219726e-06,
+    #                 "y": -9.545820355415345e-07,
+    #                 "z": 3.7e-05
+    #             }
+    #         },
+    #         "lens": {
+    #             "fNumber": 2.199776378914589,
+    #             "exitPupilOffset": {
+    #                 "z": 0.09728562164306641
+    #             },
+    #             "zoomStep": -297,
+    #             "focusStep": 309,
+    #             "opticalCenterOffset": {
+    #                 "x": 1.48461913340725e-05,
+    #                 "y": 3.083264164160937e-05
+    #             },
+    #             "focalLength": 0.024199465511189833,
+    #             "infinityLambda": 33.89023289728373
+    #         },
+    #         "battery": {
+    #             "make": "Lytro",
+    #             "chargeLevel": 8,
+    #             "model": "B01-3760",
+    #             "cycleCount": 5
+    #         },
+    #         "accelerometer": {
+    #             "samples": [
+    #                 {
+    #                     "x": -0.3689117431640625,
+    #                     "y": 9.022918701171875,
+    #                     "time": 0.0,
+    #                     "z": -1.339324951171875
+    #                 }
+    #             ]
+    #         }
+    #     },
+    #     "settings": {
+    #         "exposure": {
+    #             "bracketCount": 3,
+    #             "compensation": 0.30000001192092896,
+    #             "mode": "program",
+    #             "meter": {
+    #                 "mode": "evaluative",
+    #                 "roiMode": "af",
+    #                 "roi": [
+    #                     {
+    #                         "top": 0.0,
+    #                         "left": 0.0,
+    #                         "bottom": 1.0,
+    #                         "right": 1.0
+    #                     }
+    #                 ]
+    #             },
+    #             "bracketEnable": False,
+    #             "bracketStep": 1.0,
+    #             "bracketOffset": 0.0,
+    #             "aeLock": False
+    #         },
+    #         "whiteBalance": {
+    #             "tint": -76.0,
+    #             "mode": "auto",
+    #             "cct": 6199
+    #         },
+    #         "shutter": {
+    #             "selfTimerEnable": False,
+    #             "selfTimerDuration": 2.0,
+    #             "driveMode": "single"
+    #         },
+    #         "focus": {
+    #             "afActuationMode": "single",
+    #             "mode": "auto",
+    #             "ringLock": False,
+    #             "bracketCount": 3,
+    #             "bracketEnable": False,
+    #             "afDriveMode": "single",
+    #             "bracketStep": 3.0,
+    #             "bracketOffset": 0.0,
+    #             "roi": [
+    #                 {
+    #                     "top": 0.0,
+    #                     "left": 0.0,
+    #                     "bottom": 1.0,
+    #                     "right": 1.0
+    #                 }
+    #             ],
+    #             "captureLambda": -4.0
+    #         },
+    #         "zoom": {
+    #             "ringLock": False
+    #         },
+    #         "flash": {
+    #             "mode": "unknown",
+    #             "exposureCompensation": 0.0,
+    #             "zoomMode": "auto",
+    #             "curtainTriggerSync": "front",
+    #             "afAssistMode": "auto"
+    #         },
+    #         "depth": {
+    #             "assist": "on",
+    #             "histogram": "on",
+    #             "overlay": "on"
+    #         }
+    #     },
+    #     "algorithms": {
+    #         "awb": {
+    #             "roi": "fullFrame",
+    #             "computed": {
+    #                 "cct": 6199,
+    #                 "gain": {
+    #                     "gr": 1.0,
+    #                     "r": 1.378859281539917,
+    #                     "b": 1.1484659910202026,
+    #                     "gb": 1.0
+    #                 }
+    #             }
+    #         },
+    #         "ae": {
+    #             "computed": {
+    #                 "ev": 1.0
+    #             },
+    #             "roi": "followAf",
+    #             "mode": "live"
+    #         },
+    #         "af": {
+    #             "computed": {
+    #                 "focusStep": 309
+    #             },
+    #             "roi": "focusRoi"
+    #         }
+    #     },
+    #     "picture": {
+    #         "totalFrames": 1,
+    #         "frameIndex": 0,
+    #         "dcfDirectory": "100PHOTO",
+    #         "dcfFile": "IMG_0813"
+    #     }
+    # }
+    # private_metadata_gt = {
+    #     "generator": "lightning",
+    #     "schema": "http://schema.lytro.com/lfp/lytro_illum_private/"
+    #               + "1.1.1/lytro_illum_private_schema.json",
+    #     "devices": {
+    #         "sensor": {
+    #             "serialNumber": "0C220593"
+    #         }
+    #     },
+    #     "camera": {
+    #         "serialNumber": "B5143909630"
+    #     }
+    # }
+
+    # assert img._meta['metadata'] == metadata_gt
+    # assert img._meta['privateMetadata'] == private_metadata_gt
+
+    # Test fail
+    test_reader = imageio.read(lfp_file, 'lytro-lfp')
+    raises(IndexError, test_reader.get_data, -1)
+    raises(IndexError, test_reader.get_data, 3)
+
+
+def test_lytro_raw_illum_reading():
     """ Test reading of lytro .raw file
     """
     # Get test images
     need_internet()
-    raw_file = get_remote_file(RAW_FILENAME)
-    raw_meta_file = get_remote_file(RAW_META_FILENAME)
+    raw_file = get_remote_file(RAW_ILLUM_FILENAME)
+    raw_meta_file = get_remote_file(RAW_ILLUM_META_FILENAME)
 
     # Read image and metadata file
-    img = imageio.imread(raw_file, format='lytro-raw')
+    img = imageio.imread(raw_file, format='lytro-illum-raw')
     meta_gt = json.load(open(raw_meta_file))
 
     # Test image shape and some pixel values
@@ -450,7 +875,41 @@ def test_lytro_raw_reading():
     assert img._meta == meta_gt
 
     # Test fail
-    test_reader = imageio.read(raw_file, 'lytro-raw')
+    test_reader = imageio.read(raw_file, 'lytro-illum-raw')
+    raises(IndexError, test_reader.get_data, -1)
+    raises(IndexError, test_reader.get_data, 3)
+
+
+def test_lytro_raw_f0_reading():
+    """ Test reading of lytro .raw file
+    """
+    # Get test images
+    need_internet()
+    raw_file = get_remote_file(RAW_F0_FILENAME)
+    raw_meta_file = get_remote_file(RAW_F0_META_FILENAME)
+
+    # Read image and metadata file
+    img = imageio.imread(raw_file, format='lytro-f01-raw')
+    meta_gt = json.load(open(raw_meta_file))
+
+    # Test image shape and some pixel values
+    # Pixel values are extracted from the Matlab reference implementation
+    assert img.shape == (3280, 3280)
+    assert round(img[16, 7], 15) == 0.044688644688645
+    assert round(img[803, 74], 15) == 0.064713064713065
+    assert round(img[599, 321], 15) == 0.059340659340659
+    assert round(img[1630, 665], 15) == 0.198046398046398
+    assert round(img[940, 2030], 15) == 0.130647130647131
+    assert round(img[3164, 2031], 15) == 0.129914529914530
+    assert round(img[3235, 3250], 15) == 0.136019536019536
+    assert round(img[2954, 889], 15) == 0.159706959706960
+    assert round(img[1546, 1243], 15) == 0.227350427350427
+
+    # Test extracted metadata against extracted metadata from .txt file
+    assert img._meta == meta_gt
+
+    # Test fail
+    test_reader = imageio.read(raw_file, 'lytro-f01-raw')
     raises(IndexError, test_reader.get_data, -1)
     raises(IndexError, test_reader.get_data, 3)
 

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -20,6 +20,7 @@ RAW_F0_FILENAME = 'images/IMG_0001__frame.raw'
 RAW_F0_META_FILENAME = 'images/IMG_0001__frame.json'
 PNG_FILENAME = 'images/chelsea.png'
 
+
 def test_lytro_lfr_format():
     """
     Test basic read/write properties of LytroLfrFormat
@@ -29,7 +30,7 @@ def test_lytro_lfr_format():
     lfr_file = get_remote_file(LFR_FILENAME)
     raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
     lfp_file = get_remote_file(LFP_FILENAME)
-    raw_f01_file= get_remote_file(RAW_F0_FILENAME)
+    raw_f01_file = get_remote_file(RAW_F0_FILENAME)
     png_file = get_remote_file(PNG_FILENAME)
 
     # Test lytro lfr format
@@ -65,7 +66,7 @@ def test_lytro_illum_raw_format():
     lfr_file = get_remote_file(LFR_FILENAME)
     raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
     lfp_file = get_remote_file(LFP_FILENAME)
-    raw_f01_file= get_remote_file(RAW_F0_FILENAME)
+    raw_f01_file = get_remote_file(RAW_F0_FILENAME)
     png_file = get_remote_file(PNG_FILENAME)
 
     # Test lytro raw format
@@ -100,7 +101,7 @@ def test_lytro_f01_raw_format():
     lfr_file = get_remote_file(LFR_FILENAME)
     raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
     lfp_file = get_remote_file(LFP_FILENAME)
-    raw_f01_file= get_remote_file(RAW_F0_FILENAME)
+    raw_f01_file = get_remote_file(RAW_F0_FILENAME)
     png_file = get_remote_file(PNG_FILENAME)
 
     # Test lytro raw format
@@ -135,7 +136,7 @@ def test_lytro_lfp_format():
     lfr_file = get_remote_file(LFR_FILENAME)
     raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
     lfp_file = get_remote_file(LFP_FILENAME)
-    raw_f01_file= get_remote_file(RAW_F0_FILENAME)
+    raw_f01_file = get_remote_file(RAW_F0_FILENAME)
     png_file = get_remote_file(PNG_FILENAME)
 
     # Test lytro raw format
@@ -514,7 +515,6 @@ def test_lytro_lfp_reading():
 
     # Read image and thumbnail
     img = imageio.imread(lfp_file, format='lytro-lfp')
-    thumb_gt = imageio.imread(lfp_file)
 
     # Test image shape and some pixel values
     # Pixel values are extracted from the Matlab reference implementation
@@ -528,317 +528,177 @@ def test_lytro_lfp_reading():
     assert round(img[1032, 2230], 15) == 0.354578754578755
     assert round(img[1480, 1758], 15) == 0.098656898656899
 
-    # Test extracted thumbnail against downloaded one
-    # assert np.array_equal(img._meta['thumbnail']['image'], thumb_gt)
-
     # Test metadata and privateMetadata against ground truth data
-    # metadata_gt = {
-    #     "image": {
-    #         "width": 7728,
-    #         "orientation": 1,
-    #         "modulationExposureBias": 0.2689966559410095,
-    #         "pixelPacking": {
-    #             "bitsPerPixel": 10,
-    #             "endianness": "little"
-    #         },
-    #         "limitExposureBias": 0.0,
-    #         "height": 5368,
-    #         "pixelFormat": {
-    #             "white": {
-    #                 "gr": 1023,
-    #                 "r": 1023,
-    #                 "b": 1023,
-    #                 "gb": 1023
-    #             },
-    #             "black": {
-    #                 "gr": 64,
-    #                 "r": 64,
-    #                 "b": 64,
-    #                 "gb": 64
-    #             },
-    #             "rightShift": 0
-    #         },
-    #         "iso": 80,
-    #         "originOnSensor": {
-    #             "x": 0,
-    #             "y": 0
-    #         },
-    #         "mosaic": {
-    #             "tile": "r,gr:gb,b",
-    #             "upperLeftPixel": "gr"
-    #         },
-    #         "color": {
-    #             "whiteBalanceGain": {
-    #                 "gr": 1.0,
-    #                 "r": 1.378859281539917,
-    #                 "b": 1.1484659910202026,
-    #                 "gb": 1.0
-    #             },
-    #             "ccm": [
-    #                 2.2271547317504883,
-    #                 -1.055293321609497,
-    #                 -0.1718614399433136,
-    #                 -0.4269128441810608,
-    #                 1.7458617687225342,
-    #                 -0.3189488351345062,
-    #                 -0.20497213304042816,
-    #                 -0.7469924688339233,
-    #                 1.9519646167755127
-    #             ]
-    #         }
-    #     },
-    #     "generator": "lightning",
-    #     "schema": "http://schema.lytro.com/lfp/lytro_illum_public/"
-    #               + "1.3.5/lytro_illum_public_schema.json",
-    #     "camera": {
-    #         "make": "Lytro, Inc.",
-    #         "model": "ILLUM",
-    #         "firmware": "1.1.1 (23)"
-    #     },
-    #     "devices": {
-    #         "clock": {
-    #             "zuluTime": "2015-05-17T13:31:37.412Z",
-    #             "isTimeValid": True
-    #         },
-    #         "sensor": {
-    #             "pixelPitch": 1.4e-06,
-    #             "normalizedResponses": [
-    #                 {
-    #                     "b": 0.7344976663589478,
-    #                     "gb": 1.0,
-    #                     "cct": 5100,
-    #                     "gr": 1.0,
-    #                     "r": 0.7761663198471069
-    #                 }
-    #             ],
-    #             "perCcm": [
-    #                 {
-    #                     "ccm": [
-    #                         2.006272077560425,
-    #                         -0.5362802147865295,
-    #                         -0.46999192237854004,
-    #                         -0.6019303798675537,
-    #                         1.836044430732727,
-    #                         -0.23411400616168976,
-    #                         -0.8173090815544128,
-    #                         -1.6435128450393677,
-    #                         3.4608218669891357
-    #                     ],
-    #                     "cct": 2850.0
-    #                 },
-    #                 {
-    #                     "ccm": [
-    #                         2.4793264865875244,
-    #                         -1.2747985124588013,
-    #                         -0.20452789962291718,
-    #                         -0.5189455151557922,
-    #                         1.6118407249450684,
-    #                         -0.09289517253637314,
-    #                         -0.3602483570575714,
-    #                         -1.0115599632263184,
-    #                         2.3718082904815674
-    #                     ],
-    #                     "cct": 4150.0
-    #                 },
-    #                 {
-    #                     "ccm": [
-    #                         2.1902196407318115,
-    #                         -1.0231428146362305,
-    #                         -0.16707684099674225,
-    #                         -0.4134329855442047,
-    #                         1.7654914855957031,
-    #                         -0.3520585000514984,
-    #                         -0.18222910165786743,
-    #                         -0.7082417607307434,
-    #                         1.8904708623886108
-    #                     ],
-    #                     "cct": 6500.0
-    #                 }
-    #             ],
-    #             "pixelWidth": 7728,
-    #             "bitsPerPixel": 10,
-    #             "mosaic": {
-    #                 "tile": "r,gr:gb,b",
-    #                 "upperLeftPixel": "gr"
-    #             },
-    #             "pixelHeight": 5368,
-    #             "baseIso": 80,
-    #             "analogGain": {
-    #                 "gr": 1.0,
-    #                 "r": 1.0,
-    #                 "b": 1.0,
-    #                 "gb": 1.0
-    #             }
-    #         },
-    #         "shutter": {
-    #             "mechanism": "focalPlaneCurtain",
-    #             "frameExposureDuration": 0.000784054514952004,
-    #             "pixelExposureDuration": 0.000784054514952004,
-    #             "maxSyncSpeed": 0.004
-    #         },
-    #         "mla": {
-    #             "config": "com.lytro.mla.3",
-    #             "rotation": -0.0005426123971119523,
-    #             "tiling": "hexUniformRowMajor",
-    #             "scaleFactor": {
-    #                 "x": 1.0,
-    #                 "y": 1.0003429651260376
-    #             },
-    #             "lensPitch": 2e-05,
-    #             "sensorOffset": {
-    #                 "x": 8.421777725219726e-06,
-    #                 "y": -9.545820355415345e-07,
-    #                 "z": 3.7e-05
-    #             }
-    #         },
-    #         "lens": {
-    #             "fNumber": 2.199776378914589,
-    #             "exitPupilOffset": {
-    #                 "z": 0.09728562164306641
-    #             },
-    #             "zoomStep": -297,
-    #             "focusStep": 309,
-    #             "opticalCenterOffset": {
-    #                 "x": 1.48461913340725e-05,
-    #                 "y": 3.083264164160937e-05
-    #             },
-    #             "focalLength": 0.024199465511189833,
-    #             "infinityLambda": 33.89023289728373
-    #         },
-    #         "battery": {
-    #             "make": "Lytro",
-    #             "chargeLevel": 8,
-    #             "model": "B01-3760",
-    #             "cycleCount": 5
-    #         },
-    #         "accelerometer": {
-    #             "samples": [
-    #                 {
-    #                     "x": -0.3689117431640625,
-    #                     "y": 9.022918701171875,
-    #                     "time": 0.0,
-    #                     "z": -1.339324951171875
-    #                 }
-    #             ]
-    #         }
-    #     },
-    #     "settings": {
-    #         "exposure": {
-    #             "bracketCount": 3,
-    #             "compensation": 0.30000001192092896,
-    #             "mode": "program",
-    #             "meter": {
-    #                 "mode": "evaluative",
-    #                 "roiMode": "af",
-    #                 "roi": [
-    #                     {
-    #                         "top": 0.0,
-    #                         "left": 0.0,
-    #                         "bottom": 1.0,
-    #                         "right": 1.0
-    #                     }
-    #                 ]
-    #             },
-    #             "bracketEnable": False,
-    #             "bracketStep": 1.0,
-    #             "bracketOffset": 0.0,
-    #             "aeLock": False
-    #         },
-    #         "whiteBalance": {
-    #             "tint": -76.0,
-    #             "mode": "auto",
-    #             "cct": 6199
-    #         },
-    #         "shutter": {
-    #             "selfTimerEnable": False,
-    #             "selfTimerDuration": 2.0,
-    #             "driveMode": "single"
-    #         },
-    #         "focus": {
-    #             "afActuationMode": "single",
-    #             "mode": "auto",
-    #             "ringLock": False,
-    #             "bracketCount": 3,
-    #             "bracketEnable": False,
-    #             "afDriveMode": "single",
-    #             "bracketStep": 3.0,
-    #             "bracketOffset": 0.0,
-    #             "roi": [
-    #                 {
-    #                     "top": 0.0,
-    #                     "left": 0.0,
-    #                     "bottom": 1.0,
-    #                     "right": 1.0
-    #                 }
-    #             ],
-    #             "captureLambda": -4.0
-    #         },
-    #         "zoom": {
-    #             "ringLock": False
-    #         },
-    #         "flash": {
-    #             "mode": "unknown",
-    #             "exposureCompensation": 0.0,
-    #             "zoomMode": "auto",
-    #             "curtainTriggerSync": "front",
-    #             "afAssistMode": "auto"
-    #         },
-    #         "depth": {
-    #             "assist": "on",
-    #             "histogram": "on",
-    #             "overlay": "on"
-    #         }
-    #     },
-    #     "algorithms": {
-    #         "awb": {
-    #             "roi": "fullFrame",
-    #             "computed": {
-    #                 "cct": 6199,
-    #                 "gain": {
-    #                     "gr": 1.0,
-    #                     "r": 1.378859281539917,
-    #                     "b": 1.1484659910202026,
-    #                     "gb": 1.0
-    #                 }
-    #             }
-    #         },
-    #         "ae": {
-    #             "computed": {
-    #                 "ev": 1.0
-    #             },
-    #             "roi": "followAf",
-    #             "mode": "live"
-    #         },
-    #         "af": {
-    #             "computed": {
-    #                 "focusStep": 309
-    #             },
-    #             "roi": "focusRoi"
-    #         }
-    #     },
-    #     "picture": {
-    #         "totalFrames": 1,
-    #         "frameIndex": 0,
-    #         "dcfDirectory": "100PHOTO",
-    #         "dcfFile": "IMG_0813"
-    #     }
-    # }
-    # private_metadata_gt = {
-    #     "generator": "lightning",
-    #     "schema": "http://schema.lytro.com/lfp/lytro_illum_private/"
-    #               + "1.1.1/lytro_illum_private_schema.json",
-    #     "devices": {
-    #         "sensor": {
-    #             "serialNumber": "0C220593"
-    #         }
-    #     },
-    #     "camera": {
-    #         "serialNumber": "B5143909630"
-    #     }
-    # }
+    metadata_gt = {
+        "type": "lightField",
+        "image": {
+            "width": 3280,
+            "height": 3280,
+            "orientation": 1,
+            "representation": "rawPacked",
+            "rawDetails": {
+                "pixelFormat": {
+                    "rightShift": 0,
+                    "black": {
+                        "r": 168,
+                        "gr": 168,
+                        "gb": 168,
+                        "b": 168
+                    },
+                    "white": {
+                        "r": 4095,
+                        "gr": 4095,
+                        "gb": 4095,
+                        "b": 4095
+                    }
+                },
+                "pixelPacking": {
+                    "endianness": "big",
+                    "bitsPerPixel": 12
+                },
+                "mosaic": {
+                    "tile": "r,gr:gb,b",
+                    "upperLeftPixel": "b"
+                }
+            },
+            "color": {
+                "ccmRgbToSrgbArray": [
+                    3.1115827560424805,
+                    -1.9393929243087769,
+                    -0.172189861536026,
+                    -0.3629055917263031,
+                    1.6408803462982178,
+                    -0.27797481417655945,
+                    0.07896701246500015,
+                    -1.1558042764663696,
+                    2.0768373012542725
+                ],
+                "gamma": 0.41666001081466675,
+                "applied": {},
+                "whiteBalanceGain": {
+                    "r": 1,
+                    "gr": 1,
+                    "gb": 1,
+                    "b": 1.2578125
+                }
+            },
+            "modulationExposureBias": -1.1139298677444458,
+            "limitExposureBias": 0
+        },
+        "devices": {
+            "clock": {
+                "zuluTime": "2014-05-16T13:31:21.000Z"
+            },
+            "sensor": {
+                "bitsPerPixel": 12,
+                "mosaic": {
+                    "tile": "r,gr:gb,b",
+                    "upperLeftPixel": "b"
+                },
+                "iso": 207,
+                "analogGain": {
+                    "r": 5.625,
+                    "gr": 4.125,
+                    "gb": 4.125,
+                    "b": 4.75
+                },
+                "pixelPitch": 1.3999999761581417e-06
+            },
+            "lens": {
+                "infinityLambda": 18.033008575439453,
+                "focalLength": 0.006840000152587891,
+                "zoomStep": 943,
+                "focusStep": 672,
+                "fNumber": 1.9199999570846558,
+                "temperature": 23.642822265625,
+                "temperatureAdc": 2896,
+                "zoomStepperOffset": -2,
+                "focusStepperOffset": 25,
+                "exitPupilOffset": {
+                    "z": 0.22357696533203125
+                }
+            },
+            "ndfilter": {
+                "exposureBias": 0
+            },
+            "shutter": {
+                "mechanism": "sensorOpenApertureClose",
+                "frameExposureDuration": 0.016554275527596474,
+                "pixelExposureDuration": 0.016554275527596474
+            },
+            "soc": {
+                "temperature": 27.0545654296875,
+                "temperatureAdc": 3319
+            },
+            "accelerometer": {
+                "sampleArray": [
+                    {
+                        "x": -0.019607843831181526,
+                        "y": 1.015686273574829,
+                        "z": 0.03529411926865578,
+                        "time": 0
+                    }
+                ]
+            },
+            "mla": {
+                "tiling": "hexUniformRowMajor",
+                "lensPitch": 1.3999999999999998e-05,
+                "rotation": -0.0008588103810325265,
+                "defectArray": [],
+                "config": "com.lytro.mla.11",
+                "scaleFactor": {
+                    "x": 1,
+                    "y": 1.0003734827041626
+                },
+                "sensorOffset": {
+                    "x": -8.177771568298344e-06,
+                    "y": 8.002278804779054e-07,
+                    "z": 2.5e-05
+                }
+            }
+        },
+        "modes": {
+            "creative": "tap",
+            "regionOfInterestArray": [
+                {
+                    "type": "exposure",
+                    "x": 0.5125047564506531,
+                    "y": 0.723964273929596
+                },
+                {
+                    "type": "creative",
+                    "x": 0.5125047564506531,
+                    "y": 0.723964273929596
+                }
+            ],
+            "manualControls": False,
+            "exposureDurationMode": "auto",
+            "isoMode": "auto",
+            "ndFilterMode": "auto",
+            "exposureLock": False,
+            "overscan": 1.0526316165924072
+        },
+        "camera": {
+            "make": "Lytro, Inc.",
+            "model": "F01",
+            "firmware": "v1.0a208, vv1.2.2, Wed Sep  4 14:43:36 PDT 2013, "
+                        "fec5f2a239a2823b391a385b94ec6fc8c56bb5b1, "
+                        "mods=0, ofw=0"
+        }
+    }
+    private_metadata_gt = {
+        "devices": {
+            "sensor": {
+                "sensorSerial": "0x408F1FB8B3515D9A"
+            }
+        },
+        "camera": {
+            "serialNumber": "A303134643"
+        }
+    }
 
-    # assert img._meta['metadata'] == metadata_gt
-    # assert img._meta['privateMetadata'] == private_metadata_gt
+    assert img._meta['metadata'] == metadata_gt
+    assert img._meta['privateMetadata'] == private_metadata_gt
 
     # Test fail
     test_reader = imageio.read(lfp_file, 'lytro-lfp')


### PR DESCRIPTION
# Description

This PR adds a plugin to read Lytro ``.lfp`` and ``.raw`` files as provided by the original [Lytro F01](https://en.wikipedia.org/wiki/Lytro#Original_Lytro_Light_Field_Camera) light field camera.

The ``.lfp`` format is a container format containing raw 12bit image data and metadata.
The ``.raw`` format is a 12bit raw image format.

This extends the Lytro plugin (see PR #301 )

# Type of change

- [x] Add Lytro lfp and raw plugin to existing Lytro Formats
- [x] Rename previous Lytro lfr and raw Formats of the Illum camera

# Testing
Tests are ready.

# Checklist:

- [x] Code follows PEP guidellines
- [x] Add unit test