### PR TITLE
Allow setting timeout for http/ftp requests through environment

### DIFF
--- a/docs/envvariables.rst
+++ b/docs/envvariables.rst
@@ -18,5 +18,7 @@ for the current Python process use
 * ``IMAGEIO_FORMAT_ORDER``: Determine format preference. E.g. setting this
   to ``"TIFF, -FI"`` will prefer the FreeImage plugin over the Pillow plugin,
   but still prefer TIFF over that. Also see the ``formats.sort()`` method.
+* ``IMAGEIO_REQUEST_TIMEOUT``: Set the timeout of http/ftp request in seconds.
+  If not set, this defaults to 5 seconds.
 * ``IMAGEIO_USERDIR``: Set the path to the default user directory. If not
   given, imageio will try ``~`` and if that's not available ``/var/tmp``.

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -344,7 +344,10 @@ class Request(object):
 
         elif self._uri_type in [URI_HTTP or URI_FTP]:
             assert not want_to_write  # This should have been tested in init
-            self._file = urlopen(self.filename, timeout=5)
+            timeout = os.getenv('IMAGEIO_REQUEST_TIMEOUT')
+            if timeout is None or not timeout.isdigit():
+                timeout = 5
+            self._file = urlopen(self.filename, timeout=float(timeout))
             self._file = SeekableFileObject(self._file)
 
         return self._file


### PR DESCRIPTION
Hello devs,

as pointed out in https://github.com/imageio/imageio/issues/533, sometimes it makes sense to set the socket timeout for http/ftp requests.
Allow setting timeout for http/ftp requests through environment so that the following is possible:

```
import imageio

def unsplash_image_generator():
    os.environ['IMAGEIO_REQUEST_TIMEOUT'] = '3'
    while True:
        try:
            image = imageio.imread('https://source.unsplash.com/random')
        except OSError as e:
            print("Error fetching random unsplash image: ", e)
        else:
            yield image
```

I don't know if this is the best option to allow setting the timeout by the user.

Another solution could be:
```
Author: Johann Neuhauser <johann@it-neuhauser.de>
Date:   Tue Jun 9 10:43:31 2020 +0200

    Allow setting timeout for http/ftp requests through **kwargs

diff --git a/imageio/core/request.py b/imageio/core/request.py
index dbd455b..77b77ee 100644
--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -344,7 +344,11 @@ class Request(object):
 
         elif self._uri_type in [URI_HTTP or URI_FTP]:
             assert not want_to_write  # This should have been tested in init
-            self._file = urlopen(self.filename, timeout=5)
+            if 'timeout' in self._kwargs:
+                timeout = self._kwargs['timeout']
+            else:
+                timeout = 5
+            self._file = urlopen(self.filename, timeout=timeout)
             self._file = SeekableFileObject(self._file)
 
         return self._file
```
