### PR TITLE
Some general maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # Travis CI configuration file for imageio
 
+language: python
+
 addons:
   apt:
     packages:
@@ -10,12 +12,11 @@ branches:
   only:
     - master
 
-
 # Cache image data
 cache:
-  pip
-  directories:
-  - $HOME/.imageio/images
+  - pip
+  - directories:
+    - $HOME/.imageio/images
 
 
 matrix:
@@ -79,6 +80,15 @@ before_install:
     - cd ${SRC_DIR}
 
 install:
+    # Special stuff for Windows and Legacy Python
+    - if [ "$TRAVIS_OS_NAME" = "windows" ]; then
+        choco install python3;
+        export PATH=/c/Python38:/c/Python38/Scripts:/c/Python37:/c/Python37/Scripts:$PATH;
+      fi;
+    - if [ "${IS_LEGACY}" == "1" ]; then
+        pip install enum34 futures;
+      fi;
+    # Install dependencies depending on ENV
     - pip install invoke
     - if [ "${TEST_UNIT}" == "1" ]; then
         pip install numpy pillow psutil;
@@ -91,10 +101,6 @@ install:
     # We do NOT conda install gdal, because it causes segfaults
     - if [ "${TEST_FULL}" == "1" ]; then
        pip install simpleitk astropy;
-      fi;
-    # Install more deps on legacy py
-    - if [ "${IS_LEGACY}" == "1" ]; then
-        pip install enum34 futures;
       fi;
     # Install imageio on one/some env
     - if [ "${TEST_INSTALL}" == "1" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 # Travis CI configuration file for imageio
-# Validate this at http://lint.travis-ci.org/
-
-language: python
-
-sudo: false
 
 addons:
   apt:
@@ -18,35 +13,44 @@ branches:
 
 # Cache image data
 cache:
+  pip
   directories:
   - $HOME/.imageio/images
 
 
 matrix:
-    include:
-        - python: "3.6"
-          env: TEST_UNIT=0 TEST_STYLE=1
-        #
-        - python: "2.7"
-          env: TEST_UNIT=1 TEST_INSTALL=1 IS_LEGACY=1
-        - python: "3.4"
-          env: TEST_UNIT=1 TEST_FULL=1
-        - python: "3.5"
-          env: TEST_UNIT=1
-        - python: "3.6"
-          env: TEST_UNIT=1 TEST_COVER=1
+  include:
+    # One runner for style stuff
+    - os: linux
+      python: "3.6"
+      env: TEST_UNIT=0 TEST_STYLE=1
+    # Special OS'es / interpreters
+    - os: windows
+      language: bash
+      env: TEST_UNIT=1
+    #- os: linux
+    #  python: "pypy3.5"
+    #  env: TEST_UNIT=1
+    # The main tests run on Linux for a all relevant Python versions.
+    - os: linux
+      python: "2.7"
+      env: TEST_UNIT=1 TEST_INSTALL=1 IS_LEGACY=1
+    - os: linux
+      python: "3.4"
+      env: TEST_UNIT=1 TEST_FULL=1
+    - os: linux
+      python: "3.5"
+      env: TEST_UNIT=1
+    - os: linux
+      python: "3.6"
+      env: TEST_UNIT=1 TEST_COVER=1
+    - os: linux
+      python: "3.7-dev"
+      env: TEST_UNIT=1
 
 
 before_install:
     - REDIRECT_TO=/dev/stdout  # change to /dev/null to silence Travis
-    # Install miniconda
-    - if [ "${TEST_UNIT}" == "1" ]; then
-        wget -q http://repo.continuum.io/miniconda/Miniconda3-4.0.5-Linux-x86_64.sh -O miniconda.sh;
-        chmod +x miniconda.sh;
-        ./miniconda.sh -b -p ~/anaconda &> ${REDIRECT_TO};
-        export PATH=~/anaconda/bin:$PATH;
-        conda update --yes --quiet conda &> ${REDIRECT_TO};
-      fi;
     - SRC_DIR=$(pwd)
     # file size checks
     - if [ "${TEST_STYLE}" == "1" ]; then
@@ -75,35 +79,26 @@ before_install:
     - cd ${SRC_DIR}
 
 install:
-    # Install Python with numpy
-    - if [ "${TEST_UNIT}" == "1" ]; then
-        conda create -n testenv --yes --quiet pip python=$TRAVIS_PYTHON_VERSION > ${REDIRECT_TO};
-        source activate testenv > ${REDIRECT_TO};
-        conda install --yes --quiet numpy > ${REDIRECT_TO};
-        conda install --yes --quiet pillow -c conda-forge > ${REDIRECT_TO};
-        conda install --yes --quiet psutil > ${REDIRECT_TO};
-      fi;
-    # Install dependencies (also for testing)
     - pip install invoke
+    - if [ "${TEST_UNIT}" == "1" ]; then
+        pip install numpy pillow psutil;
+        pip install -q pytest pytest-cov coveralls;
+      fi;
     - if [ "${TEST_STYLE}" == "1" ]; then
         pip install -q black flake8 sphinx numpydoc;
-      else
-        pip install -q pytest pytest-cov coveralls;
       fi;
     # Install optional dependencies
     # We do NOT conda install gdal, because it causes segfaults
     - if [ "${TEST_FULL}" == "1" ]; then
-       easy_install -q simpleitk; true;
-       conda install -y astropy;
+       pip install simpleitk astropy;
       fi;
     # Install more deps on legacy py
     - if [ "${IS_LEGACY}" == "1" ]; then
         pip install enum34 futures;
       fi;
-    
-    # Install imageio, use installed version on only one machine
+    # Install imageio on one/some env
     - if [ "${TEST_INSTALL}" == "1" ]; then
-       python setup.py build_with_fi install > ${REDIRECT_TO};
+       python setup.py build_with_fi install;
       fi;
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ matrix:
     - os: windows
       language: bash
       env: TEST_UNIT=1
-    #- os: linux
-    #  python: "pypy3.5"
-    #  env: TEST_UNIT=1
     # The main tests run on Linux for a all relevant Python versions.
     - os: linux
       python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ install:
         export PATH=/c/Python38:/c/Python38/Scripts:/c/Python37:/c/Python37/Scripts:$PATH;
       fi;
     - if [ "${IS_LEGACY}" == "1" ]; then
-        pip install enum34 futures;
+        pip install enum34 futures pathlib;
       fi;
     # Install dependencies depending on ENV
     - pip install invoke

--- a/imageio/core/format.py
+++ b/imageio/core/format.py
@@ -403,6 +403,8 @@ class Format(object):
             while i < n:
                 try:
                     im, meta = self._get_data(i)
+                except StopIteration:
+                    return
                 except (IndexError, CannotReadFrameError):
                     if n == float("inf"):
                         return

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -556,10 +556,14 @@ def get_platform():
 def has_module(module_name):
     """Check to see if a python module is available.
     """
-    if sys.version_info > (3,):
+    if sys.version_info > (3, 4):
         import importlib
 
-        return importlib.find_loader(module_name) is not None
+        name_parts = module_name.split(".")
+        for i in range(len(name_parts)):
+            if importlib.util.find_spec(".".join(name_parts[: i + 1])) is None:
+                return False
+        return True
     else:  # pragma: no cover
         import imp
 

--- a/imageio/plugins/_bsdf.py
+++ b/imageio/plugins/_bsdf.py
@@ -202,7 +202,7 @@ class BsdfSerializer(object):
                 "Extension names must be nonempty and shorter " "than 251 chars."
             )
         if name in self._extensions:
