### PR TITLE
enable documentation builds for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,25 +9,6 @@ on:
 
 
 jobs:
-  docs:
-    name: "Documentation"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Build Docs
-        run: |
-            pip install -e .[test,docs]
-      - name: Test docbuilding
-        run: |
-            invoke docs --clean --build
-      # TODO: Upload the docs to some place
-      # where they can be served. Potentially build
-      # this in a different CI tool that can serve
-      # html artifacts
-
   style:
     name: "Linting"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #602 

I've added the ability to build documentation for PRs over at RTD. This adds a new status to each PR that will display a link to the build logs while still building or on failure. Upon success, the details will link to the temporarily built documentation so that we can visually inspect that it renders properly.