### PR TITLE
proper FileNotFoundError, pathlib support

### DIFF
--- a/imageio/core/functions.py
+++ b/imageio/core/functions.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2015, imageio contributors
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" 
+"""
 These functions represent imageio's main interface for the user. They
 provide a common API to read and write image data for a large
 variety of formats. All read and write functions accept keyword
@@ -71,10 +71,10 @@ from .. import formats
 
 def help(name=None):
     """ help(name=None)
-    
+
     Print the documentation of the format specified by name, or a list
-    of supported formats if name is omitted. 
-    
+    of supported formats if name is omitted.
+
     Parameters
     ----------
     name : str
@@ -92,14 +92,15 @@ def help(name=None):
 
 def get_reader(uri, format=None, mode='?', **kwargs):
     """ get_reader(uri, format=None, mode='?', **kwargs)
-    
+
     Returns a :class:`.Reader` object which can be used to read data
     and meta data from the specified file.
-    
+
     Parameters
     ----------
-    uri : {str, bytes, file}
-        The resource to load the image from, e.g. a filename, http address or
+    uri : {str, pathlib.Path, bytes, file}
+        The resource to load the image from, e.g. a filename, pathlib.Path,
+        http address or
         file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
@@ -111,11 +112,11 @@ def get_reader(uri, format=None, mode='?', **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the reader. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     # Create request object
     request = Request(uri, 'r' + mode, **kwargs)
-    
+
     # Get format
     if format is not None:
         format = formats[format]
@@ -124,21 +125,22 @@ def get_reader(uri, format=None, mode='?', **kwargs):
     if format is None:
         raise ValueError('Could not find a format to read the specified file '
                          'in mode %r' % mode)
-    
+
     # Return its reader object
     return format.get_reader(request)
 
 
 def get_writer(uri, format=None, mode='?', **kwargs):
     """ get_writer(uri, format=None, mode='?', **kwargs)
-    
+
     Returns a :class:`.Writer` object which can be used to write data
     and meta data to the specified file.
-    
+
     Parameters
     ----------
-    uri : {str, file}
-        The resource to write the image to, e.g. a filename or file object,
+    uri : {str, pathlib.Path, file}
+        The resource to write the image to, e.g. a filename, pathlib.Path
+        or file object,
         see the docs for more info.
     format : str
         The format to use to write the file. By default imageio selects
