### PR TITLE
Provide correct defaults to PIL if pilmode is not provided.

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -132,8 +132,11 @@ class PillowFormat(Format):
             pil_try_read(self._im)
             # Store args
             self._kwargs = dict(
-                mode=pilmode, as_gray=as_gray, is_gray=_palette_is_grayscale(self._im)
+                as_gray=as_gray, is_gray=_palette_is_grayscale(self._im)
             )
+            # setting mode=None is not the same as just not providing it
+            if pilmode is not None:
+                self._kwargs['mode'] = pilmode
             # Set length
             self._length = 1
             if hasattr(self._im, "n_frames"):


### PR DESCRIPTION
Fixes #396

setting `mode=None` isn't the same as leaving it blank, it would give bogus images to images with a color pallet.

I know you would want me to write a test case, but honestly, I really dislike PIL/pillow.