### PR TITLE
MAINT: Refactor Request.py

### DIFF
--- a/imageio/core/format.py
+++ b/imageio/core/format.py
@@ -161,7 +161,7 @@ class Format(object):
         if select_mode not in self.modes:
             modename = MODENAMES.get(select_mode, select_mode)
             raise RuntimeError(
-                "Format %s cannot read in %s mode" % (self.name, modename)
+                f"Format {self.name} cannot read in {modename} mode"
             )
         return self.Reader(self, request)
 
@@ -672,7 +672,7 @@ class FormatManager(object):
         Search a format that can read a file according to the given request.
         Returns None if no appropriate format was found. (used internally)
         """
-        select_mode = request.mode[1] if request.mode[1] in "iIvV" else ""
+        select_mode = request.mode.value[1] if request.mode.value[1] in "iIvV" else ""
 
         # Select formats that seem to be able to read it
         selected_formats = []
@@ -699,7 +699,7 @@ class FormatManager(object):
         Search a format that can write a file according to the given request.
         Returns None if no appropriate format was found. (used internally)
         """
-        select_mode = request.mode[1] if request.mode[1] in "iIvV" else ""
+        select_mode = request.mode.value[1] if request.mode.value[1] in "iIvV" else ""
 
         # Select formats that seem to be able to write it
         selected_formats = []

--- a/imageio/core/format.py
+++ b/imageio/core/format.py
@@ -35,15 +35,13 @@ import sys
 import numpy as np
 
 from . import Array, asarray
+from .request import ImageMode
 
 
-MODENAMES = {
-    "i": "single-image",
-    "I": "multi-image",
-    "v": "single-volume",
-    "V": "multi-volume",
-    "?": "any-mode",
-}
+# survived for backwards compatibility
+# I don't know if external plugin code depends on it existing
+# We no longer do
+MODENAMES = ImageMode
 
 
 class Format(object):
@@ -159,9 +157,8 @@ class Format(object):
         """
         select_mode = request.mode[1] if request.mode[1] in "iIvV" else ""
         if select_mode not in self.modes:
-            modename = MODENAMES.get(select_mode, select_mode)
             raise RuntimeError(
-                f"Format {self.name} cannot read in {modename} mode"
+                f"Format {self.name} cannot read in {request.mode.image_mode} mode"
             )
         return self.Reader(self, request)
 
@@ -174,9 +171,8 @@ class Format(object):
         """
         select_mode = request.mode[1] if request.mode[1] in "iIvV" else ""
         if select_mode not in self.modes:
-            modename = MODENAMES.get(select_mode, select_mode)
             raise RuntimeError(
-                "Format %s cannot write in %s mode" % (self.name, modename)
+                f"Format {self.name} cannot write in {request.mode.image_mode} mode"
             )
         return self.Writer(self, request)
 

--- a/imageio/core/functions.py
+++ b/imageio/core/functions.py
@@ -81,7 +81,6 @@ import numpy as np
 
 from . import Request, RETURN_BYTES
 from .. import formats
-from .format import MODENAMES
 
 
 MEMTEST_DEFAULT_MIM = "256MB"
@@ -177,9 +176,8 @@ def get_reader(uri, format=None, mode="?", **kwargs):
     else:
         format = formats.search_read_format(request)
     if format is None:
-        modename = MODENAMES.get(mode, mode)
         raise ValueError(
-            "Could not find a format to read the specified file in %s mode" % modename
+            f"Could not find a format to read the specified file in {request.mode.image_mode} mode"
         )
 
     # Return its reader object
@@ -222,9 +220,8 @@ def get_writer(uri, format=None, mode="?", **kwargs):
     else:
         format = formats.search_write_format(request)
     if format is None:
-        modename = MODENAMES.get(mode, mode)
         raise ValueError(
-            "Could not find a format to write the specified file in %s mode" % modename
+            f"Could not find a format to write the specified file in {request.mode.image_mode} mode"
         )
 
     # Return its writer object

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -231,8 +231,6 @@ class Request(object):
         is_read_request = self.mode.io_mode is IOMode.read
         is_write_request = self.mode.io_mode is IOMode.write
 
-        # import pdb; pdb.set_trace()
-
         if isinstance(uri, str):
             uri = self._sanatize_uri(uri)
 

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -17,7 +17,7 @@ from ..core import urlopen, get_remote_file
 
 from pathlib import Path
 
