### PR TITLE
Clarify documentation on .tif handling

### DIFF
--- a/docs/scipy.rst
+++ b/docs/scipy.rst
@@ -14,7 +14,8 @@ Imageio makes use of variety of plugins to support reading images (and volumes/m
 from many different formats. Fortunately, Pillow is the main plugin for common images,
 which is the same library as used by  Scipy's ``imread``. Note that Imageio
 automatically selects a plugin based on the image to read (unless a format is
-explicitly specified), but uses Pillow where possible. 
+explicitly specified), but uses Pillow where possible. An exception to this is the .tif
+format, for which the tifffile plugin is preferred due to its broader compatibility.
 
 In short terms: For images previously read by Scipy's imread, imageio should
 generally use Pillow as well, and imageio provides the same functionality as Scipy

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -63,7 +63,8 @@ READ_METADATA_KEYS = (
 
 
 class TiffFormat(Format):
-    """Provides support for a wide range of Tiff images.
+    """Provides support for a wide range of Tiff images using the ``tifffile`` 
+    plugin.
 
     Images that contain multiple pages can be read using ``imageio.mimread()``
     to read the individual pages, or ``imageio.volread()`` to obtain a
@@ -73,6 +74,10 @@ class TiffFormat(Format):
     Thus calling :py:meth:`Format.Writer.set_meta_data` after the first frame
     was written has no effect. Also, global metadata is ignored if metadata is
     provided via the `meta` argument of :py:meth:`Format.Writer.append_data`.
+    
+    If you have installed ``tifffile`` as a Python package, imageio will 
+    attempt to use that instead of the bundled version from this plugin. Doing
+    so can provide access to performance improvements and bug fixes.
 
     Parameters for reading
     ----------------------

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -76,7 +76,7 @@ class TiffFormat(Format):
     provided via the `meta` argument of :py:meth:`Format.Writer.append_data`.
 
     If you have installed tifffile as a Python package, imageio will attempt
-    to use that instead of the bundled version from this plugin. Doing so can
+    to use that as backend instead of the bundled backend. Doing so can
     provide access to new performance improvements and bug fixes.
 
     Parameters for reading

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -63,7 +63,7 @@ READ_METADATA_KEYS = (
 
 
 class TiffFormat(Format):
-    """Provides support for a wide range of Tiff images using the ``tifffile`` 
+    """Provides support for a wide range of Tiff images using the tifffile 
     plugin.
 
     Images that contain multiple pages can be read using ``imageio.mimread()``
@@ -75,9 +75,9 @@ class TiffFormat(Format):
     was written has no effect. Also, global metadata is ignored if metadata is
     provided via the `meta` argument of :py:meth:`Format.Writer.append_data`.
     
-    If you have installed ``tifffile`` as a Python package, imageio will 
-    attempt to use that instead of the bundled version from this plugin. Doing
-    so can provide access to performance improvements and bug fixes.
+    If you have installed tifffile as a Python package, imageio will attempt 
+    to use that instead of the bundled version from this plugin. Doing so can 
+    provide access to new performance improvements and bug fixes.
 
     Parameters for reading
     ----------------------

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -63,7 +63,7 @@ READ_METADATA_KEYS = (
 
 
 class TiffFormat(Format):
-    """Provides support for a wide range of Tiff images using the tifffile 
+    """Provides support for a wide range of Tiff images using the tifffile
     plugin.
 
     Images that contain multiple pages can be read using ``imageio.mimread()``
@@ -74,9 +74,9 @@ class TiffFormat(Format):
     Thus calling :py:meth:`Format.Writer.set_meta_data` after the first frame
     was written has no effect. Also, global metadata is ignored if metadata is
     provided via the `meta` argument of :py:meth:`Format.Writer.append_data`.
-    
-    If you have installed tifffile as a Python package, imageio will attempt 
-    to use that instead of the bundled version from this plugin. Doing so can 
+
+    If you have installed tifffile as a Python package, imageio will attempt
+    to use that instead of the bundled version from this plugin. Doing so can
     provide access to new performance improvements and bug fixes.
 
     Parameters for reading

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -64,7 +64,7 @@ READ_METADATA_KEYS = (
 
 class TiffFormat(Format):
     """Provides support for a wide range of Tiff images using the tifffile
-    plugin.
+    backend.
 
     Images that contain multiple pages can be read using ``imageio.mimread()``
     to read the individual pages, or ``imageio.volread()`` to obtain a


### PR DESCRIPTION
Following on from discussion in #623, I've tried to document that the tifffile plugin will switch to using an external version of the package if one is present. I've also tried to clarify the scipy migration page, since that gave the impression that Pillow was the default loader for this format.

Hopefully that's okay, do feel free to edit further! 