### PR TITLE
Respond to codecov security breach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,6 @@ jobs:
       - name: Upload coverage to Codecov
         run: |
           curl -s https://codecov.io/bash | bash
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
 
   pypy:


### PR DESCRIPTION
Codecov had a security breach in their batch uploader that leaked user's CI environment variables. We use that batch uploader as it is the recommended way to upload coverage data to codecov, so we are "affected" by this.

Link: https://about.codecov.io/security-update/

For us, the only environment variable that I'm aware of that might be remotely sensitive is our CODECOV_TOKEN, which allows us to upload coverage from private repositories. We don't have any private repos and - hence - don't really need that token. Since it's to be considered compromised, and we have to replace it anyway, we might as well clean up and remove it instead :)

Any other things that need cleanup in this process?

