### PR TITLE
Getting ready for Scipy users

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,8 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python35-conda64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python27-conda64"
-      PYTHON_VERSION: "2.7"
+    - PYTHON: "C:\\Python36-conda64"
+      PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
 
 install:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,5 +14,8 @@ To install imageio, use one of the following methods:
 * Good old ``python setup.py install``
 
 For developers, we provide a simple mechanism to allow importing 
-imageio from the cloned repository. See the file ``imageio.proxy.io`` for
+imageio from the cloned repository. See the file ``imageio.proxy.py`` for
 details.
+
+After installation, checkout the
+:doc:`examples  <examples>` and :doc:`user api <userapi>`. 

--- a/docs/scipy.rst
+++ b/docs/scipy.rst
@@ -1,6 +1,9 @@
 Transitioning from Scipy's imread
 =================================
 
+Scipy is `deprecating <https://scipy.github.io/devdocs/release.1.0.0.html#backwards-incompatible-changes>`_
+their image I/O functionality.
+
 This document is intended to help people coming from
 `Scipy <https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imread.html>`_
 to adapt to Imageio's :func:`imread <imageio.imread>` function.

--- a/docs/scipy.rst
+++ b/docs/scipy.rst
@@ -1,0 +1,19 @@
+Transitioning from Scipy's imread
+=================================
+
+This document is intended to help people coming from
+`Scipy <https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imread.html>`_
+to adapt to Imageio's :func:`imread <imageio.imread>` function.
+We recommend reading the :doc:`user api <userapi>` and checkout some
+:doc:`examples <examples>` to get a feel of imageio.
+
+Imageio makes use of variety of plugins to support reading images (and volumes/movies)
+from many different formats. Fortunately, Pillow is the main plugin for common images,
+which is the same library that Scipy's ``imread`` used. When the Pillow
+plugin is used, imageio provides the same functionality as Scipy. But
+keep in mind:
+
+    * Instead of ``mode``, use the ``pilmode`` keyword argument.
+    * Instead of ``flatten``, use the ``as_gray`` keyword argument.
+    * The documentation for the above arguments is not on :func:`imread <imageio.imread>`,
+      but on the docs of the individual formats, e.g. :doc:`PNG <format_png-pil>`.

--- a/docs/scipy.rst
+++ b/docs/scipy.rst
@@ -9,11 +9,17 @@ We recommend reading the :doc:`user api <userapi>` and checkout some
 
 Imageio makes use of variety of plugins to support reading images (and volumes/movies)
 from many different formats. Fortunately, Pillow is the main plugin for common images,
-which is the same library that Scipy's ``imread`` used. When the Pillow
-plugin is used, imageio provides the same functionality as Scipy. But
-keep in mind:
+which is the same library as used by  Scipy's ``imread``. Note that Imageio
+automatically selects a plugin based on the image to read (unless a format is
+explicitly specified), but uses Pillow where possible. 
+
+In short terms: For images previously read by Scipy's imread, imageio should
+generally use Pillow as well, and imageio provides the same functionality as Scipy
+in these cases. But keep in mind:
 
     * Instead of ``mode``, use the ``pilmode`` keyword argument.
     * Instead of ``flatten``, use the ``as_gray`` keyword argument.
     * The documentation for the above arguments is not on :func:`imread <imageio.imread>`,
       but on the docs of the individual formats, e.g. :doc:`PNG <format_png-pil>`.
+    * Imageio's functions all return numpy arrays, albeit as a subclass (so that
+      meta data can be attached). This subclass is called ``Image``.

--- a/docs/sec_gettingstarted.rst
+++ b/docs/sec_gettingstarted.rst
@@ -7,4 +7,5 @@ Getting started
   
   Installation <installation>
   Usage examples <examples>
+  Transitioning from Scipy <scipy>
   Release notes <releasenotes>

--- a/imageio/core/format.py
+++ b/imageio/core/format.py
@@ -588,7 +588,10 @@ class FormatManager(object):
                     return format
             else:
                 # Maybe the user meant to specify an extension
-                return self['.'+name.lower()]
+                try:
+                    return self['.'+name.lower()]
+                except IndexError:
+                    pass  # Fail using original name below
         
         # Nothing found ...
         raise IndexError('No format known by name %s.' % name)

