### PR TITLE
Make Request.Mode an enum

### DIFF
--- a/imageio/core/format.py
+++ b/imageio/core/format.py
@@ -35,15 +35,13 @@ import sys
 import numpy as np
 
 from . import Array, asarray
+from .request import ImageMode
 
 
-MODENAMES = {
-    "i": "single-image",
-    "I": "multi-image",
-    "v": "single-volume",
-    "V": "multi-volume",
-    "?": "any-mode",
-}
+# survived for backwards compatibility
+# I don't know if external plugin code depends on it existing
+# We no longer do
+MODENAMES = ImageMode
 
 
 class Format(object):
@@ -159,9 +157,8 @@ class Format(object):
         """
         select_mode = request.mode[1] if request.mode[1] in "iIvV" else ""
         if select_mode not in self.modes:
-            modename = MODENAMES.get(select_mode, select_mode)
             raise RuntimeError(
-                "Format %s cannot read in %s mode" % (self.name, modename)
+                f"Format {self.name} cannot read in {request.mode.image_mode} mode"
             )
         return self.Reader(self, request)
 
@@ -174,9 +171,8 @@ class Format(object):
         """
         select_mode = request.mode[1] if request.mode[1] in "iIvV" else ""
         if select_mode not in self.modes:
-            modename = MODENAMES.get(select_mode, select_mode)
             raise RuntimeError(
-                "Format %s cannot write in %s mode" % (self.name, modename)
+                f"Format {self.name} cannot write in {request.mode.image_mode} mode"
             )
         return self.Writer(self, request)
 

--- a/imageio/core/functions.py
+++ b/imageio/core/functions.py
@@ -81,7 +81,6 @@ import numpy as np
 
 from . import Request, RETURN_BYTES
 from .. import formats
-from .format import MODENAMES
 
 
 MEMTEST_DEFAULT_MIM = "256MB"
@@ -177,9 +176,8 @@ def get_reader(uri, format=None, mode="?", **kwargs):
     else:
         format = formats.search_read_format(request)
     if format is None:
-        modename = MODENAMES.get(mode, mode)
         raise ValueError(
-            "Could not find a format to read the specified file in %s mode" % modename
+            f"Could not find a format to read the specified file in {request.mode.image_mode} mode"
         )
 
     # Return its reader object
@@ -222,9 +220,8 @@ def get_writer(uri, format=None, mode="?", **kwargs):
     else:
         format = formats.search_write_format(request)
     if format is None:
-        modename = MODENAMES.get(mode, mode)
         raise ValueError(
-            "Could not find a format to write the specified file in %s mode" % modename
+            f"Could not find a format to write the specified file in {request.mode.image_mode} mode"
         )
 
     # Return its writer object

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -15,10 +15,7 @@ import enum
 
 from ..core import urlopen, get_remote_file
 
-try:
-    from pathlib import Path
-except ImportError:
-    Path = None
+from pathlib import Path
 
 # URI types
 URI_BYTES = 1
@@ -231,7 +228,7 @@ class Request(object):
             self._uri_type = URI_BYTES
             self._filename = "<bytes>"
             self._bytes = uri
-        elif Path is not None and isinstance(uri, Path):
+        elif isinstance(uri, Path):
             self._uri_type = URI_FILENAME
             self._filename = str(uri)
         # Files

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -11,6 +11,7 @@ from io import BytesIO
 import zipfile
 import tempfile
 import shutil
+import enum
 
 from ..core import urlopen, get_remote_file
 
@@ -26,6 +27,62 @@ URI_FILENAME = 3
 URI_ZIPPED = 4
 URI_HTTP = 5
 URI_FTP = 6
+
+
+class IOMode(enum.Enum):
+    read = "r"
+    write = "w"
+
+
+class ImageMode(str, enum.Enum):
+    """Available Image modes"""
+
+    single_image = "i"
+    multi_image = "I"
+    single_volume = "v"
+    multi_volume = "V"
+    any_mode = "?"
+
+    def __getitem__(self, key):
+        """For backwards compatibility with the old non-enum ImageMode"""
+        if isinstance(key, str):
+            return self.io_mode
+        elif key == 1:
+            return self.image_mode
+        else:
+            raise IndexError(f"Mode has no item {key}")
+
+
+@enum.unique
+class Mode(enum.Enum):
+    read_single_image = "ri"
+    read_multi_image = "rI"
+    read_single_volume = "rv"
+    read_multi_volume = "rV"
+    read_any = "r?"
+    write_single_image = "wi"
+    write_multi_image = "wI"
+    write_single_volume = "wv"
+    write_multi_volume = "wV"
+    write_any = "w?"
+
+    @property
+    def io_mode(self) -> IOMode:
+        return IOMode(self.value[0])
+
+    @property
+    def image_mode(self) -> ImageMode:
+        return ImageMode(self.value[1])
+
+    def __getitem__(self, key):
+        """For backwards compatibility with the old non-enum modes"""
+        if key == 0:
+            return self.io_mode
+        elif key == 1:
+            return self.image_mode
+        else:
+            raise IndexError(f"Mode has no item {key}")
+
 
 SPECIAL_READ_URIS = "<video", "<screen>", "<clipboard>"
 
