### PR TITLE
Support reading images from memory views

### DIFF
--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -183,14 +183,10 @@ class Request(object):
                 elif len(uri) < 256:  # Can go wrong with veeery tiny images
                     self._uri_type = URI_FILENAME
                     self._filename = uri
-                elif isinstance(uri, (binary_type, memoryview)) and is_read_request:
-                    self._uri_type = URI_BYTES
-                    self._filename = "<bytes>"
-                    self._bytes = uri
                 else:
                     self._uri_type = URI_FILENAME
                     self._filename = uri
-        elif py3k and isinstance(uri, (binary_type, memoryview)) and is_read_request:
+        elif isinstance(uri, (binary_type, memoryview)) and is_read_request:
             self._uri_type = URI_BYTES
             self._filename = "<bytes>"
             self._bytes = uri

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -190,7 +190,7 @@ class Request(object):
                 else:
                     self._uri_type = URI_FILENAME
                     self._filename = uri
-        elif py3k and isinstance(uri, binary_type) and is_read_request:
+        elif py3k and isinstance(uri, (binary_type, memoryview)) and is_read_request:
             self._uri_type = URI_BYTES
             self._filename = "<bytes>"
             self._bytes = uri

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -183,7 +183,7 @@ class Request(object):
                 elif len(uri) < 256:  # Can go wrong with veeery tiny images
                     self._uri_type = URI_FILENAME
                     self._filename = uri
-                elif isinstance(uri, binary_type) and is_read_request:
+                elif isinstance(uri, (binary_type, memoryview)) and is_read_request:
                     self._uri_type = URI_BYTES
                     self._filename = "<bytes>"
                     self._bytes = uri

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -219,7 +219,7 @@ def test_request_read_sources():
     for X in range(2):
 
         # Define uris to test. Define inside loop, since we need fresh files
-        uris = [filename, os.path.join(zipfilename, fname), bytes, open(filename, "rb")]
+        uris = [filename, os.path.join(zipfilename, fname), bytes, memoryview(bytes), open(filename, "rb")]
         if has_inet:
             uris.append(burl + fname)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -219,7 +219,8 @@ def test_request_read_sources():
     for X in range(2):
 
         # Define uris to test. Define inside loop, since we need fresh files
-        uris = [filename, os.path.join(zipfilename, fname), bytes, memoryview(bytes), open(filename, "rb")]
+        uris = [filename, os.path.join(zipfilename, fname),
+                bytes, memoryview(bytes), open(filename, "rb")]
         if has_inet:
             uris.append(burl + fname)
 


### PR DESCRIPTION
Currently reading an image from a buffer (`memoryview(some_bytes)`) fails. This PR aims to support reading memory views.