### PR TITLE
Add a reader plugin for the SPE format

### DIFF
--- a/imageio/plugins/__init__.py
+++ b/imageio/plugins/__init__.py
@@ -107,6 +107,7 @@ from . import simpleitk  # depends on SimpleITK
 from . import gdal  # depends on gdal
 
 from . import lytro
+from . import spe
 
 from . import example
 

--- a/imageio/plugins/spe.py
+++ b/imageio/plugins/spe.py
@@ -55,46 +55,46 @@ class Spec:
         "VChipYdim": (16, "<h"),
 
         # other stuff
-        "ControllerVersion": (0, "<h"),
-        "LogicOutput": (2, "<h"),
-        "AmpHiCapLowNoise": (4, "<H"), # enum?
+        "controller_version": (0, "<h"),
+        "logic_output": (2, "<h"),
+        "amp_high_cap_low_noise": (4, "<H"), # enum?
         "mode": (8, "<h"), # enum?
-        "exp_sec": (10, "<f"),
+        "exposure_sec": (10, "<f"),
         "date": (20, "<10S"),
-        "DetTemperature": (36, "<f"),
-        "DetType": (40, "<h"),
-        "stdiode": (44, "<h"),
-        "DelayTime": (46, "<f"),
-        "ShutterControl": (50, "<H"), # normal, disabled open, disabled closed
-                                      # but which one is which?
-        "AbsorbLive": (52, "<h"), # bool?
-        "AbsorbMode": (54, "<H"),
-        "CanDoVirtualChipFlag": (56, "<h"), # bool?
-        "ThresholdMinLive": (58, "<h"), # bool?
-        "ThresholdMinVal": (60, "<f"),
-        "ThresholdMinLive": (64, "<h"), # bool?
-        "ThresholdMinVal": (66, "<f"),
-        "ExperimentTimeLocal": (172, "<7S"),
-        "ExperimentTimeUTC": (179, "<7S"),
-        "ADCoffset": (188, "<H"),
-        "ADCrate": (190, "<H"),
-        "ADCtype": (192, "<H"),
-        "ADCresolution": (194, "<H"),
-        "ADCbitAdjust": (196, "<H"),
+        "detector_temp": (36, "<f"),
+        "detector_type": (40, "<h"),
+        "st_diode": (44, "<h"),
+        "delay_time": (46, "<f"),
+        "shutter_control": (50, "<H"), # normal, disabled open, disabled closed
+                                       # but which one is which?
+        "absorb_live": (52, "<h"),
+        "absorb_mode": (54, "<H"),
+        "can_do_virtual_chip": (56, "<h"),
+        "threshold_min_live": (58, "<h"),
+        "threshold_min_val": (60, "<f"),
+        "threshold_max_live": (64, "<h"),
+        "threshold_max_val": (66, "<f"),
+        "time_local": (172, "<7S"),
+        "time_utc": (179, "<7S"),
+        "adc_offset": (188, "<H"),
+        "adc_rate": (190, "<H"),
+        "adc_type": (192, "<H"),
+        "adc_resolution": (194, "<H"),
+        "adc_bit_adjust": (196, "<H"),
         "gain": (198, "<H"),
         "comments": (200, "<80S", 5),
         "geometric": (600, "<H"), # flags
-        "swversion": (688, "<16S"),
-        "spare4": (742, "<436S"),
+        "sw_version": (688, "<16S"),
+        "spare_4": (742, "<436S"),
         "XPrePixels": (98, "<h"),
         "XPostPixels": (100, "<h"),
         "YPrePixels": (102, "<h"),
         "YPostPixels": (104, "<h"),
-        "ReadoutTime": (672, "<f"),
+        "readout_time": (672, "<f"),
         "type": (704, "<h"), # controllers
-        "clkspd_us": (1428, "<f"),
-        "readoutMode": (1480, "<H"), # readout_modes
-        "WindowSize": (1482, "<H"),
+        "clockspeed_us": (1428, "<f"),
+        "readout_mode": (1480, "<H"), # readout_modes
+        "window_size": (1482, "<H"),
         "file_header_ver": (1992, "<f")
     }
 
