### PR TITLE
Use more standard __version__ rather than PILLOW_VERSION

### DIFF
--- a/imageio/plugins/grab.py
+++ b/imageio/plugins/grab.py
@@ -31,7 +31,7 @@ class BaseGrabFormat(Format):
             if not self._pillow_imported:
                 self._pillow_imported = True  # more like tried to import
                 import PIL
-                if not hasattr(PIL, 'PILLOW_VERSION'):  # pragma: no cover
+                if not hasattr(PIL, '__version__'):  # pragma: no cover
                     raise ImportError('Imageio Pillow requires '
                                       'Pillow, not PIL!')
                 try:

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -77,8 +77,8 @@ class PillowFormat(Format):
             if not self._pillow_imported:
                 self._pillow_imported = True  # more like tried to import
                 import PIL
-                if not hasattr(PIL, 'PILLOW_VERSION'):  # pragma: no cover
-                    raise ImportError('Imageio Pillow requires '
+                if not hasattr(PIL, '__version__'):  # pragma: no cover
+                    raise ImportError('Imageio Pillow plugin requires '
                                       'Pillow, not PIL!')
                 from PIL import Image
                 self._Image = Image


### PR DESCRIPTION
They're both the same thing:

https://github.com/python-pillow/Pillow/blob/master/src/PIL/__init__.py