### PR TITLE
Add keyword parameter to prevent interpreting uint16 arrays as uint8.

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -211,13 +211,9 @@ class PillowFormat(Format):
                 im = im[:, :, 0]
             self._written = True
             self._meta.update(meta)
-            if "prefer_uint8" in self._meta:
-                img = ndarray_to_pil(
-                    im, self.format.plugin_id, self._meta["prefer_uint8"]
-                )
-                del self._meta["prefer_uint8"]
-            else:
-                img = ndarray_to_pil(im, self.format.plugin_id)
+            img = ndarray_to_pil(
+                im, self.format.plugin_id, self._meta.pop("prefer_uint8", True)
+            )
             if "bits" in self._meta:
                 img = img.quantize()  # Make it a P image, so bits arg is used
             img.save(self._fp, format=self.format.plugin_id, **self._meta)

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -211,7 +211,13 @@ class PillowFormat(Format):
                 im = im[:, :, 0]
             self._written = True
             self._meta.update(meta)
-            img = ndarray_to_pil(im, self.format.plugin_id)
+            if "interpret_uint8" in self._meta:
+                img = ndarray_to_pil(
+                    im, self.format.plugin_id, self._meta["interpret_uint8"]
+                )
+                del self._meta["interpret_uint8"]
+            else:
+                img = ndarray_to_pil(im, self.format.plugin_id)
             if "bits" in self._meta:
                 img = img.quantize()  # Make it a P image, so bits arg is used
             img.save(self._fp, format=self.format.plugin_id, **self._meta)
@@ -286,6 +292,11 @@ class PNGFormat(PillowFormat):
         bits. In this case, given as a number between 1-256.
     dictionary (experimental): dict
         Set the ZLIB encoder dictionary.
