### PR TITLE
Optimise 16-bit PNG write performance for newer versions of Pillow

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -666,7 +666,7 @@ def ndarray_to_pil(arr, format_str=None):
         mode = "L"
         mode_base = "L"
 
-    if mode == "I;16" and int(getattr(Image, "__version__", "0")[0]) < 6:
+    if mode == "I;16" and int(getattr(Image, "__version__", "0").split(".")[0]) < 6:
         # Pillow < v6.0.0 has limited support for the "I;16" mode,
         # requiring us to fall back to this expensive workaround.
         # tobytes actually creates a copy of the image, which is costly.

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -666,9 +666,9 @@ def ndarray_to_pil(arr, format_str=None):
         mode = "L"
         mode_base = "L"
 
-    if mode == "I;16":
-        # Image.fromarray doesn't seem to be compatible with 'I;16' formats
-        # Therefore, we fallback to this expensive workaround.
+    if mode == "I;16" and int(getattr(Image, "__version__", "0")[0]) < 6:
+        # Pillow < v6.0.0 has limited support for the "I;16" mode,
+        # requiring us to fall back to this expensive workaround.
         # tobytes actually creates a copy of the image, which is costly.
         array_buffer = arr.tobytes()
         if arr.ndim == 2:


### PR DESCRIPTION
Pillow [PR #3566](https://github.com/python-pillow/Pillow/pull/3566) / release v6.0.0 improves support for I;16, allowing us to only fall back to the original tobytes workaround for older versions.

Tested with Pillow 5.4.1 (triggering workaround as before) and 6.0.0 (I;16 / arrays with dtype np.uint16 are correctly handled using Image.fromarray).

**Fluffy justification for future reference:**
Pillow doesn't seem to advertise the improved support for I;16 (besides changes to a C extension, the only trace is in a protected dictionary), so in favour of a duck test I've added a version test to the condition deciding whether apply our existing tobytes workaround. While generally the preferred way to compare versions would be to use `packaging.version`, in this case I would argue that it's fine to avoid pulling in that dependency and casting instead, since we're only concerned with the major version (had support been added in e.g. 6.0.1 things would have been different...). Finally, the need for using `getattr` with a dummy fall back comes as a consequence of Pillow's recent change of version variables; `__version__` is future-proof but was only introduced around 5.2.0, while the former `PILLOW_VERSION` has since been deprecated.
