### PR TITLE
Adds fuzzing for integration with OSS-Fuzz

### DIFF
--- a/tests/fuzzers/fuzz_read.py
+++ b/tests/fuzzers/fuzz_read.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+import os
+import sys
+import atheris
+
+import imageio
+
+def TestOneInput(data):
+    with open("/tmp/img1.file", "wb+") as img1_f:
+       img1_f.write(data)
+    try:
+        imageio.imread("/tmp/img1.file")
+    except ValueError:
+        None
+    except RuntimeError:
+        None
+    os.remove("/tmp/img1.file")
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi Maintainers,

I would like to set up continuous fuzzing of imageio by way of OSS-Fuzz. Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects. OSS-Fuzz recently added support for Python and it would be great to have imageio integrated. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

In this PR https://github.com/google/oss-fuzz/pull/4993 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate imageio. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.