-# URI types
+
 @enum.unique
 class URI(enum.Enum):
     BYTES = enum.auto()
@@ -34,8 +34,6 @@ class IOMode(enum.Enum):
 
 
 class ImageMode(str, enum.Enum):
-    """Available Image modes"""
-
     single_image = "i"
     multi_image = "I"
     single_volume = "v"

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -15,10 +15,7 @@ import enum
 
 from ..core import urlopen, get_remote_file
 
-try:
-    from pathlib import Path
-except ImportError:
-    Path = None
+from pathlib import Path
 
 # URI types
 @enum.unique

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -266,7 +266,6 @@ class Request(object):
             elif scheme is IOScheme.http:
                 self._uri_type = URI.HTTP
                 self._filename = urllib.parse.urlunsplit(parsed_uri)
-                # import pdb; pdb.set_trace()
             elif scheme is IOScheme.ftp:
                 self._uri_type = URI.FTP
                 self._filename = urllib.parse.urlunsplit(parsed_uri)
@@ -293,8 +292,6 @@ class Request(object):
                 )
                 # self._filename must be native-style but fragment must be posix-style
                 self._filename += "/" + Path(parsed_uri.fragment).as_posix()
-
-            # import pdb; pdb.set_trace()
 
         elif isinstance(uri, memoryview) and is_read_request:
             self._uri_type = URI.BYTES

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -142,33 +142,33 @@ def test_request():
 
     # Check uri-type, this is not a public property, so we test the private
     R = Request("http://example.com", "ri")
-    assert R._uri_type == core.request.URI_HTTP
+    assert R._uri_type == core.request.URI.HTTP
     R = Request("ftp://example.com", "ri")
-    assert R._uri_type == core.request.URI_FTP
+    assert R._uri_type == core.request.URI.FTP
     R = Request("file://~/foo.png", "wi")
-    assert R._uri_type == core.request.URI_FILENAME
+    assert R._uri_type == core.request.URI.FILENAME
     R = Request("<video0>", "rI")
-    assert R._uri_type == core.request.URI_BYTES
+    assert R._uri_type == core.request.URI.BYTES
     R = Request(imageio.RETURN_BYTES, "wi")
-    assert R._uri_type == core.request.URI_BYTES
+    assert R._uri_type == core.request.URI.BYTES
     #
     fname = get_remote_file("images/chelsea.png", test_dir)
     R = Request(fname, "ri")
-    assert R._uri_type == core.request.URI_FILENAME
+    assert R._uri_type == core.request.URI.FILENAME
     R = Request("~/filethatdoesnotexist", "wi")
-    assert R._uri_type == core.request.URI_FILENAME  # Too short to be bytes
+    assert R._uri_type == core.request.URI.FILENAME  # Too short to be bytes
     R = Request(b"x" * 600, "ri")
-    assert R._uri_type == core.request.URI_BYTES
+    assert R._uri_type == core.request.URI.BYTES
     R = Request(sys.stdin, "ri")
-    assert R._uri_type == core.request.URI_FILE
+    assert R._uri_type == core.request.URI.FILE
     R = Request(sys.stdout, "wi")
-    assert R._uri_type == core.request.URI_FILE
+    assert R._uri_type == core.request.URI.FILE
     # exapand user dir
     R = Request("~/foo", "wi")
     assert R.filename == os.path.expanduser("~/foo").replace("/", os.path.sep)
     # zip file
     R = Request("~/bar.zip/spam.png", "wi")
-    assert R._uri_type == core.request.URI_ZIPPED
+    assert R._uri_type == core.request.URI.ZIPPED
 
     # Test failing inits
     raises(ValueError, Request, "/some/file", None)  # mode must be str
@@ -209,7 +209,7 @@ def test_request():
         shutil.copy(chelsia, file_path)
 
         R = Request(file_path, "ri")
-        assert R._uri_type == core.request.URI_FILENAME
+        assert R._uri_type == core.request.URI.FILENAME
 
 
 def test_request_read_sources():


### PR DESCRIPTION
In preparation to introduce the Requests object in #574 I began rewriting parts of it. While doing so, I've noticed that some of the changes are just porting it to python 3.7+ to make it extensible wrt. `imopen`. These changes exist independently from #574 so I figured we can make this a separate PR.

The idea for this PR is to not introduce any new functionality but to simply refactor existing code.