### PR TITLE
Fix error with loading paletted BMP images using Pillow

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -49,3 +49,6 @@
 
 - Zulko
   Various contribution related to the ffmpeg plugin.
+
+- Addison Elliott
+  Add support for 8-bit paletted BMPs

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -127,7 +127,7 @@ class PillowFormat(Format):
             # However, there is a bug in PIL with handling animated GIFs with a different color palette on each frame.
             # This issue is resolved by using the raw palette data but the rawmode information is now lost. So we
             # store the raw mode for later use
-            if self._im.format == 'BMP' and self._im.palette.dirty:
+            if self._im.palette and self._im.palette.dirty:
                 self._im.palette.rawmode_saved = self._im.palette.rawmode
             pil_try_read(self._im)
             # Store args
@@ -168,7 +168,7 @@ class PillowFormat(Format):
                 while i < index:  # some formats need to be read in sequence
                     i += 1
                     self._seek(i)
-            if self._im.format == 'BMP' and self._im.palette.dirty:
+            if self._im.palette and self._im.palette.dirty:
                 self._im.palette.rawmode_saved = self._im.palette.rawmode
             self._im.getdata()[0]
             im = pil_get_frame(self._im, **self._kwargs)
@@ -571,11 +571,15 @@ def pil_get_frame(im, is_gray=None, as_gray=None, mode=None, dtype=None):
             # Restore the raw mode that was saved to be used to parse the palette
             if hasattr(im.palette, 'rawmode_saved'):
                 im.palette.rawmode = im.palette.rawmode_saved
-            nchannels = len(im.palette.rawmode) if im.palette.rawmode else len(im.palette.mode)
+            mode = im.palette.rawmode if im.palette.rawmode else im.palette.mode
+            nchannels = len(mode)
             # Shape it.
             p.shape = -1, nchannels
-            if p.shape[1] == 3 or (p.shape[1] == 4 and im.palette.rawmode[-1] == 'X'):
+            if p.shape[1] == 3 or (p.shape[1] == 4 and mode[-1] == 'X'):
                 p = np.column_stack((p[:, :3], 255 * np.ones(p.shape[0], p.dtype)))
+            # Swap the axes if the mode is in BGR and not RGB
+            if mode.startswith('BGR'):
+                p = p[:, [2, 1, 0]] if p.shape[1] == 3 else p[:, [2, 1, 0, 3]]
             # Apply palette
             frame_paletted = np.array(im, np.uint8)
             try:

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -122,6 +122,13 @@ class PillowFormat(Format):
             self._im = factory(self._fp, "")
             if hasattr(Image, "_decompression_bomb_check"):
                 Image._decompression_bomb_check(self._im.size)
