### PR TITLE
Moved fits import above pillow and added unit test of get_reader

### DIFF
--- a/imageio/plugins/__init__.py
+++ b/imageio/plugins/__init__.py
@@ -81,6 +81,7 @@ For the Format.Writer class:
 
 # First import plugins that we want to take precedence over freeimage
 from . import tifffile
+from . import fits  # depends on astropy
 from . import pillow
 from . import grab
 
@@ -93,9 +94,8 @@ from . import bsdf
 from . import dicom
 from . import npz
 from . import swf
-from . import feisem  # special kind of tiff, uses _tiffile
 
-from . import fits  # depends on astropy
+from . import feisem  # special kind of tiff, uses _tiffile
 from . import simpleitk  # depends on itk or SimpleITK
 from . import gdal  # depends on gdal
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -99,7 +99,7 @@ def test_fits_get_reader(tmp_path):
     phdu = fits.PrimaryHDU()
     ihdu = fits.ImageHDU(img)
     hdul = fits.HDUList([phdu,ihdu])
-    hdul.writeto('test.fits')
+    hdul.writeto(tmp_path / 'test.fits')
     try:
         im = imageio.get_reader('test.fits')
         os.remove('test.fits')

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -26,6 +26,15 @@ def teardown_module():
     imageio.formats.sort()
 
 
+@pytest.fixture
+def normal_plugin_order():
+    # Use fixture to temporarily set context of normal plugin order for
+    # tests and return to module setup afterwards
+    teardown_module()
+    yield
+    setup_module()
+
+
 @pytest.mark.skipif("astropy is None")
 def test_fits_format():
     need_internet()  # We keep the fits files in the imageio-binary repo
@@ -84,13 +93,10 @@ def test_fits_reading():
 
 @pytest.mark.skipif("astropy is None")
 @pytest.mark.skipif("IS_PYPY", reason="pypy doesn't support astropy.fits.")
-def test_fits_get_reader(tmp_path):
+def test_fits_get_reader(normal_plugin_order, tmp_path):
     """Test reading fits with get_reader method
     This is a regression test that closes GitHub issue #636
     """
-
-    # Set precedence as normal
-    imageio.formats.sort()
 
     sigma = 10
     xx, yy = np.meshgrid(np.arange(512), np.arange(512))

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -1,6 +1,5 @@
 """ Test fits plugin functionality.
 """
-import os
 import pytest
 from imageio.testing import run_tests_if_main, get_test_dir, need_internet
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -86,20 +86,23 @@ def test_fits_reading():
 @pytest.mark.skipif("IS_PYPY", reason="pypy doesn't support astropy.fits.")
 def test_fits_get_reader(tmp_path):
     """Test reading fits with get_reader method
-       This is a regression test that closes GitHub issue #636
+    This is a regression test that closes GitHub issue #636
     """
-    
-    #Set precedence as normal
+
+    # Set precedence as normal
     imageio.formats.sort()
-    
+
     sigma = 10
-    xx, yy = np.meshgrid(np.arange(512),np.arange(512))
-    z = (1/(2*np.pi*(sigma**2)))*np.exp(-((xx**2)+(yy**2))/(2*(sigma**2)))
+    xx, yy = np.meshgrid(np.arange(512), np.arange(512))
+    z = (1 / (2 * np.pi * (sigma ** 2))) * np.exp(
+        -((xx ** 2) + (yy ** 2)) / (2 * (sigma ** 2))
+    )
     img = np.log(z)
     phdu = astropy.io.fits.PrimaryHDU()
     ihdu = astropy.io.fits.ImageHDU(img)
-    hdul = astropy.io.fits.HDUList([phdu,ihdu])
-    hdul.writeto(tmp_path / 'test.fits')
-    im = imageio.get_reader(tmp_path / 'test.fits')
+    hdul = astropy.io.fits.HDUList([phdu, ihdu])
+    hdul.writeto(tmp_path / "test.fits")
+    imageio.get_reader(tmp_path / "test.fits")
+
 
 run_tests_if_main()

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -6,6 +6,8 @@ from imageio.testing import run_tests_if_main, get_test_dir, need_internet
 import imageio
 from imageio.core import get_remote_file, Request, IS_PYPY
 
+import numpy as np
+
 test_dir = get_test_dir()
 
 try:
@@ -79,25 +81,24 @@ def test_fits_reading():
     im = imageio.imread(compressed)
     assert im.shape == (2042, 3054)
 
+
 @pytest.mark.skipif("astropy is None")
+@pytest.mark.skipif("IS_PYPY", reason="pypy doesn't support astropy.fits.")
 def test_fits_get_reader(tmp_path):
-    """Test reading fits with get_reader method"""
+    """Test reading fits with get_reader method
+       This is a regression test that closes GitHub issue #636
+    """
     
     #Set precedence as normal
-    teardown_module()
+    imageio.formats.sort()
     
-    if IS_PYPY:
-        return  # no support for fits format :(
-
-    import numpy as np
-    from astropy.io import fits
     sigma = 10
     xx, yy = np.meshgrid(np.arange(512),np.arange(512))
     z = (1/(2*np.pi*(sigma**2)))*np.exp(-((xx**2)+(yy**2))/(2*(sigma**2)))
     img = np.log(z)
-    phdu = fits.PrimaryHDU()
-    ihdu = fits.ImageHDU(img)
-    hdul = fits.HDUList([phdu,ihdu])
+    phdu = astropy.io.fits.PrimaryHDU()
+    ihdu = astropy.io.fits.ImageHDU(img)
+    hdul = astropy.io.fits.HDUList([phdu,ihdu])
     hdul.writeto(tmp_path / 'test.fits')
     im = imageio.get_reader(tmp_path / 'test.fits')
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -100,11 +100,6 @@ def test_fits_get_reader(tmp_path):
     ihdu = fits.ImageHDU(img)
     hdul = fits.HDUList([phdu,ihdu])
     hdul.writeto(tmp_path / 'test.fits')
-    try:
-        im = imageio.get_reader('test.fits')
-        os.remove('test.fits')
-    except ValueError:
-        os.remove('test.fits')
-        pytest.fail('imageio.get_reader failed to find FITS loader')
+    im = imageio.get_reader(tmp_path / 'test.fits')
 
 run_tests_if_main()

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -81,7 +81,7 @@ def test_fits_reading():
     assert im.shape == (2042, 3054)
 
 @pytest.mark.skipif("astropy is None")
-def test_fits_get_reader():
+def test_fits_get_reader(tmp_path):
     """Test reading fits with get_reader method"""
     
     #Set precedence as normal


### PR DESCRIPTION
Moved the `import fits` line in `imageio/plugins/__init__.py` to occur before `import pillows` to close #636.  Also added a unit test in `tests/test_fits.py` for `imageio.get_reader()`.