### PR TITLE
Temporarily pin version of black action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@stable
+      - uses: psf/black@20.8b1
         with:
           args: ". --check"
       - name: Install Dependencies


### PR DESCRIPTION
The Black team is preparing for a new release and - for currently unknown reasons - the stable branch of the GH action was deleted in the process.

This breaks our GH Actions workflow, and to work around it we temporarily pin the version to the last stable version until the issue is resolved.

Reference to the issue at psf/black tracking the problem:
https://github.com/psf/black/issues/2079