-            logger.warn(
+            logger.warning(
                 'BSDF warning: overwriting extension "%s", '
                 "consider removing first" % name
             )
@@ -415,7 +415,7 @@ class BsdfSerializer(object):
             if extension is not None:
                 value = extension.decode(self, value)
             else:
-                logger.warn("BSDF warning: no extension found for %r" % ext_id)
+                logger.warning("BSDF warning: no extension found for %r" % ext_id)
 
         return value
 
@@ -474,7 +474,7 @@ class BsdfSerializer(object):
                 "BSDF warning: reading file with higher minor version (%s) "
                 "than the implementation (%s)."
             )
-            logger.warn(t % (__version__, file_version))
+            logger.warning(t % (__version__, file_version))
 
         return self._decode(f)
 

--- a/imageio/plugins/bsdf.py
+++ b/imageio/plugins/bsdf.py
@@ -226,7 +226,7 @@ class BsdfFormat(Format):
                 while index > self._stream.index:
                     print("skipping one")
                     self._stream.next()
-                image_ob = self._stream.next()
+                image_ob = self._stream.next()  # Can raise StopIteration
             # Is this an image?
             if (
                 isinstance(image_ob, dict)

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -871,7 +871,7 @@ class FfmpegFormat(Format):
             # For Windows, set `shell=True` in sp.Popen to prevent popup
             # of a command line window in frozen applications.
             self._proc = sp.Popen(
-                cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.STDOUT, shell=ISWIN
+                cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=None, shell=ISWIN
             )
             # Warning, directing stderr to a pipe on windows will cause ffmpeg
             # to hang if the buffer is not periodically cleared using

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -871,7 +871,7 @@ class FfmpegFormat(Format):
             # For Windows, set `shell=True` in sp.Popen to prevent popup
             # of a command line window in frozen applications.
             self._proc = sp.Popen(
-                cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=None, shell=ISWIN
+                cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.STDOUT, shell=ISWIN
             )
             # Warning, directing stderr to a pipe on windows will cause ffmpeg
             # to hang if the buffer is not periodically cleared using

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -136,7 +136,7 @@ class PillowFormat(Format):
             )
             # setting mode=None is not the same as just not providing it
             if pilmode is not None:
