### PR TITLE
BUG: Install ImageIO dependencies during final wheel build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -151,7 +151,7 @@ jobs:
 
   release:
     name: Release new Version
-    # needs: [cpython_tests, pypy_tests, build_test, docs]
+    needs: [cpython_tests, pypy_tests, build_test, docs]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -161,4 +161,4 @@ jobs:
       uses: relekang/python-semantic-release@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        # pypi_token: ${{ secrets.PYPI_API_TOKEN }}
+        pypi_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,9 @@ max-line-length = 88
 extend-ignore = E203, W503, E501
 
 [semantic_release]
-branch = fix-install-dependencies
+branch = master
 version_variable = imageio/__init__.py:__version__
 commit_parser = semantic_release.history.scipy_parser
 commit_subject = REL: Release imageio v{version}
 build_command = pip install -e .[build] && python setup.py sdist bdist_wheel
 remove_dist = False
-upload_to_pypi = False


### PR DESCRIPTION
Turns out we are importing ImageIO during the building of the wheel, and hence need to install build dependencies during the final step of the CD pipeline.

This PR fixes that plus the ability to manually trigger the CD pipeline in the actions tab (in case we ever wish to do that).