--- a/imageio/core/functions.py
+++ b/imageio/core/functions.py
@@ -198,6 +198,10 @@ def imread(uri, format=None, **kwargs):
         to see what arguments are available for a particular format.
     """
 
+    if 'mode' in kwargs:
+        raise TypeError('Invalid keyword argument "mode", '
+                        'perhaps you mean "pilmode"?')
+    
     # Get reader and read first
     reader = read(uri, format, 'i', **kwargs)
     with reader:

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -82,7 +82,7 @@ def image_as_uint(im, bitdepth=None):
        np.nanmin(im) >= 0 and np.nanmax(im) <= 1):
         warn('Lossy conversion from {} to {}, range [0, 1]'.format(
              dtype_str, out_type.__name__))
-        im = im.astype(np.float64) * (np.power(2.0, bitdepth)-1)
+        im = im.astype(np.float64) * (np.power(2.0, bitdepth)-1) + 0.499999999
     elif im.dtype == np.uint16 and bitdepth == 8:
         warn('Lossy conversion from uint16 to uint8, '
              'losing 8 bits of resolution')
@@ -111,7 +111,7 @@ def image_as_uint(im, bitdepth=None):
         # Now make float copy before we scale
         im = im.astype('float64')
         # Scale the values between 0 and 1 then multiply by the max value
-        im = (im - mi) / (ma - mi) * (np.power(2.0, bitdepth)-1)
+        im = (im - mi) / (ma - mi) * (np.power(2.0, bitdepth)-1) + 0.499999999
     assert np.nanmin(im) >= 0
     assert np.nanmax(im) < np.power(2.0, bitdepth)
     return im.astype(out_type)

--- a/imageio/plugins/_freeimage.py
+++ b/imageio/plugins/_freeimage.py
@@ -18,7 +18,7 @@ import os
 import sys
 import ctypes
 import threading
-from logging import warn
+from logging import warning as warn
 import numpy
 
 from ..core import (get_remote_file, load_lib, Dict, resource_dirs, 

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -280,7 +280,7 @@ class PNGFormat(PillowFormat):
                 else:
                     scale = float(65536 if im.dtype == np.uint16 else 255)
                     gain = 1.0
-                    im = ((im / scale) ** gamma) * scale * gain
+                    im[:] = ((im / scale) ** gamma) * scale * gain + 0.4999
             return im, info
                     
     # -- 

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -207,6 +207,31 @@ class PNGFormat(PillowFormat):
     ----------------------
     ignoregamma : bool
         Avoid gamma correction. Default False.
+    pilmode : str
+        From the Pillow documentation:
+        
+        * 'L' (8-bit pixels, grayscale)
+        * 'P' (8-bit pixels, mapped to any other mode using a color palette)
+        * 'RGB' (3x8-bit pixels, true color)
+        * 'RGBA' (4x8-bit pixels, true color with transparency mask)
+        * 'CMYK' (4x8-bit pixels, color separation)
+        * 'YCbCr' (3x8-bit pixels, color video format)
+        * 'I' (32-bit signed integer pixels)
+        * 'F' (32-bit floating point pixels)
+        
+        PIL also provides limited support for a few special modes, including
+        'LA' ('L' with alpha), 'RGBX' (true color with padding) and 'RGBa'
+        (true color with premultiplied alpha).
+        
+        When translating a color image to grayscale (mode 'L', 'I' or 'F'),
+        the library uses the ITU-R 601-2 luma transform::
+        
+            L = R * 299/1000 + G * 587/1000 + B * 114/1000
+    as_gray : bool
+        If True, the image is converted using mode 'F'. When `mode` is
+        not None and `as_gray` is True, the image is first converted
+        according to `mode`, and the result is then "flattened" using
+        mode 'F'.
     
     Parameters for saving
     ---------------------
@@ -238,31 +263,6 @@ class PNGFormat(PillowFormat):
         bits. In this case, given as a number between 1-256.
     dictionary (experimental): dict
         Set the ZLIB encoder dictionary.
-    pilmode : str
-        From the Pillow documentation:
-        
-        * 'L' (8-bit pixels, grayscale)
-        * 'P' (8-bit pixels, mapped to any other mode using a color palette)
-        * 'RGB' (3x8-bit pixels, true color)
-        * 'RGBA' (4x8-bit pixels, true color with transparency mask)
-        * 'CMYK' (4x8-bit pixels, color separation)
-        * 'YCbCr' (3x8-bit pixels, color video format)
-        * 'I' (32-bit signed integer pixels)
-        * 'F' (32-bit floating point pixels)
-        
-        PIL also provides limited support for a few special modes, including
-        'LA' ('L' with alpha), 'RGBX' (true color with padding) and 'RGBa'
-        (true color with premultiplied alpha).
-        
-        When translating a color image to grayscale (mode 'L', 'I' or 'F'),
-        the library uses the ITU-R 601-2 luma transform::
-        
-            L = R * 299/1000 + G * 587/1000 + B * 114/1000
-    as_gray : bool
-        If True, the image is converted using mode 'F'. When `mode` is
-        not None and `as_gray` is True, the image is first converted
-        according to `mode`, and the result is then "flattened" using
-        mode 'F'.
     """
     
     class Reader(PillowFormat.Reader):
