### PR TITLE
Add support for compressed FITS images

### DIFF
--- a/imageio/plugins/fits.py
+++ b/imageio/plugins/fits.py
@@ -94,11 +94,7 @@ class FitsFormat(Format):
             hdulist = _fits.open(self.request.get_file(), cache=cache, **kwargs)
 
             self._index = []
-            allowed_hdu_types = (
-                _fits.ImageHDU,
-                _fits.PrimaryHDU,
-                _fits.CompImageHDU
-            )
+            allowed_hdu_types = (_fits.ImageHDU, _fits.PrimaryHDU, _fits.CompImageHDU)
             for n, hdu in zip(range(len(hdulist)), hdulist):
                 if isinstance(hdu, allowed_hdu_types):
                     # Ignore (primary) header units with no data (use '.size'

--- a/imageio/plugins/fits.py
+++ b/imageio/plugins/fits.py
@@ -94,8 +94,13 @@ class FitsFormat(Format):
             hdulist = _fits.open(self.request.get_file(), cache=cache, **kwargs)
 
             self._index = []
+            allowed_hdu_types = (
+                _fits.ImageHDU,
+                _fits.PrimaryHDU,
+                _fits.CompImageHDU
+            )
             for n, hdu in zip(range(len(hdulist)), hdulist):
-                if isinstance(hdu, _fits.ImageHDU) or isinstance(hdu, _fits.PrimaryHDU):
+                if isinstance(hdu, allowed_hdu_types):
                     # Ignore (primary) header units with no data (use '.size'
                     # rather than '.data' to avoid actually loading the image):
                     if hdu.size > 0:
@@ -123,6 +128,6 @@ class FitsFormat(Format):
 
 # Register
 format = FitsFormat(
-    "fits", "Flexible Image Transport System (FITS) format", "fits fit fts", "iIvV"
+    "fits", "Flexible Image Transport System (FITS) format", "fits fit fts fz", "iIvV"
 )
 formats.add_format(format)

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -51,6 +51,7 @@ def test_fits_reading():
 
     simple = get_remote_file("images/simple.fits")
     multi = get_remote_file("images/multi.fits")
+    compressed = get_remote_file("images/compressed.fits.fz")
 
     # One image
     im = imageio.imread(simple)
@@ -73,6 +74,10 @@ def test_fits_reading():
     raises(IndexError, R.get_data, 3)
     raises(RuntimeError, R.get_meta_data, None)  # no meta data support
     raises(RuntimeError, R.get_meta_data, 0)  # no meta data support
+
+    # Compressed image
+    im = imageio.imread(compressed)
+    assert im.shape == (2042, 3054)
 
 
 run_tests_if_main()


### PR DESCRIPTION
Compressed FITS files, commonly named `*.fits.fz`, cannot currently be
loaded with the FITS plugin, but they are supported by astropy. See the [astropy documention on compressed image date in FITS](https://docs.astropy.org/en/stable/io/fits/usage/unfamiliar.html#compressed-image-data).

This commit adds support for loading compressed images.

If there is interest in merging this, I can add a compressed file to imageio-binaries and add a test.