### PR TITLE
More reliable tiff reading as volume

### DIFF
--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -244,7 +244,10 @@ class TiffFormat(Format):
                 # Read data as single 3D (+ color channels) array
                 if index != 0:
                     raise IndexError('Tiff support no more than 1 "volume" per file')
-                im = self._tf.asarray()  # request as singleton image
+                # There is self._tf.asarray(), but it picks the first series by
+                # default, so this seems more reliable. See #558.
+                ims = [p.asarray() for p in self._tf.pages]
+                im = np.stack(ims, 0)
                 meta = self._meta
             else:
                 # Read as 2D image

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -246,8 +246,9 @@ class TiffFormat(Format):
                     raise IndexError('Tiff support no more than 1 "volume" per file')
                 # There is self._tf.asarray(), but it picks the first series by
                 # default, so this seems more reliable. See #558.
+                number_of_slices = len(self._tf.pages)
                 ims = []
-                for i in range(len(self._tf.pages)):
+                for i in range(number_of_slices):
                     im = self._tf.pages[i].asarray()
                     if ims and ims[0].shape != im.shape:
                         break

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -246,8 +246,16 @@ class TiffFormat(Format):
                     raise IndexError('Tiff support no more than 1 "volume" per file')
                 # There is self._tf.asarray(), but it picks the first series by
                 # default, so this seems more reliable. See #558.
-                ims = [p.asarray() for p in self._tf.pages]
-                im = np.stack(ims, 0)
+                ims = []
+                for i in range(len(self._tf.pages)):
+                    im = self._tf.pages[i].asarray()
+                    if ims and ims[0].shape != im.shape:
+                        break
+                    ims.append(im)
+                if ims:
+                    im = np.stack(ims, 0)
+                else:
+                    im = self._tf.asarray()
                 meta = self._meta
             else:
                 # Read as 2D image


### PR DESCRIPTION
Closes #558 

By default a `TiffFile.as_array()` selects all data from the current series. So if there are multiple series, only the first is selected,