+            # Save the raw mode used by the palette for a BMP because it may not be the number of channels
+            # When the data is read, imageio hands the palette to PIL to handle and clears the rawmode argument
+            # However, there is a bug in PIL with handling animated GIFs with a different color palette on each frame.
+            # This issue is resolved by using the raw palette data but the rawmode information is now lost. So we
+            # store the raw mode for later use
+            if self._im.format == 'BMP' and self._im.palette.dirty:
+                self._im.palette.rawmode_saved = self._im.palette.rawmode
             pil_try_read(self._im)
             # Store args
             self._kwargs = dict(
@@ -161,6 +168,8 @@ class PillowFormat(Format):
                 while i < index:  # some formats need to be read in sequence
                     i += 1
                     self._seek(i)
+            if self._im.format == 'BMP' and self._im.palette.dirty:
+                self._im.palette.rawmode_saved = self._im.palette.rawmode
             self._im.getdata()[0]
             im = pil_get_frame(self._im, **self._kwargs)
             return im, self._im.info
@@ -556,14 +565,17 @@ def pil_get_frame(im, is_gray=None, as_gray=None, mode=None, dtype=None):
             frame = im.convert("RGBA")
         elif im.palette.mode in ("RGB", "RGBA"):
             # We can do this ourselves. Pillow seems to sometimes screw
-            # this up if a  multi-gif has a pallete for each frame ...
+            # this up if a  multi-gif has a palette for each frame ...
             # Create palette array
             p = np.frombuffer(im.palette.getdata()[1], np.uint8)
+            # Restore the raw mode that was saved to be used to parse the palette
+            if hasattr(im.palette, 'rawmode_saved'):
+                im.palette.rawmode = im.palette.rawmode_saved
+            nchannels = len(im.palette.rawmode) if im.palette.rawmode else len(im.palette.mode)
             # Shape it.
-            nchannels = len(im.palette.mode)
             p.shape = -1, nchannels
-            if p.shape[1] == 3:
-                p = np.column_stack((p, 255 * np.ones(p.shape[0], p.dtype)))
+            if p.shape[1] == 3 or (p.shape[1] == 4 and im.palette.rawmode[-1] == 'X'):
+                p = np.column_stack((p[:, :3], 255 * np.ones(p.shape[0], p.dtype)))
             # Apply palette
             frame_paletted = np.array(im, np.uint8)
             try:

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -374,8 +374,14 @@ def test_bmp():
     fname = "D:/Users/addis/Documents/PythonProjects/imageio-binaries/images/scribble_P_RGB.bmp"
 
     im = imageio.imread(fname)
-    im = imageio.imread(fname, pilmode="RGB")
-    im = imageio.imread(fname, pilmode="RGBA")
+    # im = imageio.imread(fname, pilmode="RGB")
+    # im = imageio.imread(fname, pilmode="RGBA")
+
+    import matplotlib.pyplot as plt
+
+    plt.imshow(im)
+    plt.show()
+    i = 4
 
 
 def test_scipy_imread_compat():
@@ -413,4 +419,5 @@ if __name__ == "__main__":
     # test_inside_zipfile()
     # test_png()
     # test_animated_gif()
-    run_tests_if_main()
+    test_bmp()
+    # run_tests_if_main()

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -374,8 +374,8 @@ def test_bmp():
     fname = "D:/Users/addis/Documents/PythonProjects/imageio-binaries/images/scribble_P_RGB.bmp"
 
     im = imageio.imread(fname)
-    # im = imageio.imread(fname, pilmode="RGB")
-    # im = imageio.imread(fname, pilmode="RGBA")
+    im = imageio.imread(fname, pilmode="RGB")
+    im = imageio.imread(fname, pilmode="RGBA")
 
 
 def test_scipy_imread_compat():

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -367,6 +367,17 @@ def test_inside_zipfile():
         imageio.imread(fname + "/" + name)
 
 
+def test_bmp():
+    need_internet()
+
+    # fname = get_remote_file("images/scribble_P_RGB.bmp", test_dir)
+    fname = "D:/Users/addis/Documents/PythonProjects/imageio-binaries/images/scribble_P_RGB.bmp"
+
+    im = imageio.imread(fname)
+    # im = imageio.imread(fname, pilmode="RGB")
+    # im = imageio.imread(fname, pilmode="RGBA")
+
+
 def test_scipy_imread_compat():
     # https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imread.html
     # https://github.com/scipy/scipy/blob/41a3e69ca3141d8bf996bccb5eca5fc7bbc21a51/scipy/misc/pilutil.py#L111

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -370,18 +370,11 @@ def test_inside_zipfile():
 def test_bmp():
     need_internet()
 
-    # fname = get_remote_file("images/scribble_P_RGB.bmp", test_dir)
-    fname = "D:/Users/addis/Documents/PythonProjects/imageio-binaries/images/scribble_P_RGB.bmp"
+    fname = get_remote_file("images/scribble_P_RGB.bmp", test_dir)
 
     im = imageio.imread(fname)
-    # im = imageio.imread(fname, pilmode="RGB")
-    # im = imageio.imread(fname, pilmode="RGBA")
-
-    import matplotlib.pyplot as plt
-
-    plt.imshow(im)
-    plt.show()
-    i = 4
+    im = imageio.imread(fname, pilmode="RGB")
+    im = imageio.imread(fname, pilmode="RGBA")
 
 
 def test_scipy_imread_compat():
@@ -419,5 +412,5 @@ if __name__ == "__main__":
     # test_inside_zipfile()
     # test_png()
     # test_animated_gif()
-    test_bmp()
-    # run_tests_if_main()
+    # test_bmp()
+    run_tests_if_main()


### PR DESCRIPTION
Any 8-bit paletted BMP image is unable to be loaded using the Pillow image plugin with imageio but this pull request fixes that. The error that comes up when attempting to load an 8-bit paletted BMP image is:
`ValueError: cannot reshape array of size XXX into shape (XXX, 3)`

This error occurs in **pil_get_frame** when attempting to apply the palette to get the data in RGB format.

This error comes from the fact that the raw palette is retrieved from the Pillow image and parsed rather than using the converted/stored palette. In other words, im.palette.getdata() is the raw data that gets saved upon retrieving the data into im.getpalette(). The data in im.getpalette() is converted into one format (such as RGB) while the im.palette.getdata() can be in many different formats.

The reason that im.getpalette() is not used in the pil_get_frame function is because there is some issues with reading animated GIFs with a different color table for each frame causes some issue. To be specific, the dispose method must be set to 1 meaning that each new frame should be pasted on top of the old frame, which is kinda weird/tough to do when you have different color tables. See [this issue here](https://github.com/python-pillow/Pillow/issues/1525) for more information, but it may be awhile to get a fix.

As a result of using the raw palette data, we need to know the format it is in. For BMP's, most of the time the format is going to be BGRX where X is just an unused byte. This is what causes the error is because the code currently tries to resize it to be 3 channels no matter what.

In Pillow, the im.palette class saves the raw mode of the data but once it is *saved* into im.getpalette() (via im.putpalette()), then the raw mode is set to none. This is fine if we don't ever use the raw data from the palette, but we do so we need to save it.

**Solution:** My way of fixing this is to save the rawmode before it is discarded in another placeholder variable and then restore it when pil_get_frame is called.

A new test is added to load bitmaps. This test will fail until the data is added to the imageio-binaries repository: see here.