### PR TITLE
user-defined size for memtest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ matrix:
       sudo: true
       python: "3.8-dev"
       env: TEST_UNIT=1
+  allow_failures:
+    - python: "3.8-dev"
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ matrix:
       python: "3.8-dev"
       env: TEST_UNIT=1
   allow_failures:
+    # future compatibility is nice,
+    # but a failure here shouldn't break the build until released
     - python: "3.8-dev"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,14 @@ matrix:
       python: "3.6"
       env: TEST_UNIT=1 TEST_COVER=1
     - os: linux
-      python: "3.7-dev"
+      dist: xenial
+      sudo: true
+      python: "3.7"
+      env: TEST_UNIT=1
+    - os: linux
+      dist: xenial
+      sudo: true
+      python: "3.8-dev"
       env: TEST_UNIT=1
 
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Python 2.7 and 3.4+, and is easy to install.
 Here's a minimal example of how to use imageio. See the docs for 
 <a href='http://imageio.readthedocs.io/en/latest/examples.html'>more examples</a>.
 <pre>
->>> import imageio
->>> im = imageio.imread('imageio:chelsea.png')  # read a standard image
->>> im.shape  # im is a numpy array
-(300, 451, 3)
->>> imageio.imwrite('~/chelsea-gray.jpg', im[:, :, 0])
+import imageio
+im = imageio.imread('imageio:chelsea.png')  # read a standard image
+im.shape  # im is a numpy array
+>> (300, 451, 3)
+imageio.imwrite('~/chelsea-gray.jpg', im[:, :, 0])
 </pre>
 
 <h2>API in a nutshell</h2>
@@ -127,25 +127,25 @@ one or more plugins. In that way, the burden of each developer is low,
 and together we can make imageio into a really useful library!
 </p>
 
+<h2>Contributing</h2>
 
-## Contributing
+<p>Install a complete development environment:</p>
 
-Install a complete development environment:
-
-```bash
+<pre>
 pip install -r requirements.txt
 pip install -e .
-```
+</pre>
 
-*N.B. this does not include GDAL because it has awkward compiled dependencies*
+<p><i>N.B. this does not include GDAL because it has awkward compiled dependencies</i></p>
 
-You may see failing test(s) due to missing installed components.
-On ubuntu, do `sudo apt install libfreeimage3`
+<p>You may see failing test(s) due to missing installed components.
+On ubuntu, do <code>sudo apt install libfreeimage3</code></p>
 
-Style checks, unit tests and coverage are controlled by `invoke`.
-Before committing, check these with:
+<p>
+Style checks, unit tests and coverage are controlled by <code>invoke</code>.
+Before committing, check these with:</p>
 
-```bash
+<pre>
 # reformat code on python 3.6+
 invoke autoformat
 # check there are no style errors
@@ -154,4 +154,4 @@ invoke test --style
 invoke test --unit
 # check test coverage (re-runs tests)
 invoke test --cover
-```
+</pre>

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Optional Python packages:
     <li>itk or SimpleITK (for ITK formats)</li>
     <li>astropy (for FITS plugin)</li>
     <li>osgeo (for GDAL plugin)</li>
-</ul>  
+</ul>
 
 
 <h2>Origin and outlook</h2>
@@ -126,3 +126,32 @@ It is our hope to form a group of developers, whom each maintain
 one or more plugins. In that way, the burden of each developer is low,
 and together we can make imageio into a really useful library!
 </p>
+
+
+## Contributing
+
+Install a complete development environment:
+
+```bash
+pip install -r requirements.txt
+pip install -e .
+```
+
+*N.B. this does not include GDAL because it has awkward compiled dependencies*
+
+You may see failing test(s) due to missing installed components.
+On ubuntu, do `sudo apt install libfreeimage3`
+
+Style checks, unit tests and coverage are controlled by `invoke`.
+Before committing, check these with:
+
+```bash
+# reformat code on python 3.6+
+invoke autoformat
+# check there are no style errors
+invoke test --style
+# check the tests pass
+invoke test --unit
+# check test coverage (re-runs tests)
+invoke test --cover
+```

