### PR TITLE
Setup: 'formats' for all user-facing extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Optional Python packages:
     <li><a href='https://codeberg.org/monilophyta/imageio-flif'>imageio-flif</a> (for working with <a href='https://github.com/FLIF-hub/FLIF'>FLIF</a> image files)</li>
 </ul>
 
+These extras can easily be installed along with imageio:
+
+```bash
+pip install 'imageio[ffmpeg,itk,fits,gdal]'
+# or for all of the above
+pip install 'imageio[formats]'
+```
+
 Still on an earlier version of Python? Imageio version 2.6.x supports Python 2.7 and 3.4.
 
 
@@ -125,7 +133,9 @@ for maximum test coverage (100% for the core, >95% for each plugin).
 <p>Install imageio in edit mode, with dev tools:</p>
 
 ```bash
-pip install -e .[dev,docs]
+pip install -e '.[dev,docs]'
+# or, to additionally include all user-facing extras too
+pip install -e '.[full]'
 ```
 
 <p>Most developer command are done via <code>invoke</code>.</p>

--- a/setup.py
+++ b/setup.py
@@ -172,17 +172,23 @@ class build_with_images(sdist):
 install_requires = ["numpy", "pillow"]
 
 extras_require = {
-    "linting": ["black", "flake8"],
-    "test": ["invoke", "pytest", "pytest-cov"],
-    "docs": ["sphinx", "numpydoc"],
     "ffmpeg": ["imageio-ffmpeg", "psutil"],
     "fits": ["astropy"],
     "gdal": ["gdal"],
     "itk": ["itk"],
 }
-extras_require["full"] = sorted(set(chain.from_iterable(extras_require.values())))
-extras_require["dev"] = extras_require["test"] + extras_require["linting"]
+extras_require["formats"] = sorted(set(chain.from_iterable(extras_require.values())))
 
+extras_require.update(
+    {
+        "linting": ["black", "flake8"],
+        "test": ["invoke", "pytest", "pytest-cov"],
+        "docs": ["sphinx", "numpydoc"],
+    }
+)
+extras_require["dev"] = sorted(set(extras_require["test"] + extras_require["linting"]))
+
+extras_require["full"] = sorted(set(chain.from_iterable(extras_require.values())))
 
 setup(
     cmdclass={  # 'bdist_wheel_all': bdist_wheel_all,


### PR DESCRIPTION
This was initially going to be a prelude to adding more formats which require their own dependencies (`scipy` and `hdf5` for .mat files, `hdf5` for hdf5 files, `zarr` for zarr and N5 arrays), but from #574 it looks like the plugin system is being overhauled so I may hold off on those.