+    interpret_uint8: bool
+        Let the PNG writer truncate uint16 image arrays to uint8 if their values fall
+        within the range [0, 255]. Defaults to true for legacy compatibility, however
+        it is recommended to set this to false to avoid unexpected behavior when
+        saving e.g. weakly saturated images.
     """
 
     class Reader(PillowFormat.Reader):
@@ -342,6 +353,7 @@ class PNGFormat(PillowFormat):
                 "compress_level",
                 "icc_profile",
                 "dictionary",
+                "interpret_uint8",
             )
             for key in kwargs:
                 if key not in ok_keys:
@@ -639,7 +651,7 @@ def pil_get_frame(im, is_gray=None, as_gray=None, mode=None, dtype=None):
     return frame
 
 
-def ndarray_to_pil(arr, format_str=None):
+def ndarray_to_pil(arr, format_str=None, interpret_uint8=True):
 
     from PIL import Image
 
@@ -654,7 +666,7 @@ def ndarray_to_pil(arr, format_str=None):
         if arr.dtype.kind == "f":
             arr = image_as_uint(arr)
 
-        elif arr.max() < 256 and arr.min() >= 0:
+        elif interpret_uint8 and arr.max() < 256 and arr.min() >= 0:
             arr = arr.astype(np.uint8)
             mode = mode_base = "L"
 

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -211,11 +211,11 @@ class PillowFormat(Format):
                 im = im[:, :, 0]
             self._written = True
             self._meta.update(meta)
-            if "interpret_uint8" in self._meta:
+            if "prefer_uint8" in self._meta:
                 img = ndarray_to_pil(
-                    im, self.format.plugin_id, self._meta["interpret_uint8"]
+                    im, self.format.plugin_id, self._meta["prefer_uint8"]
                 )
-                del self._meta["interpret_uint8"]
+                del self._meta["prefer_uint8"]
             else:
                 img = ndarray_to_pil(im, self.format.plugin_id)
             if "bits" in self._meta:
@@ -292,7 +292,7 @@ class PNGFormat(PillowFormat):
         bits. In this case, given as a number between 1-256.
     dictionary (experimental): dict
         Set the ZLIB encoder dictionary.
-    interpret_uint8: bool
+    prefer_uint8: bool
         Let the PNG writer truncate uint16 image arrays to uint8 if their values fall
         within the range [0, 255]. Defaults to true for legacy compatibility, however
         it is recommended to set this to false to avoid unexpected behavior when
@@ -353,7 +353,7 @@ class PNGFormat(PillowFormat):
                 "compress_level",
                 "icc_profile",
                 "dictionary",
-                "interpret_uint8",
+                "prefer_uint8",
             )
             for key in kwargs:
                 if key not in ok_keys:
@@ -651,7 +651,7 @@ def pil_get_frame(im, is_gray=None, as_gray=None, mode=None, dtype=None):
     return frame
 
 
-def ndarray_to_pil(arr, format_str=None, interpret_uint8=True):
+def ndarray_to_pil(arr, format_str=None, prefer_uint8=True):
 
     from PIL import Image
 
@@ -666,7 +666,7 @@ def ndarray_to_pil(arr, format_str=None, interpret_uint8=True):
         if arr.dtype.kind == "f":
             arr = image_as_uint(arr)
 
-        elif interpret_uint8 and arr.max() < 256 and arr.min() >= 0:
+        elif prefer_uint8 and arr.max() < 256 and arr.min() >= 0:
             arr = arr.astype(np.uint8)
             mode = mode_base = "L"
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -150,7 +150,7 @@ def test_png():
 
     # issue #352 - prevent low-luma uint16 truncation to uint8
     arr = np.full((32, 32), 255, dtype=np.uint16)  # values within range of uint8
-    imageio.imwrite(fnamebase + ".png", arr, interpret_uint8=False)
+    imageio.imwrite(fnamebase + ".png", arr, prefer_uint8=False)
     im = imageio.imread(fnamebase + ".png")
     assert im.dtype == np.uint16
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -150,9 +150,15 @@ def test_png():
 
     # issue #352 - prevent low-luma uint16 truncation to uint8
     arr = np.full((32, 32), 255, dtype=np.uint16)  # values within range of uint8
-    imageio.imwrite(fnamebase + ".png", arr, prefer_uint8=False)
-    im = imageio.imread(fnamebase + ".png")
-    assert im.dtype == np.uint16
+    preferences_dtypes = [
+        [{}, np.uint8],
+        [{"prefer_uint8": True}, np.uint8],
+        [{"prefer_uint8": False}, np.uint16],
+    ]
+    for preference, dtype in preferences_dtypes:
+        imageio.imwrite(fnamebase + ".png", arr, **preference)
+        im = imageio.imread(fnamebase + ".png")
+        assert im.dtype == dtype
 
 
 def test_png_remote():

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -148,6 +148,12 @@ def test_png():
     im2 = imageio.imread(fnamebase + "1.png")
     assert im2.dtype == np.uint16
 
+    # issue #352 - prevent low-luma uint16 truncation to uint8
+    arr = np.full((32, 32), 255, dtype=np.uint16)  # values within range of uint8
+    imageio.imwrite(fnamebase + ".png", arr, interpret_uint8=False)
+    im = imageio.imread(fnamebase + ".png")
+    assert im.dtype == np.uint16
+
 
 def test_png_remote():
     # issue #202


### PR DESCRIPTION
Response to issue #352, better late than never...

When set to False, the new keyword parameter `interpret_uint8` accepted by `imwrite` can be set to false to inhibit the default write behaviour of PNGs whereby np.uint16 image arrays are cast to np.uint8 if their elements are compatible with the latter (i.e. all values fall within the range [0, 255]).

I have perhaps not found the most elegant way to implement this change, but it gets the job done. The indirection provided by the format writer inheritance hierarchy means that propagation of the new keyword parameter to `ndarray_to_pil` needs to go via the parent class `PillowFormat.Writer`. Depending on your approach to such things it might have been nice to be able to specify the default behaviour at the level of `PNGFormat`, however this would be complicated by the fact that `ndarray_to_pil` is a general function used indirectly by all children of `PillowFormat.Writer` and thus requires a default behaviour to be defined at that level or by the function itself. I opted for the latter, with the choice for `PillowFormat.Writer` to only present it with an override if the parameter has been passed in as a keyword argument from `imwrite`.

Basically I've tried to disturb as little of the codebase as possible; please let me know if you would prefer a different approach and I'll be happy to accommodate.