### PR TITLE
Allow JPEG quality factors > 95

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -485,7 +485,6 @@ class JPEGFormat(PillowFormat):
             quality = int(quality)
             if quality < 1 or quality > 100:
                 raise ValueError("JPEG quality should be between 1 and 100.")
-            quality = min(95, max(1, quality))
 
             kwargs["quality"] = quality
             kwargs["progressive"] = bool(progressive)

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -481,10 +481,10 @@ class JPEGFormat(PillowFormat):
     class Writer(PillowFormat.Writer):
         def _open(self, quality=75, progressive=False, optimize=False, **kwargs):
 
-            # Check quality - in Pillow it should be no higher than 95
+            # The JPEG quality factor can be between 0 (worst) and 100 (best)
             quality = int(quality)
-            if quality < 1 or quality > 100:
-                raise ValueError("JPEG quality should be between 1 and 100.")
+            if quality < 0 or quality > 100:
+                raise ValueError("JPEG quality should be between 0 and 100.")
 
             kwargs["quality"] = quality
             kwargs["progressive"] = bool(progressive)

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -481,7 +481,7 @@ class JPEGFormat(PillowFormat):
     class Writer(PillowFormat.Writer):
         def _open(self, quality=75, progressive=False, optimize=False, **kwargs):
 
-            # The JPEG quality factor can be between 0 (worst) and 100 (best)
+            # The JPEG quality can be between 0 (worst) and 100 (best)
             quality = int(quality)
             if quality < 0 or quality > 100:
                 raise ValueError("JPEG quality should be between 0 and 100.")


### PR DESCRIPTION
Removes the line that previously allowed a maximum JPEG quality factor of 95. Fixes #571.