--- a/imageio/core/functions.py
+++ b/imageio/core/functions.py
@@ -89,7 +89,7 @@ MEMTEST_DEFAULT_MIM = "256MB"
 MEMTEST_DEFAULT_MVOL = "1GB"
 
 
-mem_re = re.compile(r"^([\d.]+)\s*([kKMGTPEZY]*i?[bB])?$")
+mem_re = re.compile(r"^(\d+\.?\d*)\s*([kKMGTPEZY]?i?[bB])?$")
 sizes = {"": 1, None: 1}
 for i, si in enumerate([""] + list("kMGTPEZY")):
     for b, divisor in [("b", 8), ("B", 1)]:
@@ -355,9 +355,9 @@ def mimread(uri, format=None, memtest=MEMTEST_DEFAULT_MIM, **kwargs):
         if nbyte_limit and nbytes > nbyte_limit:
             ims[:] = []  # clear to free the memory
             raise RuntimeError(
-                "imageio.mimread() has read over 256 MiB of "
+                "imageio.mimread() has read over {}B of "
                 "image data.\nStopped to avoid memory problems."
-                " Use imageio.get_reader() or memtest=False."
+                " Use imageio.get_reader() or memtest=False.".format(nbyte_limit)
             )
 
     return ims
@@ -532,9 +532,9 @@ def mvolread(uri, format=None, memtest=MEMTEST_DEFAULT_MVOL, **kwargs):
         if nbyte_limit and nbytes > nbyte_limit:  # pragma: no cover
             ims[:] = []  # clear to free the memory
             raise RuntimeError(
-                "imageio.mvolread() has read over 1 GiB of "
+                "imageio.mvolread() has read over {}B of "
                 "image data.\nStopped to avoid memory problems."
-                " Use imageio.get_reader() or memtest=False."
+                " Use imageio.get_reader() or memtest=False.".format(nbyte_limit)
             )
 
     return ims

--- a/imageio/core/functions.py
+++ b/imageio/core/functions.py
@@ -89,20 +89,20 @@ MEMTEST_DEFAULT_MIM = "256MB"
 MEMTEST_DEFAULT_MVOL = "1GB"
 
 
-mem_re = re.compile(r"^(\d+\.?\d*)\s*([kKMGTPEZY]?i?[bB])?$")
+mem_re = re.compile(r"^(\d+\.?\d*)\s*([kKMGTPEZY]?i?)B?$")
 sizes = {"": 1, None: 1}
 for i, si in enumerate([""] + list("kMGTPEZY")):
-    for b, divisor in [("b", 8), ("B", 1)]:
-        sizes[si + b] = 1000 ** i / divisor
-        sizes[si.upper() + "i" + b] = 1024 ** i / divisor
+    sizes[si] = 1000 ** i
+    if si:
+        sizes[si.upper() + "i"] = 1024 ** i
 
 
 def to_nbytes(arg, default=None):
-    if arg is True:
-        arg = default
-
     if not arg:
         return None
+
+    if arg is True:
+        return default
 
     if isinstance(arg, Number):
         return arg
@@ -324,17 +324,25 @@ def mimread(uri, format=None, memtest=MEMTEST_DEFAULT_MIM, **kwargs):
     format : str
         The format to use to read the file. By default imageio selects
         the appropriate for you based on the filename and its contents.
-    memtest : {int, float, str}
+    memtest : {bool, int, float, str}
         If truthy, this function will raise an error if the resulting
         list of images consumes greater than the amount of memory specified.
         This is to protect the system from using so much memory that it needs
         to resort to swapping, and thereby stall the computer. E.g.
         ``mimread('hunger_games.avi')``.
+
         If the argument is a number, that will be used as the threshold number
         of bytes.
-        If the argument is a string, it will be interpreted as a memory size with
-        units (e.g. '1kB', '250MiB', '80Yb'). This is case-sensitive.
-        If True, resort to the default (for compatibility reasons).
+
+        If the argument is a string, it will be interpreted as a number of bytes with
+        SI/IEC prefixed units (e.g. '1kB', '250MiB', '80.3YB').
+
+        - Units are case sensitive
+        - k, M etc. represent a 1000-fold change, where Ki, Mi etc. represent 1024-fold
+        - The "B" is optional, but if present, must be capitalised
+
+        If the argument is True, the default will be used, for compatibility reasons.
+
         Default: '256MB'
     kwargs : ...
         Further keyword arguments are passed to the reader. See :func:`.help`