@@ -335,30 +335,6 @@ class JPEGFormat(PillowFormat):
     ----------------------
     exifrotate : bool
         Automatically rotate the image according to exif flag. Default True.
-    
-    Parameters for saving
-    ---------------------
-    quality : scalar
-        The compression factor of the saved image (1..100), higher
-        numbers result in higher quality but larger file size. Default 75.
-    progressive : bool
-        Save as a progressive JPEG file (e.g. for images on the web).
-        Default False.
-    optimize : bool
-        On saving, compute optimal Huffman coding tables (can reduce a few
-        percent of file size). Default False.
-    dpi : tuple of int
-        The pixel density, ``(x,y)``.
-    icc_profile : object
-        If present and true, the image is stored with the provided ICC profile.
-        If this parameter is not provided, the image will be saved with no
-        profile attached.
-    exif : dict
-        If present, the image will be stored with the provided raw EXIF data.
-    subsampling : str
-        Sets the subsampling for the encoder. See Pillow docs for details.
-    qtables : object
-        Set the qtables for the encoder. See Pillow docs for details.
     pilmode : str
         From the Pillow documentation:
         
@@ -384,6 +360,30 @@ class JPEGFormat(PillowFormat):
         not None and `as_gray` is True, the image is first converted
         according to `mode`, and the result is then "flattened" using
         mode 'F'.
+    
+    Parameters for saving
+    ---------------------
+    quality : scalar
+        The compression factor of the saved image (1..100), higher
+        numbers result in higher quality but larger file size. Default 75.
+    progressive : bool
+        Save as a progressive JPEG file (e.g. for images on the web).
+        Default False.
+    optimize : bool
+        On saving, compute optimal Huffman coding tables (can reduce a few
+        percent of file size). Default False.
+    dpi : tuple of int
+        The pixel density, ``(x,y)``.
+    icc_profile : object
+        If present and true, the image is stored with the provided ICC profile.
+        If this parameter is not provided, the image will be saved with no
+        profile attached.
+    exif : dict
+        If present, the image will be stored with the provided raw EXIF data.
+    subsampling : str
+        Sets the subsampling for the encoder. See Pillow docs for details.
+    qtables : object
+        Set the qtables for the encoder. See Pillow docs for details.
     """
     
     class Reader(PillowFormat.Reader):

--- a/imageio/plugins/pillow_info.py
+++ b/imageio/plugins/pillow_info.py
@@ -64,7 +64,7 @@ def generate_info():  # pragma: no cover
     # Fill in the blancs
     for id in ids:
         if id in docs:
-            docs[id] = '*This is a copy from the Pillow docs.*\n\n' + docs[id]
+            docs[id] = '*From the Pillow docs:*\n\n' + docs[id]
         else:
             docs[id] = 'No docs for %s.' % id
             print('no docs for', id)
@@ -150,7 +150,7 @@ pillow_formats = [
 
 pillow_docs = {
 'BMP':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads and writes Windows and OS/2 BMP files containing ``1``, ``L``, ``P``,
@@ -164,7 +164,7 @@ u"""*This is a copy from the Pillow docs.*
         Set to ``bmp_rle`` if the file is run-length encoded.
     """,
 'BUFR':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     .. versionadded:: Pillow  1.1.3
@@ -175,14 +175,14 @@ u"""*This is a copy from the Pillow docs.*
     :py:func:`PIL.BufrStubImagePlugin.register_handler`.
     """,
 'CUR':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     CUR is used to store cursors on Windows. The CUR decoder reads the largest
     available cursor. Animated cursors are not supported.
     """,
 'DCX':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     DCX is a container file format for PCX files, defined by Intel. The DCX format
