### PR TITLE
BUG: Fix BytesIO regression for legacy pillow

### DIFF
--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -415,7 +415,7 @@ extension_list = [
     FileExtension(
         name="Joint Photographic Experts Group",
         extension=".jpeg",
-        priority=["pillow", "JPEG-FI", "JPEG-PIL", "ITK", "GDAL"],
+        priority=["pillow", "JPEG-PIL", "JPEG-FI", "ITK", "GDAL"],
     ),
     FileExtension(
         name="JPEG 2000",

--- a/imageio/plugins/pillow_legacy.py
+++ b/imageio/plugins/pillow_legacy.py
@@ -173,7 +173,7 @@ import threading
 import numpy as np
 
 from ..core import Format, image_as_uint
-from ..core import RETURN_BYTES
+from ..core.request import URI_FILE, URI_BYTES
 
 
 logger = logging.getLogger(__name__)
@@ -272,7 +272,10 @@ class PillowFormat(Format):
     def _can_write(self, request):
         Image = self._init_pillow()
         if request.mode[1] in (self.modes + "?"):
-            if request.extension in self.extensions or request.raw_uri == RETURN_BYTES:
+            if request.extension in self.extensions or request._uri_type in [
+                URI_FILE,
+                URI_BYTES,
+            ]:
                 if self.plugin_id in Image.SAVE:
                     return True
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -480,3 +480,16 @@ def test_write_to_bytes_jpg():
     bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format="JPEG")
 
     assert contents == bytes_string
+
+
+def test_write_jpg_to_bytes_io():
+    # this is a regression test
+    # see: https://github.com/imageio/imageio/issues/687
+
+    image = np.zeros((200, 200), dtype=np.uint8)
+    bytes_io = io.BytesIO()
+    iio.v3.imwrite(bytes_io, image, plugin="pillow", format="jpeg", mode="L")
+    bytes_io.seek(0)
+
+    image_from_file = iio.v3.imread(bytes_io, plugin="pillow")
+    assert np.allclose(image_from_file, image)

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import io
 from zipfile import ZipFile
 import numpy as np
 
@@ -418,6 +419,19 @@ def test_scipy_imread_compat():
     # Force using pillow (but really, Pillow's imageio's first choice! Except
     # for tiff)
     im = imageio.imread("imageio:chelsea.png", "PNG-PIL")
+
+
+def test_write_jpg_to_bytes_io():
+    # this is a regression test
+    # see: https://github.com/imageio/imageio/issues/687
+
+    image = np.zeros((200, 200), dtype=np.uint8)
+    bytes_io = io.BytesIO()
+    imageio.imwrite(bytes_io, image, 'jpeg')
+    bytes_io.seek(0)
+
+    image_from_file = imageio.imread(bytes_io)
+    assert np.allclose(image_from_file, image)
 
 
 if __name__ == "__main__":

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -427,7 +427,7 @@ def test_write_jpg_to_bytes_io():
 
     image = np.zeros((200, 200), dtype=np.uint8)
     bytes_io = io.BytesIO()
-    imageio.imwrite(bytes_io, image, 'jpeg')
+    imageio.imwrite(bytes_io, image, "jpeg")
     bytes_io.seek(0)
 
     image_from_file = imageio.imread(bytes_io)


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/687

The fix changes two things:
1. Make ImageIO prefer pillow over freeimage for the .jpeg extension
2. makes `PillowFormat._can_write` return `True` for `URI_FILE` requests

It also adds regression tests to both the v2 and v3 pillow plugin.