-                self._kwargs['mode'] = pilmode
+                self._kwargs["mode"] = pilmode
             # Set length
             self._length = 1
             if hasattr(self._im, "n_frames"):
@@ -660,7 +660,6 @@ def ndarray_to_pil(arr, format_str=None):
         arr = image_as_uint(arr, bitdepth=8)
         mode = "L"
         mode_base = "L"
-
 
     if mode == "I;16":
         # Image.fromarray doesn't seem to be compatible with 'I;16' formats

--- a/setup.py
+++ b/setup.py
@@ -252,5 +252,6 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -63,7 +63,7 @@ def test(ctx, unit=False, installed=False, style=False, cover=False):
 
 
 @task
-def black(ctx):
+def autoformat(ctx):
     """ Format the code using the Black uncompromising formatter.
     """
     black_wrapper(True)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -20,6 +20,12 @@ from imageio.core import get_remote_file, IS_PYPY
 test_dir = get_test_dir()
 
 
+if os.getenv("TRAVIS_OS_NAME") == "windows":
+    skip(
+        "Skip this on the Travis Windows run for now, see #408", allow_module_level=True
+    )
+
+
 def setup_module():
     try:
         imageio.plugins.ffmpeg.download()

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -27,6 +27,25 @@ def setup_module():
         pass
 
 
+def test_get_exe_downloaded():
+    need_internet()
+
+    # backup any user-defined path
+    if "IMAGEIO_FFMPEG_EXE" in os.environ:
+        oldpath = os.environ["IMAGEIO_FFMPEG_EXE"]
+    else:
+        oldpath = ""
+    # Test if download works
+    os.environ["IMAGEIO_FFMPEG_EXE"] = ""
+    path = imageio.plugins.ffmpeg.get_exe()
+    # cleanup
+    os.environ.pop("IMAGEIO_FFMPEG_EXE")
+    if oldpath:
+        os.environ["IMAGEIO_FFMPEG_EXE"] = oldpath
+    print(path)
+    assert os.path.isfile(path)
+
+
 def test_get_exe_env():
     # backup any user-defined path
     if "IMAGEIO_FFMPEG_EXE" in os.environ:

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -2,9 +2,17 @@
 """ Tests specific to parsing ffmpeg info.
 """
 
+import os
+from pytest import skip
 from imageio.testing import run_tests_if_main, need_internet
 
 import imageio
+
+
+if os.getenv("TRAVIS_OS_NAME") == "windows":
+    skip(
+        "Skip this on the Travis Windows run for now, see #408", allow_module_level=True
+    )
 
 
 def dedent(text, dedent=8):

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -116,6 +116,12 @@ def test_import_dependencies():
     than the known dependencies.
     """
 
+    # Skip when we know there's more imports
+    if sys.version_info < (3, ):
+        return
+    if os.getenv("TRAVIS") and os.getenv("TEST_FULL"):
+        return
+
     # Get loaded modules when numpy is imported and when imageio is imported
     modnames_ref1 = loaded_modules("numpy", 1, True)
     modnames_ref2 = loaded_modules("PIL", 1, True)
@@ -136,6 +142,13 @@ def test_import_dependencies():
         "tempfile",
         "distutils",
         "urllib",
+        # Apparently needed on CI
+        "uu",
+        "pkgutil",
+        "sysconfig",
+        "plistlib",
+        "quopri",
+        "calendar",
     ]  # discard these
 
     # Remove modules in standard library

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -117,11 +117,12 @@ def test_import_dependencies():
     """
 
     # Get loaded modules when numpy is imported and when imageio is imported
-    modnames_ref = loaded_modules("numpy", 1, True)
+    modnames_ref1 = loaded_modules("numpy", 1, True)
+    modnames_ref2 = loaded_modules("PIL", 1, True)
     modnames_new = loaded_modules("imageio", 1, True)
 
     # Get the difference; what do we import extra?
-    extra_modules = modnames_new.difference(modnames_ref)
+    extra_modules = modnames_new.difference(modnames_ref1).difference(modnames_ref2)
 
     known_modules = [
         "zipfile",

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -117,7 +117,7 @@ def test_import_dependencies():
     """
 
     # Skip when we know there's more imports
-    if sys.version_info < (3, ):
+    if sys.version_info < (3,):
         return
     if os.getenv("TRAVIS") and os.getenv("TEST_FULL"):
         return


### PR DESCRIPTION
* [x] Rename `invoke black` to `invoke autoformat`
* [x] Fix a style error
* [x] Fix for BSDF with unclosed stream
* [x] Run all CI on Travis (also Windows) *well, almost all*
* [x] Travis CI uses just pip (not conda).
* [ ] Stop using appveyor, clean up any of its needs -> Can't do this yet, because have not been able to run the ffmpeg tests on Travis' Windows run, see #408
* [x] Run CI on Python 3.7
* [x] Add 3.7 to Trove classifiers
* [x] Use `importlib.util.find_spec` instead of `importlib.find_loader`