@@ -194,7 +194,7 @@ u"""*This is a copy from the Pillow docs.*
     
     """,
 'DDS':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     DDS is a popular container texture format used in video games and natively
@@ -207,7 +207,7 @@ u"""*This is a copy from the Pillow docs.*
 'DIB':
 u"""No docs for DIB.""",
 'EPS':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL identifies EPS files containing image data, and can read files that contain
@@ -233,7 +233,7 @@ u"""*This is a copy from the Pillow docs.*
             im.size #(200,200)
     """,
 'FITS':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     .. versionadded:: Pillow  1.1.5
@@ -246,7 +246,7 @@ u"""*This is a copy from the Pillow docs.*
 'FLI':
 u"""No docs for FLI.""",
 'FPX':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads Kodak FlashPix files. In the current version, only the highest
@@ -260,7 +260,7 @@ u"""*This is a copy from the Pillow docs.*
         README for details.
     """,
 'FTEX':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     .. versionadded:: Pillow  3.2.0
@@ -270,7 +270,7 @@ u"""*This is a copy from the Pillow docs.*
     per file, in the compressed and uncompressed formats.
     """,
 'GBR':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     The GBR decoder reads GIMP brush files, version 1 and 2.
@@ -299,7 +299,7 @@ u"""*This is a copy from the Pillow docs.*
         transparent.
     """,
 'GIF':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads GIF87a and GIF89a versions of the GIF file format. The library writes
@@ -353,6 +353,7 @@ u"""*This is a copy from the Pillow docs.*
     **append_images**
         A list of images to append as additional frames. Each of the
         images in the list can be single or multiframe images.
+        This is currently only supported for GIF, PDF, TIFF, and WebP.
     
     **duration**
         The display duration of each frame of the multiframe gif, in
@@ -367,12 +368,23 @@ u"""*This is a copy from the Pillow docs.*
         eliminating unused colors. This is only useful if the palette can
         be compressed to the next smaller power of 2 elements.
     
-    **palette** 
+    **palette**
         Use the specified palette for the saved image. The palette should
         be a bytes or bytearray object containing the palette entries in
         RGBRGB... form. It should be no more than 768 bytes. Alternately,
         the palette can be passed in as an
         :py:class:`PIL.ImagePalette.ImagePalette` object.
+    
+    **disposal**
+        Indicates the way in which the graphic is to be treated after being displayed.
+    
+        * 0 - No disposal specified.
+        * 1 - Do not dispose.
+        * 2 - Restore to background color.
+        * 3 - Restore to previous content.
+    
+         Pass a single integer for a constant disposal, or a list or tuple
+         to set the disposal for each frame separately.
     
     Reading local images
     ~~~~~~~~~~~~~~~~~~~~
@@ -392,7 +404,7 @@ u"""*This is a copy from the Pillow docs.*
             im.tile = [(tag, (0, 0) + im.size, offset, extra)]
     """,
 'GRIB':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     .. versionadded:: Pillow  1.1.5
@@ -407,7 +419,7 @@ u"""*This is a copy from the Pillow docs.*
     :py:func:`PIL.GribStubImagePlugin.register_handler`.
     """,
 'HDF5':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     .. versionadded:: Pillow  1.1.5
@@ -418,7 +430,7 @@ u"""*This is a copy from the Pillow docs.*
     :py:func:`PIL.Hdf5StubImagePlugin.register_handler`.
     """,
 'ICNS':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads and (macOS only) writes macOS ``.icns`` files.  By default, the
@@ -438,7 +450,7 @@ u"""*This is a copy from the Pillow docs.*
         :py:attr:`~PIL.Image.Image.size` will be ``(1024, 1024)``).
     """,
 'ICO':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     ICO is used to store icons on Windows. The largest available icon is read.
