### PR TITLE
Fix ffmpeg can_read for webcams with id greater than 10

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -291,7 +291,7 @@ class FfmpegFormat(Format):
             self._arg_input_params += ffmpeg_params or []  # backward compat
             # Write "_video"_arg - indicating webcam support
             self.request._video = None
-            if self.request.filename in ["<video%i>" % i for i in range(10)]:
+            if re.match(r"<video\d+>", self.request.filename):
                 self.request._video = self.request.filename
             # Specify input framerate?
             if self.request._video:

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -188,7 +188,7 @@ class FfmpegFormat(Format):
         # Read from video stream?
         # Note that we could write the _video flag here, but a user might
         # select this format explicitly (and this code is not run)
-        if re.match(r"<video\d+>", request.filename):
+        if re.match(r"<video(\d+)>", request.filename):
             return True
 
         # Read from file that we know?
@@ -291,7 +291,8 @@ class FfmpegFormat(Format):
             self._arg_input_params += ffmpeg_params or []  # backward compat
             # Write "_video"_arg - indicating webcam support
             self.request._video = None
-            if re.match(r"<video\d+>", self.request.filename):
+            regex_match = re.match(r"<video(\d+)>", self.request.filename)
+            if regex_match:
                 self.request._video = self.request.filename
             # Specify input framerate?
             if self.request._video:
@@ -299,7 +300,7 @@ class FfmpegFormat(Format):
                     self._arg_input_params.extend(["-framerate", str(float(fps or 30))])
             # Get local filename
             if self.request._video:
-                index = int(self.request._video[-2])
+                index = int(regex_match.group(1))
                 self._filename = self._get_cam_inputname(index)
             else:
                 self._filename = self.request.get_local_filename()

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -188,7 +188,7 @@ class FfmpegFormat(Format):
         # Read from video stream?
         # Note that we could write the _video flag here, but a user might
         # select this format explicitly (and this code is not run)
-        if re.match(r"<video\d+>", request):
+        if re.match(r"<video\d+>", request.filename):
             return True
 
         # Read from file that we know?

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -118,6 +118,7 @@ the number of frames can be estimated from the fps and duration in the meta data
 
 """
 
+import re
 import sys
 import time
 import logging
@@ -187,7 +188,7 @@ class FfmpegFormat(Format):
         # Read from video stream?
         # Note that we could write the _video flag here, but a user might
         # select this format explicitly (and this code is not run)
-        if request.filename in ["<video%i>" % i for i in range(10)]:
+        if re.match(r"<video\d+>", request):
             return True
 
         # Read from file that we know?

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -469,11 +469,19 @@ def test_framecatcher():
 
 
 def test_webcam():
-    try:
-        imageio.read("<video0>")
-    except Exception:
-        skip("no web cam")
+    good_paths = ["<video0>", "<video42>"]
+    for path in good_paths:
+        try:
+            imageio.read(path)
+        except IndexError:
+            # IndexError should be raised when
+            # path string is good but camera doesnt exist
+            continue
 
+    bad_paths = ["<videof1>", "<video0x>", "<video>"]
+    for path in bad_paths:
+        with raises(ValueError, match=".*Could not find a format to read.*"):
+            imageio.read(path)
 
 def test_webcam_get_next_data():
     try:

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -471,8 +471,13 @@ def test_framecatcher():
 def test_webcam():
     good_paths = ["<video0>", "<video42>"]
     for path in good_paths:
+        # regression test for https://github.com/imageio/imageio/issues/676
+        tmp_request = imageio.core.Request(path, "rI")
+        assert imageio.formats["ffmpeg"].can_read(tmp_request)
+        tmp_request.finish()
+        
         try:
-            imageio.read(path)
+            imageio.read(path, format="ffmpeg")
         except IndexError:
             # IndexError should be raised when
             # path string is good but camera doesnt exist

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -483,6 +483,7 @@ def test_webcam():
         with raises(ValueError, match=".*Could not find a format to read.*"):
             imageio.read(path)
 
+
 def test_webcam_get_next_data():
     try:
         reader = imageio.get_reader("<video0>")

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -475,7 +475,7 @@ def test_webcam():
         tmp_request = imageio.core.Request(path, "rI")
         assert imageio.formats["ffmpeg"].can_read(tmp_request)
         tmp_request.finish()
-        
+
         try:
             imageio.read(path, format="ffmpeg")
         except IndexError:


### PR DESCRIPTION
In our use case, we have over 20 webcams connected to a device at any given time. Currently only webcams up to id 9 are supported. This PR adds support for arbitrary number of cameras.

Please let me know if you want me to add any tests