@@ -150,15 +152,15 @@ def get_writer(uri, format=None, mode='?', **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the writer. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     # Signal extension when returning as bytes, needed by e.g. ffmpeg
     if uri == RETURN_BYTES and isinstance(format, str):
         uri = RETURN_BYTES + '.' + format.strip('. ')
-    
+
     # Create request object
     request = Request(uri, 'w' + mode, **kwargs)
-    
+
     # Get format
     if format is not None:
         format = formats[format]
@@ -167,7 +169,7 @@ def get_writer(uri, format=None, mode='?', **kwargs):
     if format is None:
         raise ValueError('Could not find a format to write the specified file '
                          'in mode %r' % mode)
-    
+
     # Return its writer object
     return format.get_writer(request)
 
@@ -176,17 +178,18 @@ def get_writer(uri, format=None, mode='?', **kwargs):
 
 def imread(uri, format=None, **kwargs):
     """ imread(uri, format=None, **kwargs)
-    
+
     Reads an image from the specified file. Returns a numpy array, which
     comes with a dict of meta data at its 'meta' attribute.
-    
+
     Note that the image data is returned as-is, and may not always have
     a dtype of uint8 (and thus may differ from what e.g. PIL returns).
-    
+
     Parameters
     ----------
-    uri : {str, bytes, file}
-        The resource to load the image from, e.g. a filename, http address or
+    uri : {str, pathlib.Path, bytes, file}
+        The resource to load the image from, e.g. a filename, pathlib.Path,
+        http address or
         file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
@@ -194,8 +197,8 @@ def imread(uri, format=None, **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the reader. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     # Get reader and read first
     reader = read(uri, format, 'i', **kwargs)
     with reader:
@@ -204,13 +207,14 @@ def imread(uri, format=None, **kwargs):
 
 def imwrite(uri, im, format=None, **kwargs):
     """ imwrite(uri, im, format=None, **kwargs)
-    
+
     Write an image to the specified file.
-    
+
     Parameters
     ----------
-    uri : {str, file}
-        The resource to write the image to, e.g. a filename or file object,
+    uri : {str, pathlib.Path, file}
+        The resource to write the image to, e.g. a filename, pathlib.Path
+        or file object,
         see the docs for more info.
     im : numpy.ndarray
         The image data. Must be NxM, NxMx3 or NxMx4.
@@ -220,8 +224,8 @@ def imwrite(uri, im, format=None, **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the writer. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     # Test image
     if isinstance(im, np.ndarray):
         if im.ndim == 2:
@@ -232,12 +236,12 @@ def imwrite(uri, im, format=None, **kwargs):
             raise ValueError('Image must be 2D (grayscale, RGB, or RGBA).')
     else:
         raise ValueError('Image must be a numpy array.')
-    
+
     # Get writer and write first
     writer = get_writer(uri, format, 'i', **kwargs)
     with writer:
         writer.append_data(im)
-    
+
     # Return a result if there is any
     return writer.request.get_result()
 
@@ -246,14 +250,15 @@ def imwrite(uri, im, format=None, **kwargs):
 
 def mimread(uri, format=None, memtest=True, **kwargs):
     """ mimread(uri, format=None, memtest=True, **kwargs)
-    
+
     Reads multiple images from the specified file. Returns a list of
     numpy arrays, each with a dict of meta data at its 'meta' attribute.
-    
+
     Parameters
     ----------
-    uri : {str, bytes, file}
-        The resource to load the images from, e.g. a filename, http address or
+    uri : {str, pathlib.Path, bytes, file}
+        The resource to load the images from, e.g. a filename,pathlib.Path,
+        http address or
         file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
@@ -267,11 +272,11 @@ def mimread(uri, format=None, memtest=True, **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the reader. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     # Get reader
     reader = read(uri, format, 'I', **kwargs)
-    
+
     # Read
     ims = []
     nbytes = 0
@@ -284,19 +289,20 @@ def mimread(uri, format=None, memtest=True, **kwargs):
             raise RuntimeError('imageio.mimread() has read over 256 MiB of '
                                'image data.\nStopped to avoid memory problems.'
                                ' Use imageio.get_reader() or memtest=False.')
-    
+
     return ims
 
 
 def mimwrite(uri, ims, format=None, **kwargs):
     """ mimwrite(uri, ims, format=None, **kwargs)
-    
+
     Write multiple images to the specified file.
-    
+
     Parameters
     ----------
-    uri : {str, file}
-        The resource to write the images to, e.g. a filename or file object,
+    uri : {str, pathlib.Path, file}
+        The resource to write the images to, e.g. a filename, pathlib.Path
+        or file object,
         see the docs for more info.
     ims : sequence of numpy arrays
         The image data. Each array must be NxM, NxMx3 or NxMx4.
@@ -306,19 +312,19 @@ def mimwrite(uri, ims, format=None, **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the writer. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     #Ensure non empty sequence
     if len(ims) == 0:
         raise ValueError('Numpy sequence must not be empty.')
-    
+
     # Get writer
     writer = get_writer(uri, format, 'I', **kwargs)
     with writer:
-        
+
         # Iterate over images (ims may be a generator)
         for im in ims:
-            
+
             # Test image
             if isinstance(im, np.ndarray):
                 if im.ndim == 2:
@@ -330,10 +336,10 @@ def mimwrite(uri, ims, format=None, **kwargs):
                                      '(grayscale, RGB, or RGBA).')
             else:
                 raise ValueError('Image must be a numpy array.')
-            
+
             # Add image
             writer.append_data(im)
-    
+
     # Return a result if there is any
     return writer.request.get_result()
 
@@ -342,14 +348,15 @@ def mimwrite(uri, ims, format=None, **kwargs):
 
 def volread(uri, format=None, **kwargs):
     """ volread(uri, format=None, **kwargs)
-    
+
     Reads a volume from the specified file. Returns a numpy array, which
     comes with a dict of meta data at its 'meta' attribute.
-    
+
     Parameters
     ----------
-    uri : {str, bytes, file}
-        The resource to load the volume from, e.g. a filename, http address or
+    uri : {str, pathlib.Path, bytes, file}
+        The resource to load the volume from, e.g. a filename, pathlib.Path,
+        http address or
         file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
@@ -357,8 +364,8 @@ def volread(uri, format=None, **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the reader. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     # Get reader and read first
     reader = read(uri, format, 'v', **kwargs)
     with reader:
@@ -367,13 +374,14 @@ def volread(uri, format=None, **kwargs):
 
 def volwrite(uri, im, format=None, **kwargs):
     """ volwrite(uri, vol, format=None, **kwargs)
-    
+
     Write a volume to the specified file.
-    
+
     Parameters
     ----------
-    uri : {str, file}
-        The resource to write the image to, e.g. a filename or file object,
+    uri : {str, pathlib.Path, file}
+        The resource to write the image to, e.g. a filename, pathlib.Path
+        or file object,
         see the docs for more info.
     vol : numpy.ndarray
         The image data. Must be NxMxL (or NxMxLxK if each voxel is a tuple).
@@ -383,8 +391,8 @@ def volwrite(uri, im, format=None, **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the writer. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     # Test image
     if isinstance(im, np.ndarray):
         if im.ndim == 3:
@@ -396,12 +404,12 @@ def volwrite(uri, im, format=None, **kwargs):
                              'a tuple.')
     else:
         raise ValueError('Image must be a numpy array.')
-    
+
     # Get writer and write first
     writer = get_writer(uri, format, 'v', **kwargs)
     with writer:
         writer.append_data(im)
-    
+
     # Return a result if there is any
     return writer.request.get_result()
 
@@ -410,14 +418,15 @@ def volwrite(uri, im, format=None, **kwargs):
 
 def mvolread(uri, format=None, memtest=True, **kwargs):
     """ mvolread(uri, format=None, memtest=True, **kwargs)
-    
+
     Reads multiple volumes from the specified file. Returns a list of
     numpy arrays, each with a dict of meta data at its 'meta' attribute.
-    
+
     Parameters
     ----------
-    uri : {str, bytes, file}
-        The resource to load the volumes from, e.g. a filename, http address or
+    uri : {str, pathlib.Path, bytes, file}
+        The resource to load the volumes from, e.g. a filename, pathlib.Path,
+        http address or
         file object, see the docs for more info.
     format : str
         The format to use to read the file. By default imageio selects
@@ -431,11 +440,11 @@ def mvolread(uri, format=None, memtest=True, **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the reader. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     # Get reader and read all
     reader = read(uri, format, 'V', **kwargs)
-    
+
     ims = []
     nbytes = 0
     for im in reader:
@@ -447,19 +456,20 @@ def mvolread(uri, format=None, memtest=True, **kwargs):
             raise RuntimeError('imageio.mvolread() has read over 1 GiB of '
                                'image data.\nStopped to avoid memory problems.'
                                ' Use imageio.get_reader() or memtest=False.')
-    
+
     return ims
 
 
 def mvolwrite(uri, ims, format=None, **kwargs):
     """ mvolwrite(uri, vols, format=None, **kwargs)
-    
+
     Write multiple volumes to the specified file.
-    
+
     Parameters
     ----------
-    uri : {str, file}
-        The resource to write the volumes to, e.g. a filename or file object,
+    uri : {str, pathlib.Path, file}
+        The resource to write the volumes to, e.g. a filename, pathlib.Path
+        or file object,
         see the docs for more info.
     ims : sequence of numpy arrays
         The image data. Each array must be NxMxL (or NxMxLxK if each
@@ -470,15 +480,15 @@ def mvolwrite(uri, ims, format=None, **kwargs):
     kwargs : ...
         Further keyword arguments are passed to the writer. See :func:`.help`
         to see what arguments are available for a particular format.
-    """ 
-    
+    """
+
     # Get writer
     writer = get_writer(uri, format, 'V', **kwargs)
     with writer:
-        
+
         # Iterate over images (ims may be a generator)
         for im in ims:
-            
+
             # Test image
             if isinstance(im, np.ndarray):
                 if im.ndim == 3:
@@ -490,10 +500,10 @@ def mvolwrite(uri, ims, format=None, **kwargs):
                                      'a tuple.')
             else:
                 raise ValueError('Image must be a numpy array.')
-            
+
             # Add image
             writer.append_data(im)
-    
+
     # Return a result if there is any
     return writer.request.get_result()
 

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -189,7 +189,7 @@ class Request(object):
             self._uri_type = URI_BYTES
             self._filename = '<bytes>'
             self._bytes = uri
-        elif Path is not None:
+        elif Path is not None and isinstance(uri, Path):
             self._uri_type = URI_FILENAME
             self._filename = str(uri)
         # Files

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -20,6 +20,11 @@ from ..core import string_types, binary_type, urlopen, get_remote_file
 
 if sys.version_info < (3,):
     FileNotFoundError = OSError
+try:
+    from pathlib import Path
+except ImportError:
+    Path = None
+
 # URI types
 URI_BYTES = 1
 URI_FILE = 2
@@ -184,6 +189,9 @@ class Request(object):
             self._uri_type = URI_BYTES
             self._filename = '<bytes>'
             self._bytes = uri
+        elif Path is not None:
+            self._uri_type = URI_FILENAME
+            self._filename = str(uri)
         # Files
         elif is_read_request:
             if hasattr(uri, 'read') and hasattr(uri, 'close'):

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2015, imageio contributors
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" 
+"""
 Definition of the Request object, which acts as a kind of bridge between
 what the user wants and what the plugins can.
 """
@@ -18,6 +18,8 @@ import shutil
 
 from ..core import string_types, binary_type, urlopen, get_remote_file
 
+if sys.version_info < (3,):
+    FileNotFoundError = OSError
 # URI types
 URI_BYTES = 1
 URI_FILE = 2
@@ -38,10 +40,10 @@ EXAMPLE_IMAGES = {
     'checkerboard.png': 'Black and white image of a chekerboard',
     'clock.png': 'Photo of a clock with motion blur (Stefan van der Walt)',
     'coffee.png': 'Image of a cup of coffee (Rachel Michetti)',
-    
+
     'chelsea.png': 'Image of Stefan\'s cat',
     'wikkie.png': 'Image of Almar\'s cat',
-    
+
     'coins.png': 'Image showing greek coins from Pompeii',
     'horse.png': 'Image showing the silhouette of a horse (Andreas Preuss)',
     'hubble_deep_field.png': 'Photograph taken by Hubble telescope (NASA)',
@@ -49,7 +51,7 @@ EXAMPLE_IMAGES = {
     'moon.png': 'Image showing a portion of the surface of the moon',
     'page.png': 'A scanned page of text',
     'text.png': 'A photograph of handdrawn text',
-    
+
     'chelsea.zip': 'The chelsea.png in a zipfile (for testing)',
     'newtonscradle.gif': 'Animated GIF of a newton\'s cradle',
     'cockatoo.mp4': 'Video file of a cockatoo',
@@ -59,14 +61,14 @@ EXAMPLE_IMAGES = {
 
 class Request(object):
     """ Request(uri, mode, **kwargs)
-    
+
     Represents a request for reading or saving an image resource. This
     object wraps information to that request and acts as an interface
     for the plugins to several resources; it allows the user to read
     from filenames, files, http, zipfiles, raw bytes, etc., but offer
     a simple interface to the plugins via ``get_file()`` and
     ``get_local_filename()``.
-    
+
     For each read/write operation a single Request instance is used and passed
     to the can_read/can_write method of a format, and subsequently to
     the Reader/Writer class. This allows rudimentary passing of
@@ -83,28 +85,28 @@ class Request(object):
         "i" for an image, "I" for multiple images, "v" for a volume,
         "V" for multiple volumes, "?" for don't care.
     """
-    
+
     def __init__(self, uri, mode, **kwargs):
-        
-        # General        
+
+        # General
         self._uri_type = None
         self._filename = None
         self._kwargs = kwargs
         self._result = None         # Some write actions may have a result
-        
+
         # To handle the user-side
         self._filename_zip = None   # not None if a zipfile is used
         self._bytes = None          # Incoming bytes
         self._zipfile = None        # To store a zipfile instance (if used)
-        
+
         # To handle the plugin side
         self._file = None               # To store the file instance
         self._filename_local = None     # not None if using tempfile on this FS
         self._firstbytes = None         # For easy header parsing
-        
+
         # To store formats that may be able to fulfil this request
         #self._potential_formats = []
-        
+
         # Check mode
         self._mode = mode
         if not isinstance(mode, string_types):
@@ -115,17 +117,17 @@ class Request(object):
             raise ValueError('Request requires mode[0] to be "r" or "w"')
         if mode[1] not in 'iIvV?':
             raise ValueError('Request requires mode[1] to be in "iIvV?"')
-        
+
         # Parse what was given
         self._parse_uri(uri)
-    
+
     def _parse_uri(self, uri):
         """ Try to figure our what we were given
         """
         py3k = sys.version_info[0] == 3
         is_read_request = self.mode[0] == 'r'
         is_write_request = self.mode[0] == 'w'
-        
+
         if isinstance(uri, string_types):
             # Explicit
             if uri.startswith('imageio:'):
@@ -193,35 +195,35 @@ class Request(object):
                 self._uri_type = URI_FILE
                 self._filename = '<file>'
                 self._file = uri
-        
+
         # Expand user dir
         if self._uri_type == URI_FILENAME and self._filename.startswith('~'):
             self._filename = os.path.expanduser(self._filename)
-        
+
         # Check if a zipfile
         if self._uri_type == URI_FILENAME:
             # Search for zip extension followed by a path separater
             for needle in ['.zip/', '.zip\\']:
                 zip_i = self._filename.lower().find(needle)
-                if zip_i > 0:                    
+                if zip_i > 0:
                     zip_i += 4
                     self._uri_type = URI_ZIPPED
-                    self._filename_zip = (self._filename[:zip_i], 
+                    self._filename_zip = (self._filename[:zip_i],
                                           self._filename[zip_i:].lstrip('/\\'))
                     break
-        
+
         # Check if we could read it
         if self._uri_type is None:
             uri_r = repr(uri)
             if len(uri_r) > 60:
                 uri_r = uri_r[:57] + '...'
             raise IOError("Cannot understand given URI: %s." % uri_r)
-        
+
         # Check if this is supported
         noWriting = [URI_HTTP, URI_FTP]
         if is_write_request and self._uri_type in noWriting:
             raise IOError('imageio does not support writing to http/ftp.')
-        
+
         # Deprecated way to load standard images, give a sensible error message
         if is_read_request and self._uri_type in [URI_FILENAME, URI_ZIPPED]:
             fn = self._filename
@@ -231,16 +233,16 @@ class Request(object):
                 raise IOError('No such file: %r. This file looks like one of '
                               'the standard images, but from imageio 2.1, '
                               'standard images have to be specified using '
-                              '"imageio:%s".' % (fn, fn)) 
-        
-        # Make filename absolute 
+                              '"imageio:%s".' % (fn, fn))
+
+        # Make filename absolute
         if self._uri_type in [URI_FILENAME, URI_ZIPPED]:
             if self._filename_zip:
                 self._filename_zip = (os.path.abspath(self._filename_zip[0]),
                                       self._filename_zip[1])
             else:
                 self._filename = os.path.abspath(self._filename)
-        
+
         # Check whether file name is valid
         if self._uri_type in [URI_FILENAME, URI_ZIPPED]:
             fn = self._filename
@@ -249,13 +251,13 @@ class Request(object):
             if is_read_request:
                 # Reading: check that the file exists (but is allowed a dir)
                 if not os.path.exists(fn):
-                    raise IOError("No such file: '%s'" % fn)
+                    raise FileNotFoundError("No such file: '%s'" % fn)
             else:
                 # Writing: check that the directory to write to does exist
                 dn = os.path.dirname(fn)
                 if not os.path.exists(dn):
-                    raise IOError("The directory %r does not exist" % dn)
-    
+                    raise FileNotFoundError("The directory %r does not exist" % dn)
+
     @property
     def filename(self):
         """ The uri for which reading/saving was requested. This
@@ -264,7 +266,7 @@ class Request(object):
         but use ``get_file()`` or ``get_local_filename()`` instead.
         """
         return self._filename
-    
+
     @property
     def mode(self):
         """ The mode of the request. The first character is "r" or "w",
@@ -274,46 +276,46 @@ class Request(object):
         "V" for multiple volumes, "?" for don't care.
         """
         return self._mode
-    
+
     @property
     def kwargs(self):
         """ The dict of keyword arguments supplied by the user.
         """
         return self._kwargs
-    
+
     ## For obtaining data
-    
+
     def get_file(self):
         """ get_file()
         Get a file object for the resource associated with this request.
         If this is a reading request, the file is in read mode,
         otherwise in write mode. This method is not thread safe. Plugins
         do not need to close the file when done.
-        
+
         This is the preferred way to read/write the data. But if a
         format cannot handle file-like objects, they should use
         ``get_local_filename()``.
         """
         want_to_write = self.mode[0] == 'w'
-        
+
         # Is there already a file?
-        # Either _uri_type == URI_FILE, or we already opened the file, 
+        # Either _uri_type == URI_FILE, or we already opened the file,
         # e.g. by using firstbytes
         if self._file is not None:
             return self._file
-        
+
         if self._uri_type == URI_BYTES:
-            if want_to_write:                          
+            if want_to_write:
                 self._file = BytesIO()
             else:
                 self._file = BytesIO(self._bytes)
-        
+
         elif self._uri_type == URI_FILENAME:
             if want_to_write:
                 self._file = open(self.filename, 'wb')
             else:
                 self._file = open(self.filename, 'rb')
-        
+
         elif self._uri_type == URI_ZIPPED:
             # Get the correct filename
             filename, name = self._filename_zip
@@ -324,21 +326,21 @@ class Request(object):
                 # Open zipfile and open new file object for specific file
                 self._zipfile = zipfile.ZipFile(filename, 'r')
                 self._file = self._zipfile.open(name, 'r')
-        
+
         elif self._uri_type in [URI_HTTP or URI_FTP]:
             assert not want_to_write  # This should have been tested in init
             self._file = urlopen(self.filename, timeout=5)
             fix_HTTPResponse(self._file)
-        
+
         return self._file
-    
+
     def get_local_filename(self):
         """ get_local_filename()
         If the filename is an existing file on this filesystem, return
         that. Otherwise a temporary file is created on the local file
         system which can be used by the format to read from or write to.
         """
-        
+
         if self._uri_type == URI_FILENAME:
             return self._filename
         else:
@@ -353,27 +355,27 @@ class Request(object):
                 with open(self._filename_local, 'wb') as file:
                     shutil.copyfileobj(self.get_file(), file)
             return self._filename_local
-    
+
     def finish(self):
         """ finish()
         For internal use (called when the context of the reader/writer
         exits). Finishes this request. Close open files and process
         results.
         """
-        
+
         # Init
         bytes = None
-        
+
         # Collect bytes from temp file
         if self.mode[0] == 'w' and self._filename_local:
             with open(self._filename_local, 'rb') as file:
                 bytes = file.read()
-        
+
         # Collect bytes from BytesIO file object.
         written = (self.mode[0] == 'w') and self._file
         if written and self._uri_type in [URI_BYTES, URI_ZIPPED]:
             bytes = self._file.getvalue()
-        
+
         # Close open files that we know of (and are responsible for)
         if self._file and self._uri_type != URI_FILE:
             self._file.close()
@@ -388,7 +390,7 @@ class Request(object):
             except Exception:  # pragma: no cover
                 pass
             self._filename_local = None
-        
+
         # Handle bytes that we collected
         if bytes is not None:
             if self._uri_type == URI_BYTES:
@@ -397,26 +399,26 @@ class Request(object):
                 zf = zipfile.ZipFile(self._filename_zip[0], 'a')
                 zf.writestr(self._filename_zip[1], bytes)
                 zf.close()
-        
+
         # Detach so gc can clean even if a reference of self lingers
         self._bytes = None
-    
+
     def get_result(self):
         """ For internal use. In some situations a write action can have
         a result (bytes data). That is obtained with this function.
         """
         self._result, res = None, self._result
         return res
-    
+
     @property
     def firstbytes(self):
-        """ The first 256 bytes of the file. These can be used to 
+        """ The first 256 bytes of the file. These can be used to
         parse the header to determine the file-format.
         """
         if self._firstbytes is None:
             self._read_first_bytes()
         return self._firstbytes
-    
+
     def _read_first_bytes(self, N=256):
         if self._bytes is not None:
             self._firstbytes = self._bytes[:N]
@@ -450,7 +452,7 @@ class Request(object):
 
 def read_n_bytes(f, N):
     """ read_n_bytes(file, n)
-    
+
     Read n bytes from the given file, or less if the file has less
     bytes. Returns zero bytes if the file is closed.
     """
@@ -469,27 +471,27 @@ def fix_HTTPResponse(f):
     to use the file object.
     """
     count = [0]
-    
+
     def read(n=None):
         res = ori_read(n)
         count[0] += len(res)
         return res
-    
+
     def tell():
         return count[0]
-    
+
     def seek(i, mode=0):
         if not (mode == 0 and i == count[0]):
             ori_seek(i, mode)
-    
+
     def fail_seek(i, mode=0):
         raise RuntimeError('No seeking allowed!')
-    
+
     # Note, there is currently no protection from wrapping an object more than
     # once, it will (probably) work though, because closures.
     ori_read = f.read
     ori_seek = f.seek if hasattr(f, 'seek') else fail_seek
-    
+
     f.read = read
     f.tell = tell
     f.seek = seek

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -264,7 +264,8 @@ class Request(object):
                 # Writing: check that the directory to write to does exist
                 dn = os.path.dirname(fn)
                 if not os.path.exists(dn):
-                    raise FileNotFoundError("The directory %r does not exist" % dn)
+                    raise FileNotFoundError("The directory %r does not exist"
+                                            % dn)
 
     @property
     def filename(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -176,10 +176,12 @@ def test_request():
     #
     raises(IOError, Request, ['invalid', 'uri'] * 10, 'ri')  # invalid uri
     raises(IOError, Request, 4, 'ri')  # invalid uri
-    raises(FileNotFoundError, Request, '/does/not/exist', 'ri')  # reading nonexistent
-    raises(FileNotFoundError, Request, '/does/not/exist.zip/spam.png', 'ri')  # dito
+     # nonexistent reads
+    raises(FileNotFoundError, Request, '/does/not/exist', 'ri')
+    raises(FileNotFoundError, Request, '/does/not/exist.zip/spam.png', 'ri')
     raises(IOError, Request, 'http://example.com', 'wi')  # no writing here
-    raises(FileNotFoundError, Request, '/does/not/exist.png', 'wi')  # write dir nonexist
+    # write dir nonexist
+    raises(FileNotFoundError, Request, '/does/not/exist.png', 'wi')
 
     # Test auto-download
     R = Request('imageio:chelsea.png', 'ri')
@@ -517,7 +519,8 @@ def test_functions():
     W2.close()
     assert W1.format is W2.format
     # Fail
-    raises(FileNotFoundError, imageio.save, '~/dirdoesnotexist/wtf.notexistingfile')
+    raises(FileNotFoundError, imageio.save,
+           '~/dirdoesnotexist/wtf.notexistingfile')
 
     # Test imread()
     im1 = imageio.imread(fname1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,11 @@ from imageio.core import get_remote_file, IS_PYPY
 if sys.version_info < (3,):
     FileNotFoundError = OSError
 
+try:
+    from pathlib import Path
+except ImportError:
+    Path = None
+
 test_dir = get_test_dir()
 
 
@@ -176,12 +181,16 @@ def test_request():
     #
     raises(IOError, Request, ['invalid', 'uri'] * 10, 'ri')  # invalid uri
     raises(IOError, Request, 4, 'ri')  # invalid uri
-     # nonexistent reads
+    # nonexistent reads
     raises(FileNotFoundError, Request, '/does/not/exist', 'ri')
     raises(FileNotFoundError, Request, '/does/not/exist.zip/spam.png', 'ri')
+    if Path is not None:
+        raises(FileNotFoundError, Request, Path('/does/not/exist'), 'ri')
     raises(IOError, Request, 'http://example.com', 'wi')  # no writing here
     # write dir nonexist
     raises(FileNotFoundError, Request, '/does/not/exist.png', 'wi')
+    if Path is not None:
+        raises(FileNotFoundError, Request, Path('/does/not/exist.png'), 'wi')
 
     # Test auto-download
     R = Request('imageio:chelsea.png', 'ri')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,18 +19,21 @@ from imageio import core
 from imageio.core import Request
 from imageio.core import get_remote_file, IS_PYPY
 
+if sys.version_info < (3,):
+    FileNotFoundError = OSError
+
 test_dir = get_test_dir()
 
 
 def test_fetching():
     """ Test fetching of files """
-    
+
     need_internet()
-    
+
     # Clear image files
     if os.path.isdir(test_dir):
-        shutil.rmtree(test_dir)   
-    
+        shutil.rmtree(test_dir)
+
     # This should download the file (force download, because local cache)
     fname1 = get_remote_file('images/chelsea.png', test_dir, True)
     mtime1 = os.path.getmtime(fname1)
@@ -46,7 +49,7 @@ def test_fetching():
     # This should not
     fname5 = get_remote_file('images/chelsea.png', test_dir, '2014-01-01')
     mtime5 = os.path.getmtime(fname4)
-    # 
+    #
     assert os.path.isfile(fname1)
     assert fname1 == fname2
     assert fname1 == fname3
@@ -56,9 +59,9 @@ def test_fetching():
         # weird, but these often fail on my osx VM
         assert mtime1 == mtime2
         assert mtime1 < mtime3
-        assert mtime3 < mtime4  
+        assert mtime3 < mtime4
         assert mtime4 == mtime5
-    
+
     # Test failures
     _urlopen = core.fetching.urlopen
     _chunk_read = core.fetching._chunk_read
@@ -87,37 +90,37 @@ def test_fetching():
 
 
 def test_findlib1():
-    
+
     # Lib name would need to be "libc.so.5", or "libc.so.6", or ...
     # Meh, just skip
     skip('always skip, is tested implicitly anyway')
-    
+
     if not sys.platform.startswith('linux'):
         skip('test on linux only')
-    
+
     # Candidate libs for common lib (note, this runs only on linux)
     dirs, paths = core.findlib.generate_candidate_libs(['libc'])
     assert paths
 
 
 def test_findlib2():
-    
+
     if not sys.platform.startswith('linux'):
         skip('test on linux only')
-    
+
     need_internet()  # need our own version of FI to test this bit
-    
+
     # Candidate libs for common freeimage
     fi_dir = os.path.join(core.appdata_dir('imageio'), 'freeimage')
     if not os.path.isdir(fi_dir):
         os.mkdir(fi_dir)
-    dirs, paths = core.findlib.generate_candidate_libs(['libfreeimage'], 
+    dirs, paths = core.findlib.generate_candidate_libs(['libfreeimage'],
                                                        [fi_dir])
     #assert fi_dir in dirs -> Cannot test: lib may not exist
     assert paths
-    
+
     open(os.path.join(fi_dir, 'notalib.test.so'), 'wb')
-    
+
     # Loading libs
     gllib = ctypes.util.find_library('GL')
     core.load_lib([gllib], [])
@@ -131,7 +134,7 @@ def test_findlib2():
 
 def test_request():
     """ Test request object """
-    
+
     # Check uri-type, this is not a public property, so we test the private
     R = Request('http://example.com', 'ri')
     assert R._uri_type == core.request.URI_HTTP
@@ -161,7 +164,7 @@ def test_request():
     # zip file
     R = Request('~/bar.zip/spam.png', 'wi')
     assert R._uri_type == core.request.URI_ZIPPED
-    
+
     # Test failing inits
     raises(ValueError, Request, '/some/file', None)  # mode must be str
     raises(ValueError, Request, '/some/file', 3)  # mode must be str
@@ -173,11 +176,11 @@ def test_request():
     #
     raises(IOError, Request, ['invalid', 'uri'] * 10, 'ri')  # invalid uri
     raises(IOError, Request, 4, 'ri')  # invalid uri
-    raises(IOError, Request, '/does/not/exist', 'ri')  # reading nonexistent
-    raises(IOError, Request, '/does/not/exist.zip/spam.png', 'ri')  # dito
+    raises(FileNotFoundError, Request, '/does/not/exist', 'ri')  # reading nonexistent
+    raises(FileNotFoundError, Request, '/does/not/exist.zip/spam.png', 'ri')  # dito
     raises(IOError, Request, 'http://example.com', 'wi')  # no writing here
-    raises(IOError, Request, '/does/not/exist.png', 'wi')  # write dir nonexist
-    
+    raises(FileNotFoundError, Request, '/does/not/exist.png', 'wi')  # write dir nonexist
+
     # Test auto-download
     R = Request('imageio:chelsea.png', 'ri')
     assert R.filename == get_remote_file('images/chelsea.png')
@@ -188,7 +191,7 @@ def test_request():
 
 
 def test_request_read_sources():
-    
+
     # Make an image available in many ways
     fname = 'images/chelsea.png'
     filename = get_remote_file(fname, test_dir)
@@ -198,13 +201,13 @@ def test_request_read_sources():
     z = ZipFile(os.path.join(test_dir, 'test.zip'), 'w')
     z.writestr(fname, bytes)
     z.close()
-    
+
     has_inet = os.getenv('IMAGEIO_NO_INTERNET', '') not in ('1', 'yes', 'true')
-    
+
     # Read that image from these different sources. Read data from file
     # and from local file (the two main plugin-facing functions)
     for X in range(2):
-        
+
         # Define uris to test. Define inside loop, since we need fresh files
         uris = [filename,
                 os.path.join(test_dir, 'test.zip', fname),
@@ -212,7 +215,7 @@ def test_request_read_sources():
                 open(filename, 'rb')]
         if has_inet:
             uris.append(burl + fname)
-        
+
         for uri in uris:
             R = Request(uri, 'ri')
             first_bytes = R.firstbytes
@@ -229,7 +232,7 @@ def test_request_read_sources():
 
 
 def test_request_save_sources():
-    
+
     # Prepare desinations
     fname = 'images/chelsea.png'
     filename = get_remote_file(fname, test_dir)
@@ -239,7 +242,7 @@ def test_request_save_sources():
     filename2 = os.path.join(test_dir, fname2)
     zipfilename2 = os.path.join(test_dir, 'test.zip')
     file2 = BytesIO()
-    
+
     # Write an image into many different destinations
     # Do once via file and ones via local filename
     for i in range(2):
@@ -248,7 +251,7 @@ def test_request_save_sources():
             if os.path.isfile(xx):
                 os.remove(xx)
         # Write to three destinations
-        for uri in (filename2, 
+        for uri in (filename2,
                     os.path.join(zipfilename2, fname2),
                     file2,
                     imageio.RETURN_BYTES  # This one last to fill `res`
@@ -267,21 +270,21 @@ def test_request_save_sources():
 
 
 def test_request_file_no_seek():
-    
+
     class File:
-        
+
         def read(self, n):
             return b'\x00' * n
-            
+
         def seek(self, i):
             raise IOError('Not supported')
-        
+
         def tell(self):
             raise Exception('Not supported')
-        
+
         def close(self):
             pass
-    
+
     R = Request(File(), 'ri')
     with raises(IOError):
         R.firstbytes
@@ -289,7 +292,7 @@ def test_request_file_no_seek():
 
 def test_util_imagelist():
     meta = {'foo': 3, 'bar': {'spam': 1, 'eggs': 2}}
-    
+
     # Image list
     L = core.util.ImageList(meta)
     assert isinstance(L, list)
@@ -300,7 +303,7 @@ def test_util_imagelist():
 
 def test_util_image():
     meta = {'foo': 3, 'bar': {'spam': 1, 'eggs': 2}}
-    # Image 
+    # Image
     a = np.zeros((10, 10))
     im = core.util.Image(a, meta)
     isinstance(im, np.ndarray)
@@ -377,7 +380,7 @@ def test_util_asarray():
 def test_util_progres_bar(sleep=0):
     """ Test the progress bar """
     # This test can also be run on itself to *see* the result
-    
+
     # Progress bar
     for Progress in (core.StdoutProgressIndicator, core.BaseProgressIndicator):
         B = Progress('test')
@@ -391,7 +394,7 @@ def test_util_progres_bar(sleep=0):
             assert B._progress == i
         B.increase_progress(1)
         assert B._progress == i + 1
-        B.finish()  
+        B.finish()
         assert B.status() == 2
         # Without max
         B.start('Run without max int')
@@ -481,32 +484,32 @@ def test_util_image_as_uint():
 
 
 def test_util_has_has_module():
-    
+
     assert not core.has_module('this_module_does_not_exist')
     assert core.has_module('sys')
 
 
 def test_functions():
     """ Test the user-facing API functions """
-    
+
     # Test help(), it prints stuff, so we just check whether that goes ok
     imageio.help()  # should print overview
     imageio.help('PNG')  # should print about PNG
-    
+
     fname1 = get_remote_file('images/chelsea.png', test_dir)
     fname2 = fname1[:-3] + 'jpg'
     fname3 = fname1[:-3] + 'notavalidext'
     open(fname3, 'wb')
-    
+
     # Test read()
     R1 = imageio.read(fname1)
     R2 = imageio.read(fname1, 'png')
     assert R1.format is R2.format
     # Fail
     raises(ValueError, imageio.read, fname3)  # existing but not readable
-    raises(IOError, imageio.read, 'notexisting.barf')
+    raises(FileNotFoundError, imageio.read, 'notexisting.barf')
     raises(IndexError, imageio.read, fname1, 'notexistingformat')
-    
+
     # Test save()
     W1 = imageio.save(fname2)
     W2 = imageio.save(fname2, 'JPG')
@@ -514,14 +517,14 @@ def test_functions():
     W2.close()
     assert W1.format is W2.format
     # Fail
-    raises(IOError, imageio.save, '~/dirdoesnotexist/wtf.notexistingfile')
-    
+    raises(FileNotFoundError, imageio.save, '~/dirdoesnotexist/wtf.notexistingfile')
+
     # Test imread()
     im1 = imageio.imread(fname1)
     im2 = imageio.imread(fname1, 'png')
     assert im1.shape[2] == 3
     assert np.all(im1 == im2)
-    
+
     # Test imsave()
     if os.path.isfile(fname2):
         os.remove(fname2)
@@ -529,7 +532,7 @@ def test_functions():
     imageio.imsave(fname2, im1[:, :, 0])
     imageio.imsave(fname2, im1)
     assert os.path.isfile(fname2)
-    
+
     # Test mimread()
     fname3 = get_remote_file('images/newtonscradle.gif', test_dir)
     ims = imageio.mimread(fname3)
@@ -540,10 +543,10 @@ def test_functions():
     # Test protection
     with raises(RuntimeError):
         imageio.mimread('imageio:chelsea.png', 'dummy', length=np.inf)
-    
+
     if IS_PYPY:
         return  # no support for npz format :(
-    
+
     # Test mimsave()
     fname5 = fname3[:-4] + '2.npz'
     if os.path.isfile(fname5):
@@ -552,7 +555,7 @@ def test_functions():
     imageio.mimsave(fname5, [im[:, :, 0] for im in ims])
     imageio.mimsave(fname5, ims)
     assert os.path.isfile(fname5)
-    
+
     # Test volread()
     fname4 = get_remote_file('images/stent.npz', test_dir)
     vol = imageio.volread(fname4)
@@ -560,7 +563,7 @@ def test_functions():
     assert vol.shape[0] == 256
     assert vol.shape[1] == 128
     assert vol.shape[2] == 128
-    
+
     # Test volsave()
     volc = np.zeros((10, 10, 10, 3), np.uint8)  # color volume
     fname6 = os.path.join(test_dir, 'images', 'stent2.npz')
@@ -570,13 +573,13 @@ def test_functions():
     imageio.volsave(fname6, volc)
     imageio.volsave(fname6, vol)
     assert os.path.isfile(fname6)
-    
+
     # Test mvolread()
     vols = imageio.mvolread(fname4)
     assert isinstance(vols, list)
     assert len(vols) == 1
     assert vols[0].shape == vol.shape
-    
+
     # Test mvolsave()
     if os.path.isfile(fname6):
         os.remove(fname6)
@@ -584,7 +587,7 @@ def test_functions():
     imageio.mvolsave(fname6, [volc, volc])
     imageio.mvolsave(fname6, vols)
     assert os.path.isfile(fname6)
-    
+
     # Fail for save functions
     raises(ValueError, imageio.imsave, fname2, np.zeros((100, 100, 5)))
     raises(ValueError, imageio.imsave, fname2, 42)
@@ -598,7 +601,7 @@ def test_functions():
 
 def test_example_plugin():
     """ Test the example plugin """
-    
+
     fname = os.path.join(test_dir, 'out.png')
     r = Request('imageio:chelsea.png', 'r?')
     R = imageio.formats['dummy'].get_reader(r)


### PR DESCRIPTION
Python's [FileNotFoundError](https://docs.python.org/3/library/exceptions.html#FileNotFoundError) is for non-existent directories and files.

Moreover, as of Python 3.3, IOError has been [merged](https://docs.python.org/3/library/exceptions.html#OSError) into OSError, and may eventually be deprecated.

It was very surprising to me to have IOError raised for a missing file or directory, as every other module I've used uses the appropriate FileNotFoundError.


Additionally, added pathlib support, which is Python standard library since Python 3.5. 