### PR TITLE
Issue 357 add proxy support

### DIFF
--- a/imageio/core/fetching.py
+++ b/imageio/core/fetching.py
@@ -129,7 +129,7 @@ def get_remote_file(fname, directory=None, force_download=False, auto=True, prox
         return filename
 
 
-def _fetch_file(url, file_name, print_destination=True, proxy_address=False):
+def _fetch_file(url, file_name, proxy_address=False, print_destination=True):
     """Load requested file, downloading it if needed or requested
 
     Parameters

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -48,7 +48,7 @@ def limit_lines(lines, N=32):
     return lines
 
 
-def download(directory=None, force_download=False):
+def download(directory=None, force_download=False, proxy_address=False):
     """ Download the ffmpeg exe to your computer.
 
     Parameters
@@ -70,7 +70,8 @@ def download(directory=None, force_download=False):
     fname = 'ffmpeg/' + FNAME_PER_PLATFORM[plat]
     get_remote_file(fname=fname,
                     directory=directory,
-                    force_download=force_download)
+                    force_download=force_download,
+                    proxy_address=proxy_address)
 
 
 def get_exe():

--- a/imageio/testing.py
+++ b/imageio/testing.py
@@ -22,21 +22,20 @@ for i in range(9):
     if os.path.isfile(os.path.join(ROOT_DIR, '.gitignore')):
         break
 
-
-STYLE_IGNORES = ['E226', 
-                 'E241', 
-                 'E265', 
+STYLE_IGNORES = ['E226',
+                 'E241',
+                 'E265',
                  'E266',  # too many leading '#' for block comment
                  'E402',  # module level import not at top of file
                  'E731',  # do not assign a lambda expression, use a def
                  'E741',
-                 'W291', 
+                 'W291',
                  'W293',
                  'W503',  # line break before binary operator
-                 
+
                  # flake8 plugins that we do not follow
                  'N',  # Dont be pedantic about names in plugins
-                 'I', 'D', 'T', 'CG',  
+                 'I', 'D', 'T', 'CG',
                  ]
 
 
@@ -89,7 +88,7 @@ def clean_test_dir(strict=False):
         except Exception:
             if strict:
                 raise
-        
+
 
 def need_internet():
     if os.getenv('IMAGEIO_NO_INTERNET', '').lower() in ('1', 'true', 'yes'):
@@ -124,16 +123,16 @@ def test_style():
     except ImportError as err:
         print('Skipping flake8 test, flake8 not installed')
         return
-    
+
     # Reporting
     print('Running flake8 on %s' % ROOT_DIR)
     sys.stdout = FileForTesting(sys.stdout)
-    
+
     # Init
     ignores = STYLE_IGNORES.copy()
     fail = False
     count = 0
-    
+
     # Iterate over files
     for dir, dirnames, filenames in os.walk(ROOT_DIR):
         dir = os.path.relpath(dir, ROOT_DIR)
@@ -156,7 +155,7 @@ def test_style():
                     fail = True
                     print('----')
                 sys.stdout.flush()
-    
+
     # Report result
     sys.stdout.revert()
     if not count:
@@ -191,18 +190,19 @@ def _clear_imageio():
 class FileForTesting(object):
     """ Alternative to stdout that makes path relative to ROOT_DIR
     """
+
     def __init__(self, original):
         self._original = original
-    
+
     def write(self, msg):
         if msg.startswith(ROOT_DIR):
             msg = os.path.relpath(msg, ROOT_DIR)
         self._original.write(msg)
         self._original.flush()
-    
+
     def flush(self):
         self._original.flush()
-    
+
     def revert(self):
         sys.stdout = self._original
 
@@ -223,7 +223,7 @@ def _get_style_test_options(filename):
             elif 'ignore' in line:
                 words = line.replace(',', ' ').split(' ')
                 words = [w.strip() for w in words if w.strip()]
-                words = [w for w in words if 
+                words = [w for w in words if
                          (w[1:].isnumeric() and w[0] in 'EWFCN')]
                 ignores.extend(words)
     return skip, ignores
@@ -234,10 +234,10 @@ def _test_style(filename, ignore):
     """
     if isinstance(ignore, (list, tuple)):
         ignore = ','.join(ignore)
-    
+
     orig_dir = os.getcwd()
     orig_argv = sys.argv
-    
+
     os.chdir(ROOT_DIR)
     sys.argv[1:] = [filename]
     sys.argv.append('--ignore=' + ignore)


### PR DESCRIPTION
Added ```proxy_address``` as a passed variable. 
If ```False```, business as usual. If ```proxy_address``` is a proxy address, it's handled through urllib in ```fetching.py```. 

It seemed to work for myself and otherse, but let me know if there are problems. 

Proxy is passed through the ```get_remote_file``` method. 

Example:
```imageio.plugins.ffmpeg.download(proxy_address='https:corporate.zombie.net:2011')```