@@ -357,7 +365,9 @@ def mimread(uri, format=None, memtest=MEMTEST_DEFAULT_MIM, **kwargs):
             raise RuntimeError(
                 "imageio.mimread() has read over {}B of "
                 "image data.\nStopped to avoid memory problems."
-                " Use imageio.get_reader() or memtest=False.".format(nbyte_limit)
+                " Use imageio.get_reader(), increase threshold, or memtest=False".format(
+                    int(nbyte_limit)
+                )
             )
 
     return ims
@@ -502,17 +512,25 @@ def mvolread(uri, format=None, memtest=MEMTEST_DEFAULT_MVOL, **kwargs):
     format : str
         The format to use to read the file. By default imageio selects
         the appropriate for you based on the filename and its contents.
-    memtest : {int, float, str}
+    memtest : {bool, int, float, str}
         If truthy, this function will raise an error if the resulting
         list of images consumes greater than the amount of memory specified.
         This is to protect the system from using so much memory that it needs
         to resort to swapping, and thereby stall the computer. E.g.
         ``mimread('hunger_games.avi')``.
+
         If the argument is a number, that will be used as the threshold number
         of bytes.
-        If the argument is a string, it will be interpreted as a memory size with
-        units (e.g. '1kB', '250MiB', '80Yb'). This is case-sensitive.
-        If True, resort to the default (for compatibility reasons).
+
+        If the argument is a string, it will be interpreted as a number of bytes with
+        SI/IEC prefixed units (e.g. '1kB', '250MiB', '80.3YB').
+
+        - Units are case sensitive
+        - k, M etc. represent a 1000-fold change, where Ki, Mi etc. represent 1024-fold
+        - The "B" is optional, but if present, must be capitalised
+
+        If the argument is True, the default will be used, for compatibility reasons.
+
         Default: '1GB'
     kwargs : ...
         Further keyword arguments are passed to the reader. See :func:`.help`
@@ -534,7 +552,9 @@ def mvolread(uri, format=None, memtest=MEMTEST_DEFAULT_MVOL, **kwargs):
             raise RuntimeError(
                 "imageio.mvolread() has read over {}B of "
                 "image data.\nStopped to avoid memory problems."
-                " Use imageio.get_reader() or memtest=False.".format(nbyte_limit)
+                " Use imageio.get_reader(), increase threshold, or memtest=False".format(
+                    int(nbyte_limit)
+                )
             )
 
     return ims

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,20 @@
 # core
+
 numpy
 pillow
 enum34; python_version < "3.4"
 futures; python_version < "3.2"
 pathlib; python_version < "3.0"
+
 # extras
+
 astropy
 # gdal
 simpleitk
 imageio-ffmpeg
+
 # development
+
 invoke
 pytest
 pytest-cov
@@ -17,6 +22,8 @@ coveralls
 psutil
 flake8
 black; python_version >= "3.6"
+
 # docs
+
 sphinx
 numpydoc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# core
+numpy
+pillow
+enum34; python_version < "3.4"
+futures; python_version < "3.2"
+pathlib; python_version < "3.0"
+# extras
+astropy
+# gdal
+simpleitk
+imageio-ffmpeg
+# development
+invoke
+pytest
+pytest-cov
+coveralls
+psutil
+flake8
+black; python_version >= "3.6"
+# docs
+sphinx
+numpydoc

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -628,10 +628,10 @@ def test_functions():
     [
         (1, 1),
         ("1", 1),
-        ("8b", 1),
         ("8B", 8),
         ("1MB", 1000 ** 2),
-        ("1Gib", 1024 ** 3 / 8),
+        ("1M", 1000 ** 2),
+        ("1GiB", 1024 ** 3),
         ("1.5TB", 1.5 * 1000 ** 4),
     ],
 )