@@ -110,15 +167,12 @@ class Request(object):
         # self._potential_formats = []
 
         # Check mode
-        self._mode = mode
-        if not isinstance(mode, str):
-            raise ValueError("Request requires mode must be a string")
-        if not len(mode) == 2:
-            raise ValueError("Request requires mode to have two chars")
-        if mode[0] not in "rw":
-            raise ValueError('Request requires mode[0] to be "r" or "w"')
-        if mode[1] not in "iIvV?":
-            raise ValueError('Request requires mode[1] to be in "iIvV?"')
+        if isinstance(mode, str):
+            self._mode = Mode(mode)
+        elif isinstance(mode, Mode):
+            self._mode = mode
+        else:
+            raise ValueError("Mode must be either string or iio.Mode")
 
         # Parse what was given
         self._parse_uri(uri)
@@ -132,8 +186,8 @@ class Request(object):
 
     def _parse_uri(self, uri):
         """Try to figure our what we were given"""
-        is_read_request = self.mode[0] == "r"
-        is_write_request = self.mode[0] == "w"
+        is_read_request = self.mode.io_mode is IOMode.read
+        is_write_request = self.mode.io_mode is IOMode.write
 
         if isinstance(uri, str):
             # Explicit
@@ -309,7 +363,7 @@ class Request(object):
         format cannot handle file-like objects, they should use
         ``get_local_filename()``.
         """
-        want_to_write = self.mode[0] == "w"
+        want_to_write = self.mode.io_mode is IOMode.write
 
         # Is there already a file?
         # Either _uri_type == URI_FILE, or we already opened the file,
@@ -371,7 +425,7 @@ class Request(object):
                 ext = os.path.splitext(self._filename)[1]
             self._filename_local = tempfile.mktemp(ext, "imageio_")
             # Write stuff to it?
-            if self.mode[0] == "r":
+            if self.mode.io_mode == IOMode.read:
                 with open(self._filename_local, "wb") as file:
                     shutil.copyfileobj(self.get_file(), file)
             return self._filename_local
@@ -383,7 +437,7 @@ class Request(object):
         results.
         """
 
-        if self.mode[0] == "w":
+        if self.mode.io_mode == IOMode.write:
 
             # See if we "own" the data and must put it somewhere
             bytes = None

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -26,7 +26,7 @@ URI_HTTP = 5
 URI_FTP = 6
 
 
-class IOMode(enum.Enum):
+class IOMode(str, enum.Enum):
     """Available Image modes
 
     This is a helper enum for ``Request.Mode`` which is a composite of a
@@ -71,7 +71,7 @@ class ImageMode(str, enum.Enum):
 
 
 @enum.unique
-class Mode(enum.Enum):
+class Mode(str, enum.Enum):
     """The mode to use when interacting with the resource
 
     ``Request.Mode`` is a composite of ``Request.ImageMode`` and

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,6 +23,7 @@ import imageio
 from imageio import core
 from imageio.core import Request
 from imageio.core import get_remote_file, IS_PYPY
+from imageio.core.request import Mode
 
 
 try:
@@ -774,5 +775,11 @@ def test_imwrite_not_array_like():
     with raises(ValueError):
         imageio.imwrite("foo.bmp", "asd")
 
+
+def test_request_mode_backwards_compatibility():
+    mode = Mode("ri")
+    assert mode == "ri"
+    assert mode[0] == "r"
+    assert mode[1] == "i" 
 
 run_tests_if_main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -783,4 +783,10 @@ def test_request_mode_backwards_compatibility():
     assert mode[1] == "i"
 
 
+def test_faulty_legacy_mode_access():
+    mode = Mode("ri")
+    with pytest.raises(IndexError):
+        mode[3]  # has no third component
+
+
 run_tests_if_main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -780,6 +780,7 @@ def test_request_mode_backwards_compatibility():
     mode = Mode("ri")
     assert mode == "ri"
     assert mode[0] == "r"
-    assert mode[1] == "i" 
+    assert mode[1] == "i"
+
 
 run_tests_if_main()


### PR DESCRIPTION
To have an easier time integrating the Requests object in #574 I would like to make its mode an enum. In #574 we need to allow the request object to be constructible from a single character (`r`/`w`) while maintaining backward compatibility. I was thinking that this can be done by converting (`r`/`w`) -> (`r?`/`w?`) and allowing new plugins to ignore the second character of the current request mode.

In practice, this would mean that legacy plugins can use the mode as they are used to (pretend that it is a two-character string), while new plugins can do `request.mode.io_mode` and only get the read/write portion. I think `request.mode.io_mode is IOMode.read` is more readable than `request.mode[0] == "r"`. Maybe we can even do the casting implicitly and have something like `request.mode is IOMode.read`.

The idea for this PR is to not introduce any new functionality but to simply refactor existing code.