@@ -115,7 +115,7 @@ class Spec:
 
     # Do not decode the following metadata keys into strings, but leave them
     # as byte arrays
-    no_decode = ["spare4"]
+    no_decode = ["spare_4"]
 
 
 class SpeFormat(Format):
@@ -143,11 +143,11 @@ class SpeFormat(Format):
         directions.
     comments : list of str
         The SPE format allows for 5 comment strings of 80 characters each.
-    ControllerVersion : int
+    controller_version : int
         Hardware version
-    LogicOutput : int
+    logic_output : int
         Definition of output BNC
-    AmpHiCapLowNoise : int
+    amp_hi_cap_low_noise : int
         Amp switching mode
     mode : int
         Timing mode
@@ -155,68 +155,70 @@ class SpeFormat(Format):
         Alternative exposure in seconds
     date : str
         Date string
-    DetTemperature : float
+    detector_temp : float
         Detector temperature
-    stdiode : int
+    detector_type : int
+        CCD / diode array type
+    st_diode : int
         Trigger diode
-    DelayTime : float
+    delay_time : float
         Used with async mode
-    ShutterControl : int
+    shutter_control : int
         Normal, disabled open, or disabled closed
-    AbsorbLive : bool
+    absorb_live : bool
         on / off
-    AbsorbMode : int
+    absorb_mode : int
         Reference strip or file
-    CanDoVirtualChipFlag : bool
+    can_do_virtual_chip : bool
         True or False whether chip can do virtual chip
-    ThresholdMinLive : bool
+    threshold_min_live : bool
         on / off
-    ThresholdMinVal : float
+    threshold_min_val : float
         Threshold minimum value
-    ThresholdMaxLive : bool
+    threshold_max_live : bool
         on / off
-    ThresholdMaxVal : float
+    threshold_max_val : float
         Threshold maximum value
-    ExperimentTimeLocal : str
+    time_local : str
         Experiment local time
-    ExperimentTimeUTC : str
+    time_utc : str
         Experiment UTC time
-    ADCoffset : int
+    adc_offset : int
         ADC offset
-    ADCrate : int
+    adc_rate : int
         ADC rate
-    ADCtype : int
+    adc_type : int
         ADC type
-    ADCresolution : int
+    adc_resolution : int
         ADC resolution
-    ADCbitAdjust : int
+    adc_bit_adjust : int
         ADC bit adjust
     gain : int
         gain
     sw_version : str
         Version of software which created this file
-    spare4 : bytes
+    spare_4 : bytes
         Reserved space
-    ReadoutTime : float
+    readout_time : float
         Experiment readout time
     type : str
         Controller type
-    clkspd_us : float
+    clockspeed_us : float
         Vertical clock speed in microseconds
-    readoutMode : {"full frame", "frame transfer", "kinetics", ""}
+    readout_mode : {"full frame", "frame transfer", "kinetics", ""}
         Readout mode. Empty string means that this was not set by the
         Software.
-    WindowSize : int
+    window_size : int
         Window size for Kinetics mode
     file_header_ver : float
         File header version
-    ChipSize : [int, int]
+    chip_size : [int, int]
         x and y dimensions of the camera chip
-    VirtChipSize : [int, int]
+    virt_chip_size : [int, int]
         Virtual chip x and y dimensions
-    PrePixels : [int, int]
+    pre_pixels : [int, int]
         Pre pixels in x and y dimensions
-    PostPixels : [int, int],
+    post_pixels : [int, int],
         Post pixels in x and y dimensions
     geometric : list of {"rotate", "reverse", "flip"}
         Geometric operations
@@ -261,14 +263,14 @@ class SpeFormat(Format):
                 self._meta["ROIs"] = roi_array_to_dict(self._meta["ROIs"][:nr])
 
                 # chip sizes