@@ -448,8 +460,8 @@ u"""*This is a copy from the Pillow docs.*
     **sizes**
         A list of sizes including in this ico file; these are a 2-tuple,
         ``(width, height)``; Default to ``[(16, 16), (24, 24), (32, 32), (48, 48),
-        (64, 64), (128, 128), (255, 255)]``. Any sizes bigger than the original
-        size or 255 will be ignored.
+        (64, 64), (128, 128), (256, 256)]``. Any sizes bigger than the original
+        size or 256 will be ignored.
     
     IM
     ^^
@@ -463,7 +475,7 @@ u"""*This is a copy from the Pillow docs.*
 'IM':
 u"""No docs for IM.""",
 'IMT':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads Image Tools images containing ``L`` data.
@@ -471,7 +483,7 @@ u"""*This is a copy from the Pillow docs.*
 'IPTC':
 u"""No docs for IPTC.""",
 'JPEG':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads JPEG, JFIF, and Adobe JPEG files containing ``L``, ``RGB``, or
@@ -556,11 +568,11 @@ u"""*This is a copy from the Pillow docs.*
         If present, sets the subsampling for the encoder.
     
         * ``keep``: Only valid for JPEG files, will retain the original image setting.
-        * ``4:4:4``, ``4:2:2``, ``4:1:1``: Specific sampling values
+        * ``4:4:4``, ``4:2:2``, ``4:2:0``: Specific sampling values
         * ``-1``: equivalent to ``keep``
         * ``0``: equivalent to ``4:4:4``
         * ``1``: equivalent to ``4:2:2``
-        * ``2``: equivalent to ``4:1:1``
+        * ``2``: equivalent to ``4:2:0``
     
     **qtables**
         If present, sets the qtables for the encoder. This is listed as an
@@ -582,7 +594,7 @@ u"""*This is a copy from the Pillow docs.*
         details.
     """,
 'JPEG2000':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     .. versionadded:: Pillow  2.4.0
@@ -671,27 +683,29 @@ u"""*This is a copy from the Pillow docs.*
        ``_imaging`` DLL).
     """,
 'MCIDAS':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL identifies and reads 8-bit McIdas area files.
     """,
 'MIC':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL identifies and reads Microsoft Image Composer (MIC) files. When opened, the
     first sprite in the file is loaded. You can use :py:meth:`~file.seek` and
     :py:meth:`~file.tell` to read other sprites from the file.
+    
+    Note that there may be an embedded gamma of 2.2 in MIC files.
     """,
 'MPEG':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL identifies MPEG files.
     """,
 'MPO':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     Pillow identifies and reads Multi Picture Object (MPO) files, loading the primary
@@ -700,14 +714,14 @@ u"""*This is a copy from the Pillow docs.*
     zero-indexed and random access is supported.
     """,
 'MSP':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL identifies and reads MSP files from Windows 1 and 2. The library writes
     uncompressed (Windows 1) versions of this format.
     """,
 'PCD':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads PhotoCD files containing ``RGB`` data. This only reads the 768x512
@@ -715,13 +729,13 @@ u"""*This is a copy from the Pillow docs.*
     encoding.
     """,
 'PCX':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads and writes PCX files containing ``1``, ``L``, ``P``, or ``RGB`` data.
     """,
 'PIXAR':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL provides limited support for PIXAR raster files. The library can identify
@@ -730,7 +744,7 @@ u"""*This is a copy from the Pillow docs.*
     The format code is ``PIXAR``.
     """,
 'PNG':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL identifies, reads, and writes PNG files containing ``1``, ``L``, ``P``,
@@ -739,8 +753,21 @@ u"""*This is a copy from the Pillow docs.*
     The :py:meth:`~PIL.Image.Image.write` method sets the following
     :py:attr:`~PIL.Image.Image.info` properties, when appropriate:
     
+    **chromaticity**
+        The chromaticity points, as an 8 tuple of floats. (``White Point
+        X``, ``White Point Y``, ``Red X``, ``Red Y``, ``Green X``, ``Green
+        Y``, ``Blue X``, ``Blue Y``)
+    
     **gamma**
         Gamma, given as a floating point number.
