### PR TITLE
adding tests (currently failing) for standard TIF metadata write

### DIFF
--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -23,9 +23,9 @@ def test_tifffile_format():
 
 def test_tifffile_reading_writing():
     """ Test reading and saving tiff """
-    
+
     need_internet()  # We keep a test image in the imageio-binary repo
-    
+
     im2 = np.ones((10, 10, 3), np.uint8) * 2
 
     filename1 = os.path.join(test_dir, 'test_tiff.tiff')
@@ -37,7 +37,7 @@ def test_tifffile_reading_writing():
     assert im.shape == im2.shape
     assert (im == im2).all()
     assert len(ims) == 1
-    
+
     # Multiple images
     imageio.mimsave(filename1, [im2, im2, im2])
     im = imageio.imread(filename1)
@@ -56,7 +56,7 @@ def test_tifffile_reading_writing():
     assert len(vols) == 1 and vol.shape == vols[0].shape
     for i in range(3):
         assert (vol[i] == im2).all()
-    
+
     # remote multipage rgb file
     filename2 = get_remote_file('images/multipage_rgb.tif')
     img = imageio.mimread(filename2)
@@ -75,12 +75,12 @@ def test_tifffile_reading_writing():
     assert R.format.name == 'TIFF'
     ims = list(R)  # == [im for im in R]
     assert (ims[0] == im2).all()
-    # meta = R.get_meta_data()
-    # assert meta['orientation'] == 'top_left'  # not there in later version
+    meta = R.get_meta_data()
+    assert meta['is_shaped'] == '{"shape": [2, 10, 10, 3]}'
     # Fail
     raises(IndexError, R.get_data, -1)
     raises(IndexError, R.get_data, 3)
-    
+
     # Ensure imread + imwrite works round trip
     filename3 = os.path.join(test_dir, 'test_tiff2.tiff')
     im1 = imageio.imread(filename1)
@@ -89,7 +89,7 @@ def test_tifffile_reading_writing():
     assert im1.ndim == 3
     assert im1.shape == im3.shape
     assert (im1 == im3).all()
-    
+
     # Ensure imread + imwrite works round trip - volume like
     filename3 = os.path.join(test_dir, 'test_tiff2.tiff')
     im1 = imageio.volread(filename1)
@@ -98,6 +98,30 @@ def test_tifffile_reading_writing():
     assert im1.ndim == 4
     assert im1.shape == im3.shape
     assert (im1 == im3).all()
+
+
+def test_tifffile_metadata():
+
+    need_internet()  # We keep a test image in the imageio-binary repo
+
+    etags = [(65000,'s',None,'My custom tag #1',True),
+                              (65001,'s',None,'My custom tag #2',True),
+                              (65002,'f',2,[123456.789,9876.54321],True)]
+
+    im2 = np.ones((10, 10, 3), np.uint8) * 2
+
+    filename1 = os.path.join(test_dir, 'test_tiff_meta.tiff')
+
+# %% One image
+    imageio.imwrite(filename1, im2,
+                   description='an image I like',
+                   extratags=etags)
+
+# %% Multiple images
+    imageio.mimwrite(filename1, [im2, im2, im2],
+                    description='lots of images I like',
+                    extratags=etags)
+
 
 
 run_tests_if_main()


### PR DESCRIPTION
This is a continuation of #299.
Upon testing, I found that imageio 2.3.0 has the exact same problem as before. Perhaps this is because metadata write wasn't part of the test suite.

These standard tags are a core part of tifffile usage for science/medical purposes, as you can automatically record arbitrary data about the experiment etc.

So I created a pull request that shows the failure on write, that has worked for years with tiffffile