### PR TITLE
 Add support for reading videos with 16 bits per channel through FFMPEG

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -187,11 +187,15 @@ class FfmpegFormat(Format):
         (100, 100) or "640x480". For camera streams, this allows setting
         the capture resolution. For normal video data, ffmpeg will
         rescale the data.
+    dtype : str | type
+        The dtype for the output arrays. Determines the bit-depth that
+        is requested from ffmpeg. Supported dtypes: uint8, uint16.
+        Default: uint8.
     pixelformat : str
         The pixel format for the camera to use (e.g. "yuyv422" or
         "gray"). The camera needs to support the format in order for
         this to take effect. Note that the images produced by this
-        reader are always rgb8.
+        reader are always RGB.
     input_params : list
         List additional arguments to ffmpeg for input file options.
         (Can also be provided as ``ffmpeg_params`` for backwards compatibility)


### PR DESCRIPTION
I've implemented the option to read `uint16` RGB, i.e. the `rgb48le` pixel format. The choice is manual for now, because reading the original pixel format would require us to start ffmpeg (or, even better, ffprobe) once again.
If there's something I've missed, please tell me, or just correct me yourself.