### PR TITLE
factor out PillowPlugin.open()

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -119,11 +119,10 @@ class PillowPlugin(object):
                 ) from None
 
         self._request = request
-        self._image = None
-
-    def open(self):
         if self._request.mode.io_mode == IOMode.read:
             self._image = Image.open(self._request.get_file())
+        else:
+            self._image = None
 
     def close(self):
         if self._image:
@@ -311,7 +310,6 @@ class PillowPlugin(object):
         return self._image.info
 
     def __enter__(self):
-        self.open()
         return self
 
     def __exit__(self, type, value, traceback):


### PR DESCRIPTION
See #562 for the discussion. At first I did not realize that `open()` was in fact a "private" method only used by the class itself. Nevertheless, with request doing most of the handling, I think the pattern of opening a file when the plugin object is created makes more sense.