### PR TITLE
SPE plugin: Read metadata from SDT-control software

### DIFF
--- a/imageio/plugins/spe.py
+++ b/imageio/plugins/spe.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from datetime import datetime
 import logging
 import os
-from typing import Dict, Mapping, Sequence, Union
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Union
 
 import numpy as np
 
@@ -169,12 +169,23 @@ class SDTControlSpec:
         "SEAR": "arbitrary"
     }
 
-    # n: Which of the 5 comment fields to use
-    # slice: Which characters from the selected comment
-    # cvt: Callable to convert characters to something useful
-    # scale (optional): Scaling factor for numbers
-    CommentDesc = namedtuple("CommendDesc", ["n", "slice", "cvt", "scale"],
-                             defaults=[None])
+    class CommentDesc:
+        """Describe how to extract a metadata entry from a comment string"""
+        n: int
+        """Which of the 5 SPE comment fields to use."""
+        slice: slice
+        """Which characters from the `n`-th comment to use."""
+        cvt: Callable[[str], Any]
+        """How to convert characters to something useful."""
+        scale: Union[None, float]
+        """Optional scaling factor for numbers"""
+        def __init__(self, n: int, slice: slice,
+                     cvt: Callable[[str], Any] = str,
+                     scale: Optional[float] = None):
+            self.n = n
+            self.slice = slice
+            self.cvt = cvt
+            self.scale = scale
 
     comments = {
         "sdt_major_version": CommentDesc(4, slice(66, 68), int),

--- a/tests/test_spe.py
+++ b/tests/test_spe.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import numpy as np
 import pytest
 
@@ -38,7 +40,7 @@ def test_spe_reading():
     np.testing.assert_equal(vols, [[fr1, fr2]])
 
     # Test get_reader
-    r = imageio.get_reader(fname)
+    r = imageio.get_reader(fname, sdt_meta=False)
 
     np.testing.assert_equal(r.get_data(1), fr2)
     np.testing.assert_equal(list(r), [fr1, fr2])
@@ -64,6 +66,20 @@ def test_spe_reading():
     ]
     assert md["comments"] == cmt
     np.testing.assert_equal(md["frame_shape"], fr1.shape)
+
+    # Check reading SDT-control metadata
+    with imageio.get_reader(fname) as r2:
+        sdt_meta = r2.get_meta_data()
+
+    assert sdt_meta["delay_shutter"] == pytest.approx(0.001)
+    assert sdt_meta["delay_macro"] == pytest.approx(0.048)
+    assert sdt_meta["exposure_time"] == pytest.approx(0.002)
+    assert sdt_meta["comment"] == "OD 1.0 in r, g"
+    assert sdt_meta["datetime"] == datetime(2018, 7, 2, 9, 46, 15)
+    assert sdt_meta["sdt_major_version"] == 2
+    assert sdt_meta["sdt_minor_version"] == 18
+    assert isinstance(sdt_meta["modulation_script"], str)
+    assert sdt_meta["sequence_type"] == "standard"
 
 
 run_tests_if_main()


### PR DESCRIPTION
This adds support for reading metadata written by the SDT-control microscopy software. Hardly any changes to old code, so it should be safe.