+    
+    **srgb**
+        The sRGB rendering intent as an integer.
+    
+          * 0 Perceptual
+          * 1 Relative Colorimetric
+          * 2 Saturation
+          * 3 Absolute Colorimetric
     
     **transparency**
         For ``P`` images: Either the palette index for full transparent pixels,
@@ -802,28 +829,28 @@ u"""*This is a copy from the Pillow docs.*
         documentation for details.
     """,
 'PPM':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads and writes PBM, PGM and PPM files containing ``1``, ``L`` or ``RGB``
     data.
     """,
 'PSD':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL identifies and reads PSD files written by Adobe Photoshop 2.5 and 3.0.
     
     """,
 'SGI':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     Pillow reads and writes uncompressed ``L``, ``RGB``, and ``RGBA`` files.
     
     """,
 'SPIDER':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads and writes SPIDER image files of 32-bit floating point data
@@ -866,22 +893,27 @@ u"""*This is a copy from the Pillow docs.*
 'SUN':
 u"""No docs for SUN.""",
 'TGA':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads 24- and 32-bit uncompressed and run-length encoded TGA files.
     """,
 'TIFF':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
-    PIL reads and writes TIFF files. It can read both striped and tiled images,
-    pixel and plane interleaved multi-band images, and either uncompressed, or
-    Packbits, LZW, or JPEG compressed images.
+    Pillow reads and writes TIFF files. It can read both striped and tiled
+    images, pixel and plane interleaved multi-band images. If you have
+    libtiff and its headers installed, PIL can read and write many kinds
+    of compressed TIFF files. If not, PIL will only read and write
+    uncompressed files.
     
-    If you have libtiff and its headers installed, PIL can read and write many more
-    kinds of compressed TIFF files. If not, PIL will always write uncompressed
-    files.
+    .. note::
+    
+        Beginning in version 5.0.0, Pillow requires libtiff to read or
+        write compressed files. Prior to that release, Pillow had buggy
+        support for reading Packbits, LZW and JPEG compressed TIFFs
+        without using libtiff.
     
     The :py:meth:`~PIL.Image.Image.write` method sets the following
     :py:attr:`~PIL.Image.Image.info` properties:
@@ -1000,7 +1032,7 @@ u"""*This is a copy from the Pillow docs.*
     
     """,
 'WMF':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL can identify playable WMF files.
@@ -1032,13 +1064,13 @@ u"""*This is a copy from the Pillow docs.*
     
         im = Image.open("sample.wmf")""",
 'XBM':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads and writes X bitmap files (mode ``1``).
     """,
 'XPM':
-u"""*This is a copy from the Pillow docs.*
+u"""*From the Pillow docs:*
 
     
     PIL reads X pixmap files (mode ``P``) with 256 colors or less.

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ for line in open(initFile).readlines():
         elif docStatus == 1:
             docStatus = 2
     if docStatus == 1:
