### PR TITLE
Fixed bug in image_as_uint

### DIFF
--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -119,7 +119,7 @@ def image_as_uint(im, bitdepth=None):
         if not np.isfinite(ma):
             raise ValueError("Maximum image value is not finite")
         if ma == mi:
-             return im.astype(out_type) 
+             return im.astype(out_type)
         _precision_warn(dtype_str1, dtype_str2, "Range [{}, {}].".format(mi, ma))
         # Now make float copy before we scale
         im = im.astype("float64")

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -91,7 +91,7 @@ def image_as_uint(im, bitdepth=None):
     ):
         # Already the correct format? Return as-is
         return im
-    if im.sum() == 0:
+    if np.all(im == 0):
         return im.astype(out_type)
     if dtype_str1.startswith("float") and np.nanmin(im) >= 0 and np.nanmax(im) <= 1:
         _precision_warn(dtype_str1, dtype_str2, "Range [0, 1].")

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -119,10 +119,7 @@ def image_as_uint(im, bitdepth=None):
         if not np.isfinite(ma):
             raise ValueError("Maximum image value is not finite")
         if ma == mi:
-            if np.all(im == ma): 
-                return im.astype(out_type)
-            else:
-                raise ValueError("Max value == min value, ambiguous given dtype")
+             return im.astype(out_type) 
         _precision_warn(dtype_str1, dtype_str2, "Range [{}, {}].".format(mi, ma))
         # Now make float copy before we scale
         im = im.astype("float64")

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -91,8 +91,6 @@ def image_as_uint(im, bitdepth=None):
     ):
         # Already the correct format? Return as-is
         return im
-    if np.all(im == 0):
-        return im.astype(out_type)
     if dtype_str1.startswith("float") and np.nanmin(im) >= 0 and np.nanmax(im) <= 1:
         _precision_warn(dtype_str1, dtype_str2, "Range [0, 1].")
         im = im.astype(np.float64) * (np.power(2.0, bitdepth) - 1) + 0.499999999
@@ -121,7 +119,10 @@ def image_as_uint(im, bitdepth=None):
         if not np.isfinite(ma):
             raise ValueError("Maximum image value is not finite")
         if ma == mi:
-            raise ValueError("Max value == min value, ambiguous given dtype")
+            if np.all(im == ma): 
+                return im.astype(out_type)
+            else:
+                raise ValueError("Max value == min value, ambiguous given dtype")
         _precision_warn(dtype_str1, dtype_str2, "Range [{}, {}].".format(mi, ma))
         # Now make float copy before we scale
         im = im.astype("float64")

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -119,7 +119,7 @@ def image_as_uint(im, bitdepth=None):
         if not np.isfinite(ma):
             raise ValueError("Maximum image value is not finite")
         if ma == mi:
-             return im.astype(out_type)
+            return im.astype(out_type)
         _precision_warn(dtype_str1, dtype_str2, "Range [{}, {}].".format(mi, ma))
         # Now make float copy before we scale
         im = im.astype("float64")

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -91,6 +91,8 @@ def image_as_uint(im, bitdepth=None):
     ):
         # Already the correct format? Return as-is
         return im
+    if im.sum() == 0:
+        return im.astype(out_type)
     if dtype_str1.startswith("float") and np.nanmin(im) >= 0 and np.nanmax(im) <= 1:
         _precision_warn(dtype_str1, dtype_str2, "Range [0, 1].")
         im = im.astype(np.float64) * (np.power(2.0, bitdepth) - 1) + 0.499999999

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -441,7 +441,6 @@ def test_util_image_as_uint():
     raises(ValueError, core.image_as_uint, 4)
     raises(ValueError, core.image_as_uint, "not an image")
     raises(ValueError, core.image_as_uint, np.array([0, 1]), bitdepth=13)
-    raises(ValueError, core.image_as_uint, np.array([2.0, 2.0], "float32"))
     raises(ValueError, core.image_as_uint, np.array([0.0, np.inf], "float32"))
     raises(ValueError, core.image_as_uint, np.array([-np.inf, 0.0], "float32"))
 


### PR DESCRIPTION
There's a bug in image_as_uint that causes imsave to crash if you try to save an image of all 0's and the datatype isn't unit8 or uint16.

You can easily test this:
`import imageio as io`
`img = np.zeros((256,256), dtype=np.int32)`
`io.imsave("test.png",img)`