### PR TITLE
tifffile plugin: Various fixes

### DIFF
--- a/imageio/plugins/feisem.py
+++ b/imageio/plugins/feisem.py
@@ -52,6 +52,9 @@ class FEISEMFormat(TiffFormat):
             metadata : dict
                 Dictionary of metadata.
             """
+            if hasattr(self, "_fei_meta"):
+                return self._fei_meta
+
             md = {"root": {}}
             current_tag = "root"
             reading_metadata = False
@@ -80,7 +83,8 @@ class FEISEMFormat(TiffFormat):
                             md[current_tag][key] = val
             if not md["root"] and len(md) == 1:
                 raise ValueError("Input file %s contains no FEI metadata." % filename)
-            self._meta.update(md)
+
+            self._fei_meta = md
             return md
 
 

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -325,7 +325,12 @@ class TiffFormat(Format):
                 meta["software"] = self._software
             # No need to check self.request.mode; tifffile figures out whether
             # this is a single page, or all page data at once.
-            self._tf.save(np.asanyarray(im), contiguous=False, **meta)
+            try:
+                # TiffWriter.save has been deprecated in version 2020.9.30
+                write_meth = self._tf.write
+            except AttributeError:
+                write_meth = self._tf.save
+            write_meth(np.asanyarray(im), contiguous=False, **meta)
             self._frames_written += 1
 
         @staticmethod

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -325,7 +325,7 @@ class TiffFormat(Format):
                 meta["software"] = self._software
             # No need to check self.request.mode; tifffile figures out whether
             # this is a single page, or all page data at once.
-            self._tf.save(np.asanyarray(im), **meta)
+            self._tf.save(np.asanyarray(im), contiguous=False, **meta)
             self._frames_written += 1
 
         @staticmethod


### PR DESCRIPTION
`Reader.get_meta_data(i)` already worked correctly, but `Reader.get_data(i).meta` contained the result of the last call to `Reader.get_meta_data` regardless of `i`.

`Writer.append_data(img, meta)` set the global metadata to `meta`, which was also not what I would expect.

Here is a possible fix which hopefully does not break anything. With this, any frame written to a file using `append_data(…, meta=None)` will have the global metadata associated with it. This is debatable but resembles the old behavior. The alternative would be to write the global metadata only for frame 0 and no metadata for other frames unless explicitly given—which I think would actually make more sense.