### PR TITLE
Support reading and writing more metadata in the tifffile plugin

### DIFF
--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, print_function, division
 
 import sys
+import datetime
 
 from .. import formats
 from ..core import Format
@@ -43,7 +44,8 @@ READ_METADATA_KEYS = ('planar_configuration', 'is_fluoview', 'is_nih',
                       'is_palette', 'is_reduced', 'is_rgb', 'is_sgi',
                       'is_shaped', 'is_stk', 'is_tiled', 'is_mdgel'
                       'resolution_unit', 'compression', 'is_mediacy',
-                      'orientation')
+                      'orientation', 'description', 'description1',
+                      'is_imagej', 'software')
 
 
 class TiffFormat(Format):
@@ -126,6 +128,16 @@ class TiffFormat(Format):
         True if page contains UIC2Tag tag.
     is_lsm : bool
         True if page contains LSM CZ_LSM_INFO tag.
+    description : str
+        Image description
+    description1 : str
+        Additional description
+    is_imagej : None or str
+        ImageJ metadata
+    software : str
+        Software used to create the TIFF file
+    datetime : datetime.datetime
+        Creation date and time
 
     Metadata for writing
     --------------------
@@ -230,6 +242,16 @@ class TiffFormat(Format):
                     self._meta[key] = getattr(page, key)
                 except Exception:
                     pass
+
+            # tifffile <= 0.12.1 use datetime, newer use DateTime
+            for key in ('datetime', 'DateTime'):
+                try:
+                    self._meta['datetime'] = datetime.datetime.strptime(
+                        page.tags[key].value, '%Y:%m:%d %H:%M:%S')
+                    break
+                except Exception:
+                    pass
+
             return self._meta
 
     # -- writer

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -38,7 +38,7 @@ def load_lib():
 TIFF_FORMATS = ('.tif', '.tiff', '.stk', '.lsm')
 WRITE_METADATA_KEYS = ('photometric', 'planarconfig', 'resolution',
                        'description', 'compress', 'volume', 'writeshape',
-                       'extratags')
+                       'extratags', 'datetime')
 READ_METADATA_KEYS = ('planar_configuration', 'is_fluoview', 'is_nih',
                       'is_contig', 'is_micromanager', 'is_ome', 'is_lsm'
                       'is_palette', 'is_reduced', 'is_rgb', 'is_sgi',

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -108,5 +108,20 @@ def test_tifffile_reading_writing():
     assert md['datetime'] == datetime.datetime(2015, 5, 9, 9, 8, 29)
     assert md['software'] == 'tifffile.py'
 
+    # Write metadata
+    dt = datetime.datetime(2018, 8, 6, 15, 35, 5)
+    w = imageio.get_writer(filename1, software='testsoftware')
+    w.append_data(np.zeros((10, 10)), meta={'description': 'test desc',
+                                            'datetime': dt})
+    w.close()
+    r = imageio.get_reader(filename1)
+    md = r.get_meta_data()
+    assert 'datetime' in md
+    assert md['datetime'] == dt
+    assert 'software' in md
+    assert md['software'] == 'testsoftware'
+    assert 'description' in md
+    assert md['description'] == 'test desc'
+
 
 run_tests_if_main()

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -2,6 +2,7 @@
 """
 
 import os
+import datetime
 
 import numpy as np
 
@@ -98,6 +99,14 @@ def test_tifffile_reading_writing():
     assert im1.ndim == 4
     assert im1.shape == im3.shape
     assert (im1 == im3).all()
+
+    # Read metadata
+    md = imageio.get_reader(filename2).get_meta_data()
+    assert md['is_imagej'] is None
+    assert md['description'] == 'shape=(2,3,10,10)'
+    assert md['description1'] == ''
+    assert md['datetime'] == datetime.datetime(2015, 5, 9, 9, 8, 29)
+    assert md['software'] == 'tifffile.py'
 
 
 run_tests_if_main()


### PR DESCRIPTION
Allow for reading 'description', 'description1', 'is_imagej', 'software', and 'datetime' tags, allow for writing also the 'datetime' tag.

Additionally, this fixes writing the 'software' tag for tifffile >= 0.15