### PR TITLE
Re-enable some flake checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,12 +86,9 @@ install:
     # Install dependencies (also for testing)
     - pip install invoke
     - if [ "${TEST_STYLE}" == "1" ]; then
-        pip install -q black;
-        pip install -q sphinx;
-        pip install -q numpydoc;
+        pip install -q black flake8 sphinx numpydoc;
       else
-        pip install -q pytest pytest-cov;
-        pip install -q coveralls;
+        pip install -q pytest pytest-cov coveralls;
       fi;
     # Install optional dependencies
     # We do NOT conda install gdal, because it causes segfaults

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,4 +26,4 @@ details.
 
 Further imageio has the following dev-dependencies:
 
-``pip install black pytest pytest-cov sphinx numpydoc``
+``pip install black flake8 pytest pytest-cov sphinx numpydoc``

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -73,10 +73,10 @@ def flake8_wrapper():
     """ Helper function to catch the worst style errors (e.g. unused variables).
     """
     # http://pep8.readthedocs.io/en/latest/intro.html#error-codes
-    cmd = [sys.executable, '-m', 'flake8', '--select=F,E11', 'imageio', 'tests']
+    cmd = [sys.executable, "-m", "flake8", "--select=F,E11", "imageio", "tests"]
     ret_code = subprocess.call(cmd, cwd=ROOT_DIR)
     if ret_code == 0:
-        print('No style errors found')
+        print("No style errors found")
     else:
         sys.exit(ret_code)
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import subprocess
 import webbrowser
 
 from invoke import task
@@ -11,7 +12,8 @@ from ._config import ROOT_DIR
 def lint(ctx):
     """ alias for "invoke test --style"
     """
-    black_wrapper(False)
+    flake8_wrapper()  # exits on fail
+    black_wrapper(False)  # always exits
 
 
 @task(
@@ -37,7 +39,8 @@ def test(ctx, unit=False, installed=False, style=False, cover=False):
         sys.exit(testing.test_unit())
 
     if style:
-        black_wrapper(False)
+        flake8_wrapper()  # exits on fail
+        black_wrapper(False)  # always exits
 
     if installed:
         for p in list(sys.path):
@@ -64,6 +67,18 @@ def black(ctx):
     """ Format the code using the Black uncompromising formatter.
     """
     black_wrapper(True)
+
+
+def flake8_wrapper():
+    """ Helper function to catch the worst style errors (e.g. unused variables).
+    """
+    # http://pep8.readthedocs.io/en/latest/intro.html#error-codes
+    cmd = [sys.executable, '-m', 'flake8', '--select=F,E11', 'imageio', 'tests']
+    ret_code = subprocess.call(cmd, cwd=ROOT_DIR)
+    if ret_code == 0:
+        print('No style errors found')
+    else:
+        sys.exit(ret_code)
 
 
 def black_wrapper(writeback):

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -364,7 +364,7 @@ def test_inside_zipfile():
         z.writestr("x.jpg", open(get_remote_file("images/rommel.jpg"), "rb").read())
 
     for name in ("x.png", "x.jpg"):
-        im = imageio.imread(fname + "/" + name)
+        imageio.imread(fname + "/" + name)
 
 
 def test_scipy_imread_compat():


### PR DESCRIPTION
In #373 we used Black instead of flake8 to check and apply style. In the process, however, we lost the flake checking for unused imports, use of undefined variables, etc. This PR brings that back.