### PR TITLE
Fix false-positive zip detection

### DIFF
--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -201,12 +201,15 @@ class Request(object):
                 zip_i = self._filename.lower().find(needle)
                 if zip_i > 0:
                     zip_i += 4
-                    self._uri_type = URI_ZIPPED
-                    self._filename_zip = (
-                        self._filename[:zip_i],
-                        self._filename[zip_i:].lstrip("/\\"),
-                    )
-                    break
+                    zip_path = self._filename[:zip_i]
+                    if is_write_request or os.path.isfile(zip_path):
+                        self._uri_type = URI_ZIPPED
+
+                        self._filename_zip = (
+                            zip_path,
+                            self._filename[zip_i:].lstrip("/\\"),
+                        )
+                        break
 
         # Check if we could read it
         if self._uri_type is None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,7 @@ import shutil
 import ctypes.util
 from zipfile import ZipFile
 from io import BytesIO
+import tempfile
 
 import numpy as np
 import pytest
@@ -199,6 +200,17 @@ def test_request():
     R = Request("imageio:chelsea.zip/chelsea.png", "ri")
     assert R._filename_zip[0] == get_remote_file("images/chelsea.zip")
     assert R.filename == get_remote_file("images/chelsea.zip") + "/chelsea.png"
+
+    # Test zip false-positive detection
+    with tempfile.TemporaryDirectory() as tmp_path:
+        bait_zip = os.path.join(tmp_path, "test.zip")
+        os.mkdir(bait_zip)
+        file_path = os.path.join(bait_zip, "foo.jpg")
+        chelsia = get_remote_file("images/chelsea.png")
+        shutil.copy(chelsia, file_path)
+
+        R = Request(file_path, "ri")
+        assert R._uri_type == core.request.URI_FILENAME
 
 
 def test_request_read_sources():


### PR DESCRIPTION
Fix bug with false-positive zip detection when some directory in path contains `.zip` suffix in its name.
Add test case for that. It fails on current upstream master