### PR TITLE
Replaced camera.png due to copyright issue

### DIFF
--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -35,7 +35,7 @@ RETURN_BYTES = "<bytes>"
 # Example images that will be auto-downloaded
 EXAMPLE_IMAGES = {
     "astronaut.png": "Image of the astronaut Eileen Collins",
-    "camera.png": "Classic grayscale image of a photographer",
+    "camera.png": "A grayscale image of a photographer",
     "checkerboard.png": "Black and white image of a chekerboard",
     "wood.jpg": "A (repeatable) texture of wooden planks",
     "bricks.jpg": "A (repeatable) texture of stone bricks",


### PR DESCRIPTION
Closes #452

Replacement happened in [this commit](https://github.com/imageio/imageio-binaries/commit/42393619bfeaf3a4c767788a53f76c4a464246f8) in the imageio-binaries repo.

This is a PR to match that, trigger CI just in case, and tweak the description of the image.