-                self._meta["ChipSize"] = [self._meta.pop("xDimDet", None),
-                                          self._meta.pop("yDimDet", None)]
-                self._meta["VirtChipSize"] = [
+                self._meta["chip_size"] = [self._meta.pop("xDimDet", None),
+                                           self._meta.pop("yDimDet", None)]
+                self._meta["virt_chip_size"] = [
                     self._meta.pop("VChipXdim", None),
                     self._meta.pop("VChipYdim", None)]
-                self._meta["PrePixels"] = [self._meta.pop("XPrePixels", None),
-                                           self._meta.pop("YPrePixels", None)]
-                self._meta["PostPixels"] = [
+                self._meta["pre_pixels"] = [self._meta.pop("XPrePixels", None),
+                                            self._meta.pop("YPrePixels", None)]
+                self._meta["post_pixels"] = [
                     self._meta.pop("XPostPixels", None),
                     self._meta.pop("YPostPixels", None)]
 
@@ -287,17 +289,25 @@ class SpeFormat(Format):
                     g.append("flip")
                 self._meta["geometric"] = g
 
-                #Make some additional information more human-readable
+                # Make some additional information more human-readable
                 t = self._meta["type"]
                 if 1 <= t <= len(Spec.controllers):
                     self._meta["type"] = Spec.controllers[t - 1]
                 else:
-                    self._meta.pop("type", None)
-                m = self._meta["readoutMode"]
+                    self._meta["type"] = ""
+                m = self._meta["readout_mode"]
                 if 1 <= m <= len(Spec.readout_modes):
-                    self._meta["readoutMode"] = Spec.readout_modes[m - 1]
+                    self._meta["readout_mode"] = Spec.readout_modes[m - 1]
                 else:
-                    self._meta.pop("readoutMode", None)
+                    self._meta["readout_mode"] = ""
+
+                # bools
+                for k in ("absorb_live", "can_do_virtual_chip",
+                          "threshold_min_live", "threshold_max_live"):
+                    self._meta[k] = bool(self._meta[k])
+
+                # frame shape
+                self._meta["frame_shape"] = self._shape
             return self._meta
 
         def _close(self):
@@ -327,7 +337,7 @@ class SpeFormat(Format):
                     # entry, return this entry itself.
                     v = np.asscalar(v)
                 except ValueError:
-                    v = np.ravel(v)
+                    v = np.squeeze(v)
                 ret[name] = v
             return ret
 

--- a/imageio/plugins/spe.py
+++ b/imageio/plugins/spe.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+# imageio is distributed under the terms of the (new) BSD License.
+
+""" SPE file reader
+"""
+
+from __future__ import absolute_import, print_function, division
+
 import os
 import warnings
 import numpy as np
@@ -111,6 +119,108 @@ class Spec:
 
 
 class SpeFormat(Format):
+    """ Some CCD camera software produces images in the Princeton Instruments
+    SPE file format. This plugin supports reading such files.
+
+    Parameters for reading
+    ----------------------
+    char_encoding : str
+        Character encoding used to decode strings in the metadata. Defaults
+        to "latin1".
+    check_filesize : bool
+        The number of frames in the file is stored in the file header. However,
+        this number may be wrong for certain software. If this is `True`
+        (default), derive the number of frames also from the file size and
+        raise a warning if the two values do not match.
+
+    Metadata for reading
+    --------------------
+    ROIs : list of dict
+        Regions of interest used for recording images. Each dict has the
+        "top_left" key containing x and y coordinates of the top left corner,
+        the "bottom_right" key with x and y coordinates of the bottom right
+        corner, and the "bin" key with number of binned pixels in x and y
+        directions.
+    comments : list of str
+        The SPE format allows for 5 comment strings of 80 characters each.
+    ControllerVersion : int
+        Hardware version
+    LogicOutput : int
+        Definition of output BNC
+    AmpHiCapLowNoise : int
+        Amp switching mode
+    mode : int
+        Timing mode
+    exp_sec : float
+        Alternative exposure in seconds
+    date : str
+        Date string
+    DetTemperature : float
+        Detector temperature
+    stdiode : int
+        Trigger diode
+    DelayTime : float
+        Used with async mode
+    ShutterControl : int
+        Normal, disabled open, or disabled closed
+    AbsorbLive : bool
+        on / off
+    AbsorbMode : int
+        Reference strip or file
+    CanDoVirtualChipFlag : bool
+        True or False whether chip can do virtual chip
+    ThresholdMinLive : bool
+        on / off
+    ThresholdMinVal : float
+        Threshold minimum value
+    ThresholdMaxLive : bool
+        on / off
+    ThresholdMaxVal : float
+        Threshold maximum value
+    ExperimentTimeLocal : str
+        Experiment local time
+    ExperimentTimeUTC : str
+        Experiment UTC time
+    ADCoffset : int
+        ADC offset
+    ADCrate : int
+        ADC rate
+    ADCtype : int
+        ADC type
+    ADCresolution : int
+        ADC resolution
+    ADCbitAdjust : int
+        ADC bit adjust
+    gain : int
+        gain
+    sw_version : str
+        Version of software which created this file
+    spare4 : bytes
+        Reserved space
+    ReadoutTime : float
+        Experiment readout time
+    type : str
+        Controller type
+    clkspd_us : float
+        Vertical clock speed in microseconds
+    readoutMode : {"full frame", "frame transfer", "kinetics", ""}
+        Readout mode. Empty string means that this was not set by the
+        Software.
+    WindowSize : int
+        Window size for Kinetics mode
+    file_header_ver : float
+        File header version
+    ChipSize : [int, int]
+        x and y dimensions of the camera chip
+    VirtChipSize : [int, int]
+        Virtual chip x and y dimensions
+    PrePixels : [int, int]
+        Pre pixels in x and y dimensions
+    PostPixels : [int, int],
+        Post pixels in x and y dimensions
+    geometric : list of {"rotate", "reverse", "flip"}
+        Geometric operations
+    """
     def _can_read(self, request):
         return (request.mode[1] in self.modes + "?" and
                 request.extension in self.extensions)

--- a/imageio/plugins/spe.py
+++ b/imageio/plugins/spe.py
@@ -32,7 +32,7 @@ class Spec:
     to be found.
     """
     basic = {
-        "datatype": (108, "<h"), #dtypes
+        "datatype": (108, "<h"),  # dtypes
         "xdim": (42, "<H"),
         "ydim": (656, "<H"),
         "NumFrames": (1446, "<i"),
@@ -57,16 +57,17 @@ class Spec:
         # other stuff
         "controller_version": (0, "<h"),
         "logic_output": (2, "<h"),
-        "amp_high_cap_low_noise": (4, "<H"), # enum?
-        "mode": (8, "<h"), # enum?
+        "amp_high_cap_low_noise": (4, "<H"),  # enum?
+        "mode": (8, "<h"),  # enum?
         "exposure_sec": (10, "<f"),
         "date": (20, "<10S"),
         "detector_temp": (36, "<f"),
         "detector_type": (40, "<h"),
         "st_diode": (44, "<h"),
         "delay_time": (46, "<f"),
-        "shutter_control": (50, "<H"), # normal, disabled open, disabled closed
-                                       # but which one is which?
+        # shutter_control: normal, disabled open, disabled closed
+        # But which one is which?
+        "shutter_control": (50, "<H"),
         "absorb_live": (52, "<h"),
         "absorb_mode": (54, "<H"),
         "can_do_virtual_chip": (56, "<h"),
@@ -83,7 +84,7 @@ class Spec:
         "adc_bit_adjust": (196, "<H"),
         "gain": (198, "<H"),
         "comments": (200, "<80S", 5),
-        "geometric": (600, "<H"), # flags
+        "geometric": (600, "<H"),  # flags
         "sw_version": (688, "<16S"),
         "spare_4": (742, "<436S"),
         "XPrePixels": (98, "<h"),
@@ -91,9 +92,9 @@ class Spec:
         "YPrePixels": (102, "<h"),
         "YPostPixels": (104, "<h"),
         "readout_time": (672, "<f"),
-        "type": (704, "<h"), # controllers
+        "type": (704, "<h"),  # controllers
         "clockspeed_us": (1428, "<f"),
-        "readout_mode": (1480, "<H"), # readout_modes
+        "readout_mode": (1480, "<H"),  # readout_modes
         "window_size": (1482, "<H"),
         "file_header_ver": (1992, "<f")
     }
@@ -248,8 +249,8 @@ class SpeFormat(Format):
                 l //= self._shape[0] * self._shape[1] * self._dtype.itemsize
                 if l != self._len:
                     warnings.warn("Number of frames according to file header "
-                                  "does not match the size of file " +
-                                  filename + ".")
+                                  "does not match the size of file %s." %
+                                  self.request.filename)
                     self._len = min(l, self._len)
 
             self._meta = None
@@ -327,7 +328,7 @@ class SpeFormat(Format):
                     # Silently ignore string decoding failures
                     try:
                         v = decode(v)
-                    except:
+                    except Exception:
                         warnings.warn("Failed to decode \"{}\" metadata "
                                       "string. Check `char_encoding` "
                                       "parameter.".format(name))

--- a/imageio/plugins/spe.py
+++ b/imageio/plugins/spe.py
@@ -1,0 +1,281 @@
+import os
+import warnings
+import numpy as np
+
+from .. import formats
+from ..core import Format
+
+
+class Spec:
+    """SPE file specification data
+
+    Tuples of (offset, datatype, count), where offset is the offset in the SPE
+    file and datatype is the datatype as used in `numpy.fromfile`()
+
+    `data_start` is the offset of actual image data.
+
+    `dtypes` translates SPE datatypes (0...4) to numpy ones, e. g. dtypes[0]
+    is dtype("<f") (which is np.float32).
+
+    `controllers` maps the `type` metadata to a human readable name
+
+    `readout_modes` maps the `readoutMode` metadata to something human readable
+    although this may not be accurate since there is next to no documentation
+    to be found.
+    """
+    basic = {
+        "datatype": (108, "<h"), #dtypes
+        "xdim": (42, "<H"),
+        "ydim": (656, "<H"),
+        "NumFrames": (1446, "<i"),
+    }
+
+    metadata = {
+        # ROI information
+        "NumROI": (1510, "<h"),
+        "ROIs": (1512, np.dtype([("startx", "<H"),
+                                 ("endx", "<H"),
+                                 ("groupx", "<H"),
+                                 ("starty", "<H"),
+                                 ("endy", "<H"),
+                                 ("groupy", "<H")]), 10),
+
+        # chip-related sizes
+        "xDimDet": (6, "<H"),
+        "yDimDet": (18, "<H"),
+        "VChipXdim": (14, "<h"),
+        "VChipYdim": (16, "<h"),
+
+        # other stuff
+        "ControllerVersion": (0, "<h"),
+        "LogicOutput": (2, "<h"),
+        "AmpHiCapLowNoise": (4, "<H"), # enum?
+        "mode": (8, "<h"), # enum?
+        "exp_sec": (10, "<f"),
+        "date": (20, "<10S"),
+        "DetTemperature": (36, "<f"),
+        "DetType": (40, "<h"),
+        "stdiode": (44, "<h"),
+        "DelayTime": (46, "<f"),
+        "ShutterControl": (50, "<H"), # normal, disabled open, disabled closed
+                                      # but which one is which?
+        "AbsorbLive": (52, "<h"), # bool?
+        "AbsorbMode": (54, "<H"),
+        "CanDoVirtualChipFlag": (56, "<h"), # bool?
+        "ThresholdMinLive": (58, "<h"), # bool?
+        "ThresholdMinVal": (60, "<f"),
+        "ThresholdMinLive": (64, "<h"), # bool?
+        "ThresholdMinVal": (66, "<f"),
+        "ExperimentTimeLocal": (172, "<7S"),
+        "ExperimentTimeUTC": (179, "<7S"),
+        "ADCoffset": (188, "<H"),
+        "ADCrate": (190, "<H"),
+        "ADCtype": (192, "<H"),
+        "ADCresolution": (194, "<H"),
+        "ADCbitAdjust": (196, "<H"),
+        "gain": (198, "<H"),
+        "comments": (200, "<80S", 5),
+        "geometric": (600, "<H"), # flags
+        "swversion": (688, "<16S"),
+        "spare4": (742, "<436S"),
+        "XPrePixels": (98, "<h"),
+        "XPostPixels": (100, "<h"),
+        "YPrePixels": (102, "<h"),
+        "YPostPixels": (104, "<h"),
+        "ReadoutTime": (672, "<f"),
+        "type": (704, "<h"), # controllers
+        "clkspd_us": (1428, "<f"),
+        "readoutMode": (1480, "<H"), # readout_modes
+        "WindowSize": (1482, "<H"),
+        "file_header_ver": (1992, "<f")
+    }
+
+    data_start = 4100
+
+    dtypes = [np.dtype("<f"), np.dtype("<i"), np.dtype("<h"),
+              np.dtype("<H"), np.dtype("<I")]
+
+    controllers = [
+        "new120 (Type II)", "old120 (Type I)", "ST130", "ST121", "ST138",
+        "DC131 (PentaMax)", "ST133 (MicroMax/Roper)", "ST135 (GPIB)", "VTCCD",
+        "ST116 (GPIB)", "OMA3 (GPIB)", "OMA4"
+    ]
+
+    # This was gathered from random places on the internet and own experiments
+    # with the camera. May not be accurate.
+    readout_modes = ["full frame", "frame transfer", "kinetics"]
+
+    # Do not decode the following metadata keys into strings, but leave them
+    # as byte arrays
+    no_decode = ["spare4"]
+
+
+class SpeFormat(Format):
+    def _can_read(self, request):
+        return (request.mode[1] in self.modes + "?" and
+                request.extension in self.extensions)
+
+    def _can_write(self, request):
+        return False
+
+    class Reader(Format.Reader):
+        def _open(self, char_encoding="latin1", check_filesize=True):
+            self._file = self.request.get_file()
+            self._char_encoding = char_encoding
+
+            info = self._parse_header(Spec.basic)
+            self._dtype = Spec.dtypes[info["datatype"]]
+            self._shape = (info["ydim"], info["xdim"])
+            self._len = info["NumFrames"]
+
+            if check_filesize:
+                # Some software writes incorrecet `NumFrames` metadata
+                # Use the file size to determine the number of frames
+                fsz = os.path.getsize(self.request.get_local_filename())
+                l = fsz - Spec.data_start
+                l //= self._shape[0] * self._shape[1] * self._dtype.itemsize
+                if l != self._len:
+                    warnings.warn("Number of frames according to file header "
+                                  "does not match the size of file " +
+                                  filename + ".")
+                    self._len = min(l, self._len)
+
+            self._meta = None
+
+        def _get_meta_data(self, index):
+            if self._meta is None:
+                self._meta = self._parse_header(Spec.metadata)
+
+                nr = self._meta.pop("NumROI", None)
+                nr = 1 if nr < 1 else nr
+                self._meta["ROIs"] = roi_array_to_dict(self._meta["ROIs"][:nr])
+
+                # chip sizes
+                self._meta["ChipSize"] = [self._meta.pop("xDimDet", None),
+                                          self._meta.pop("yDimDet", None)]
+                self._meta["VirtChipSize"] = [
+                    self._meta.pop("VChipXdim", None),
+                    self._meta.pop("VChipYdim", None)]
+                self._meta["PrePixels"] = [self._meta.pop("XPrePixels", None),
+                                           self._meta.pop("YPrePixels", None)]
+                self._meta["PostPixels"] = [
+                    self._meta.pop("XPostPixels", None),
+                    self._meta.pop("YPostPixels", None)]
+
+                # comments
+                self._meta["comments"] = [str(c)
+                                          for c in self._meta["comments"]]
+
+                # geometric operations
+                g = []
+                f = self._meta.pop("geometric", 0)
+                if f & 1:
+                    g.append("rotate")
+                if f & 2:
+                    g.append("reverse")
+                if f & 4:
+                    g.append("flip")
+                self._meta["geometric"] = g
+
+                #Make some additional information more human-readable
+                t = self._meta["type"]
+                if 1 <= t <= len(Spec.controllers):
+                    self._meta["type"] = Spec.controllers[t - 1]
+                else:
+                    self._meta.pop("type", None)
+                m = self._meta["readoutMode"]
+                if 1 <= m <= len(Spec.readout_modes):
+                    self._meta["readoutMode"] = Spec.readout_modes[m - 1]
+                else:
+                    self._meta.pop("readoutMode", None)
+            return self._meta
+
+        def _close(self):
+            # The file should be closed by `self.request`
+            pass
+
+        def _parse_header(self, spec):
+            ret = {}
+            # Decode each string from the numpy array read by np.fromfile
+            decode = np.vectorize(lambda x: x.decode(self._char_encoding))
+
+            for name, sp in spec.items():
+                self._file.seek(sp[0])
+                cnt = (1 if len(sp) < 3 else sp[2])
+                v = np.fromfile(self._file, dtype=sp[1], count=cnt)
+                if v.dtype.kind == "S" and name not in Spec.no_decode:
+                    # Silently ignore string decoding failures
+                    try:
+                        v = decode(v)
+                    except:
+                        warnings.warn("Failed to decode \"{}\" metadata "
+                                      "string. Check `char_encoding` "
+                                      "parameter.".format(name))
+
+                try:
+                    # For convenience, if the array contains only one single
+                    # entry, return this entry itself.
+                    v = np.asscalar(v)
+                except ValueError:
+                    v = np.ravel(v)
+                ret[name] = v
+            return ret
+
+        def _get_length(self):
+            if self.request.mode[1] in 'vV':
+                return 1
+            else:
+                return self._len
+
+        def _get_data(self, index):
+            if index < 0:
+                raise IndexError("Image index %i < 0" % index)
+            if index >= self._len:
+                raise IndexError("Image index %i > %i" % (index, self._len))
+
+            if self.request.mode[1] in "vV":
+                if index != 0:
+                    raise IndexError("Index has to be 0 in v and V modes")
+                self._file.seek(Spec.data_start)
+                data = np.fromfile(
+                    self._file, dtype=self._dtype,
+                    count=self._shape[0] * self._shape[1] * self._len)
+                data = data.reshape((self._len,) + self._shape)
+            else:
+                self._file.seek(
+                    Spec.data_start + index * self._shape[0] *
+                    self._shape[1] * self._dtype.itemsize)
+                data = np.fromfile(
+                    self._file, dtype=self._dtype,
+                    count=self._shape[0] * self._shape[1])
+                data = data.reshape(self._shape)
+            return data, self._get_meta_data(index)
+
+
+def roi_array_to_dict(a):
+    """Convert the `ROIs` structured arrays to :py:class:`dict`
+
+    Parameters
+    ----------
+    a : numpy.ndarray
+        Structured array containing ROI data
+
+    Returns
+    -------
+    list of dict
+        One dict per ROI. Keys are "top_left", "bottom_right", and "bin",
+        values are tuples whose first element is the x axis value and the
+        second element is the y axis value.
+    """
+    l = []
+    a = a[["startx", "starty", "endx", "endy", "groupx", "groupy"]]
+    for sx, sy, ex, ey, gx, gy in a:
+        d = {"top_left": [int(sx), int(sy)],
+             "bottom_right": [int(ex), int(ey)],
+             "bin": [int(gx), int(gy)]}
+        l.append(d)
+    return l
+
+
+fmt = SpeFormat("spe", "SPE file format", ".spe", "iIvV")
+formats.add_format(fmt, overwrite=True)

--- a/tests/test_spe.py
+++ b/tests/test_spe.py
@@ -49,11 +49,16 @@ def test_spe_reading():
     md = r.get_meta_data()
     assert(md["ROIs"] == [{"top_left": [238, 187], "bottom_right": [269, 218],
                            "bin": [1, 1]}])
-    cmt = ["OD 1.0 in r, g                                                                  ",
-           "0002000000000000048000000000000000000000000000000000000000000000000002000001000X",
-           "                                                                                ",
-           "                                                                                ",
-           "ACCI2xSEQU-1---10000010001600300EA                              SW0218COMVER0500"]
+    cmt = ["OD 1.0 in r, g                                                    "
+           "              ",
+           "000200000000000004800000000000000000000000000000000000000000000000"
+           "0002000001000X",
+           "                                                                  "
+           "              ",
+           "                                                                  "
+           "              ",
+           "ACCI2xSEQU-1---10000010001600300EA                              SW"
+           "0218COMVER0500"]
     assert(md["comments"] == cmt)
     np.testing.assert_equal(md["frame_shape"], fr1.shape)
 

--- a/tests/test_spe.py
+++ b/tests/test_spe.py
@@ -55,6 +55,7 @@ def test_spe_reading():
            "                                                                                ",
            "ACCI2xSEQU-1---10000010001600300EA                              SW0218COMVER0500"]
     assert(md["comments"] == cmt)
+    np.testing.assert_equal(md["frame_shape"], fr1.shape)
 
 
 run_tests_if_main()

--- a/tests/test_spe.py
+++ b/tests/test_spe.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+
+import imageio
+from imageio.plugins import spe
+from imageio.testing import run_tests_if_main, get_test_dir, need_internet
+from imageio.core import get_remote_file
+
+
+test_dir = get_test_dir()
+
+
+def test_spe_format():
+    for name in ("spe", ".spe"):
+        fmt = imageio.formats[name]
+        assert(isinstance(fmt, spe.SpeFormat))
+
+
+def test_spe_reading():
+    need_internet()
+    fname = get_remote_file("images/test_000_.SPE")
+
+    fr1 = np.zeros((32, 32), np.uint16)
+    fr2 = np.ones_like(fr1)
+
+    # Test imread
+    im = imageio.imread(fname)
+    ims = imageio.mimread(fname)
+
+    np.testing.assert_equal(im, fr1)
+    np.testing.assert_equal(ims, [fr1, fr2])
+
+    # Test volread
+    vol = imageio.volread(fname)
+    vols = imageio.mvolread(fname)
+
+    np.testing.assert_equal(vol, [fr1, fr2])
+    np.testing.assert_equal(vols, [[fr1, fr2]])
+
+    # Test get_reader
+    r = imageio.get_reader(fname)
+
+    np.testing.assert_equal(r.get_data(1), fr2)
+    np.testing.assert_equal(list(r), [fr1, fr2])
+    pytest.raises(IndexError, r.get_data, -1)
+    pytest.raises(IndexError, r.get_data, 2)
+
+    # check metadata
+    md = r.get_meta_data()
+    assert(md["ROIs"] == [{"top_left": [238, 187], "bottom_right": [269, 218],
+                           "bin": [1, 1]}])
+    cmt = ["OD 1.0 in r, g                                                                  ",
+           "0002000000000000048000000000000000000000000000000000000000000000000002000001000X",
+           "                                                                                ",
+           "                                                                                ",
+           "ACCI2xSEQU-1---10000010001600300EA                              SW0218COMVER0500"]
+    assert(md["comments"] == cmt)
+
+
+run_tests_if_main()


### PR DESCRIPTION
This PR adds a plugin which can read image files in the SPE format, including some of its metadata.