-        __doc__ += line
+        __doc__ += line.rstrip() + '\n'
 
 # Template for long description. __doc__ gets inserted here
 long_description = """

--- a/tasks/install_python.ps1
+++ b/tasks/install_python.ps1
@@ -96,10 +96,10 @@ function InstallPip ($python_home) {
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -eq "3.5") {
-        $filename = "Miniconda3-4.0.5-Windows-" + $platform_suffix + ".exe"
+    if ($python_version -eq "3.6") {
+        $filename = "Miniconda3-4.4.10-Windows-" + $platform_suffix + ".exe"
     } else {
-        $filename = "Miniconda2-4.0.5-Windows-" + $platform_suffix + ".exe"
+        $filename = "Miniconda2-4.4.10-Windows-" + $platform_suffix + ".exe"
     }
     $url = $MINICONDA_URL + $filename
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -487,7 +487,14 @@ def test_util_image_as_uint():
         (np.array([0, 1], 'float64'), 16, np.uint16([0, 65535])),
         (np.array([-1.0, 1.0], 'float16'), 16, np.uint16([0, 65535])),
         (np.array([-1.0, 1.0], 'float32'), 16, np.uint16([0, 65535])),
-        (np.array([-1.0, 1.0], 'float64'), 16, np.uint16([0, 65535])),)
+        (np.array([-1.0, 1.0], 'float64'), 16, np.uint16([0, 65535])),
+        # Rounding
+        (np.array([1.4/255, 1.6/255], 'float32'), 8, np.uint8([1, 2])),
+        (np.array([254.4/255, 254.6/255], 'float32'), 8, np.uint8([254, 255])),
+        (np.array([1.4/65535, 1.6/65535], 'float32'), 16, np.uint16([1, 2])),
+        (np.array([65534.4/65535, 65534.6/65535], 'float32'), 16,
+            np.uint16([65534, 65535])),  # noqa
+        )
 
     for tup in test_arrays:
         res = core.image_as_uint(tup[0], bitdepth=tup[1])

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -143,7 +143,8 @@ def test_import_dependencies():
         else:
             print(modname, mod.__file__)
     
-    # Check that only imageio is left
+    # Check that only imageio is left (Windows needs a little help)
+    extra_modules.difference_update(['pythoncom', 'pywintypes', 'win32com'])
     assert extra_modules == {'imageio'}
 
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -329,6 +329,33 @@ def test_images_with_transparency():
     assert im.shape == (24, 30, 4)
 
 
+def test_scipy_imread_compat():
+    # https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imread.html
+    # https://github.com/scipy/scipy/blob/41a3e69ca3141d8bf996bccb5eca5fc7bbc21a51/scipy/misc/pilutil.py#L111
+    
+    im = imageio.imread('imageio:chelsea.png')
+    assert im.shape == (300, 451, 3) and im.dtype == 'uint8'
+    
+    # Scipy users may default to using "mode", but our getreader() already has
+    # a "mode" argument, so they should use pilmode instead.
+    try:
+        im = imageio.imread('imageio:chelsea.png', mode='L')
+    except TypeError as err:
+        assert 'pilmode' in str(err)
+    
+    im = imageio.imread('imageio:chelsea.png', pilmode='RGBA')
+    assert im.shape == (300, 451, 4) and im.dtype == 'uint8'
+    
+    im = imageio.imread('imageio:chelsea.png', pilmode='L')
+    assert im.shape == (300, 451) and im.dtype == 'uint8'
+    
+    im = imageio.imread('imageio:chelsea.png', pilmode='F')
+    assert im.shape == (300, 451) and im.dtype == 'float32'
+    
+    im = imageio.imread('imageio:chelsea.png', as_gray=True)
+    assert im.shape == (300, 451) and im.dtype == 'float32'
+
+
 if __name__ == '__main__':
     # test_png()
     # test_animated_gif()

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -329,6 +329,15 @@ def test_images_with_transparency():
     assert im.shape == (24, 30, 4)
 
 
+def test_regression_302():
+    # When using gamma correction, the result should keep the same dtype
+    need_internet()
+    
+    fname = get_remote_file('images/kodim03.png')
+    im = imageio.imread(fname)
+    assert im.shape == (512, 768, 3) and im.dtype == 'uint8'
+
+    
 def test_scipy_imread_compat():
     # https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imread.html
     # https://github.com/scipy/scipy/blob/41a3e69ca3141d8bf996bccb5eca5fc7bbc21a51/scipy/misc/pilutil.py#L111

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -354,6 +354,10 @@ def test_scipy_imread_compat():
     
     im = imageio.imread('imageio:chelsea.png', as_gray=True)
     assert im.shape == (300, 451) and im.dtype == 'float32'
+    
+    # Force using pillow (but really, Pillow's imageio's first choice! Except
+    # for tiff)
+    im = imageio.imread('imageio:chelsea.png', 'PNG-PIL')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* [x] Pillow plugin has `pilmode` argument (can't name it `mode` because we already use that name in `get_reader()` (closes #289).
* [x] Pillow plugin has `as_gray` argument.
* [x] Raise an informative error when `mode` is used in `imread`.
* [x] Add a small doc for transitioning users.
* [x] Get rid of debug message when Pillow image fails to close (closes #300) .
* [x] Update autogenerated Pillow info.
* [x] Fix gamma correction dtype (closes #302).
* [x] Fix rounding of float data (closes #296).
* [x] Fix that jpg cannot read from http due it pillow using eek (cloese #238 ).