@@ -640,7 +640,7 @@ def test_to_nbytes_correct(arg, expected):
     assert n == expected
 
 
-@pytest.mark.parametrize("arg", ["1mb", "1Giib", "GB", "1M", "1.3.2TB"])
+@pytest.mark.parametrize("arg", ["1mb", "1Giib", "GB", "1.3.2TB", "8b"])
 def test_to_nbytes_incorrect(arg):
     with raises(ValueError):
         to_nbytes(arg)
@@ -648,13 +648,19 @@ def test_to_nbytes_incorrect(arg):
 
 def test_memtest():
     fname3 = get_remote_file("images/newtonscradle.gif", test_dir)
-    imageio.mimread(fname3, memtest=True)
-    imageio.mimread(fname3, memtest=False)
+    imageio.mimread(fname3)  # trivial case
     imageio.mimread(fname3, memtest=1000 ** 2 * 256)
     imageio.mimread(fname3, memtest="256MB")
+    imageio.mimread(fname3, memtest="256M")
+    imageio.mimread(fname3, memtest="256MiB")
+
+    # low limit should be hit
     with raises(RuntimeError):
         imageio.mimread(fname3, memtest=10)
     with raises(RuntimeError):
+        imageio.mimread(fname3, memtest="64B")
+
+    with raises(ValueError):
         imageio.mimread(fname3, memtest="64b")
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -632,6 +632,7 @@ def test_functions():
         ("8B", 8),
         ("1MB", 1000 ** 2),
         ("1Gib", 1024 ** 3 / 8),
+        ("1.5TB", 1.5 * 1000 ** 4),
     ],
 )
 def test_to_nbytes_correct(arg, expected):
@@ -639,7 +640,7 @@ def test_to_nbytes_correct(arg, expected):
     assert n == expected
 
 
-@pytest.mark.parametrize("arg", ["1mb", "1Giib", "GB", "1M"])
+@pytest.mark.parametrize("arg", ["1mb", "1Giib", "GB", "1M", "1.3.2TB"])
 def test_to_nbytes_incorrect(arg):
     with raises(ValueError):
         to_nbytes(arg)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,8 +10,11 @@ from zipfile import ZipFile
 from io import BytesIO
 
 import numpy as np
+import pytest
 
 from pytest import raises, skip
+
+from imageio.core.functions import to_nbytes
 from imageio.testing import run_tests_if_main, get_test_dir, need_internet
 
 import imageio
@@ -618,6 +621,40 @@ def test_functions():
     raises(ValueError, imageio.volsave, fname6, 42)
     raises(ValueError, imageio.mvolsave, fname6, [np.zeros((90, 90, 90, 40))])
     raises(ValueError, imageio.mvolsave, fname6, [42])
+
+
+@pytest.mark.parametrize(
+    "arg,expected",
+    [
+        (1, 1),
+        ("1", 1),
+        ("8b", 1),
+        ("8B", 8),
+        ("1MB", 1000 ** 2),
+        ("1Gib", 1024 ** 3 / 8),
+    ],
+)
+def test_to_nbytes_correct(arg, expected):
+    n = to_nbytes(arg)
+    assert n == expected
+
+
+@pytest.mark.parametrize("arg", ["1mb", "1Giib", "GB", "1M"])
+def test_to_nbytes_incorrect(arg):
+    with raises(ValueError):
+        to_nbytes(arg)
+
+
+def test_memtest():
+    fname3 = get_remote_file("images/newtonscradle.gif", test_dir)
+    imageio.mimread(fname3, memtest=True)
+    imageio.mimread(fname3, memtest=False)
+    imageio.mimread(fname3, memtest=1000 ** 2 * 256)
+    imageio.mimread(fname3, memtest="256MB")
+    with raises(RuntimeError):
+        imageio.mimread(fname3, memtest=10)
+    with raises(RuntimeError):
+        imageio.mimread(fname3, memtest="64b")
 
 
 def test_example_plugin():


### PR DESCRIPTION
Allows callers to define the size limit where they want memtest to raise an error. Retains compatibility with `True`/`False`, and interprets either a number of bytes, or a string e.g. "256MB", "10.2Yib".

Includes tests.