### PR TITLE
BUG: Avoid pillow 8.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ class build_with_images(sdist):
         # Build as  normal
         sdist.run(self)
 
-
+# avoid pillow 8.3 because it doesn't respect numpy API
 install_requires = ["numpy", "pillow != 8.3.0"]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ class build_with_images(sdist):
         sdist.run(self)
 
 
-install_requires = ["numpy", "pillow"]
+install_requires = ["numpy", "pillow != 8.3.0"]
 
 extras_require = {
     "linting": ["black", "flake8"],

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ class build_with_images(sdist):
         # Build as  normal
         sdist.run(self)
 
+
 # avoid pillow 8.3 because it doesn't respect numpy API
 install_requires = ["numpy", "pillow != 8.3.0"]
 


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/655

On top of what is reported, this bug in pillow also affects our CI, since we always fetch the latest version. As per my suggestion, this PR simply excludes pillow 8.3.0 (for now).

Tracking issue upstream: https://github.com/python-pillow/Pillow/issues/5571