### PR TITLE
Faster video write

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -52,3 +52,6 @@
 
 - Addison Elliott
   Add support for 8-bit paletted BMPs
+
+- Mark Harfouche
+  Speedups to pillow and ffpmeg by avoiding memory copies and conversions.

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -1060,7 +1060,7 @@ def parse_ffmpeg_info(text):
     # matches can be empty, see #171, assume nframes = inf
     # the regexp omits values of "1k tbr" which seems a specific edge-case #262
     # it seems that tbr is generally to be preferred #262
-    matches = re.findall(" ([0-9]+\.?[0-9]*) (tbr|fps)", line)
+    matches = re.findall(r" ([0-9]+\.?[0-9]*) (tbr|fps)", line)
     fps = 0
     matches.sort(key=lambda x: x[1] == "tbr", reverse=True)
     if matches:


### PR DESCRIPTION
writing to video converts things to string.

This is pretty costly seeing as a string is a full fledged copy of the image.

I'm encoding close to 4k video. I'm still trying to optimize how things are written, but these benchmarks show that at least in the first 30 frames, the system is slowed down, at least by 10-20% by converting the image to a string.

Without the patch:
![frame_per_seconds_ffmpeg_no_patch](https://user-images.githubusercontent.com/90008/47867018-b8533200-ddd6-11e8-9eaf-ffc65af4940d.png)

With the patch:
![frame_per_seconds_ffmpeg](https://user-images.githubusercontent.com/90008/47867034-be491300-ddd6-11e8-959c-cd024a19a803.png)
