### PR TITLE
FEAT: allow plugin objects in plugin kwarg

### DIFF
--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 from .request import (
     IOMode,
@@ -65,7 +65,7 @@ def imopen(
     uri,
     io_mode: str,
     *,
-    plugin: str = None,
+    plugin: Union[str, Any] = None,
     legacy_mode: bool = True,
     **kwargs,
 ) -> Any:
@@ -81,7 +81,7 @@ def imopen(
     uri : str or pathlib.Path or bytes or file or Request
         The :doc:`ImageResources <getting_started.request>` to load the image
         from.
-    io_mode : {str}
+    io_mode : str
         The mode in which the file is opened. Possible values are::
 
             ``r`` - open the file for reading
@@ -98,14 +98,14 @@ def imopen(
             ``V`` for multiple volumes,
             ``?`` for don't care (default)
 
-    plugin : {str, None}
+    plugin : str, Plugin, or None
         The plugin to use. If set to None (default) imopen will perform a
         search for a matching plugin.
     legacy_mode : bool
         If true (default) use the v2 behavior when searching for a suitable
         plugin. This will ignore v3 plugins and will check ``plugin``
         against known extensions if no plugin with the given name can be found.
-    **kwargs : {any}
+    **kwargs : Any
         Additional keyword arguments will be passed to the plugin upon
         construction.
 
@@ -139,14 +139,23 @@ def imopen(
     # plugin specified, no search needed
     # (except in legacy mode)
     if plugin is not None:
-        try:
-            config = _get_config(plugin, legacy_mode)
-        except (IndexError, ValueError):
-            request.finish()
-            raise
+        if isinstance(plugin, str):
+            try:
+                config = _get_config(plugin, legacy_mode)
+            except (IndexError, ValueError):
+                request.finish()
+                raise
+
+            def loader(request, **kwargs):
+                return config.plugin_class(request, **kwargs)
+
+        else:
+
+            def loader(request, **kwargs):
+                return plugin(request, **kwargs)
 
         try:
-            return config.plugin_class(request, **kwargs)
+            return loader(request, **kwargs)
         except InitializationError as class_specific:
             err_from = class_specific
             err_type = RuntimeError if legacy_mode else IOError

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -173,7 +173,7 @@ def imopen(
         except Exception as generic_error:
             err_from = generic_error
             err_type = IOError
-            err_msg = f"An unknown error occured while initializing `{plugin}`."
+            err_msg = f"An unknown error occured while initializing plugin `{plugin}`."
 
         request.finish()
         raise err_type(err_msg) from err_from

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -149,10 +149,13 @@ def imopen(
             def loader(request, **kwargs):
                 return config.plugin_class(request, **kwargs)
 
-        else:
+        elif not legacy_mode:
 
             def loader(request, **kwargs):
                 return plugin(request, **kwargs)
+
+        else:
+            raise ValueError("The `plugin` argument must be a string.")
 
         try:
             return loader(request, **kwargs)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -975,7 +975,10 @@ def test_imopen_explicit_plugin_input(clear_plugins, tmp_path):
 
     from imageio.plugins.pillow import PillowPlugin
 
-    with iio.v3.imopen(tmp_path / "foo.tiff", "w", legacy_mode=False, plugin=PillowPlugin) as f:
+    with iio.v3.imopen(
+        tmp_path / "foo.tiff", "w", legacy_mode=False, plugin=PillowPlugin
+    ) as f:
         assert isinstance(f, PillowPlugin)
+
 
 run_tests_if_main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -969,4 +969,13 @@ def test_legacy_write_empty(image_files):
         iio.v3.imwrite(image_files / "foo.tiff", np.ones((0, 10, 10)))
 
 
+def test_imopen_explicit_plugin_input(clear_plugins, tmp_path):
+    with pytest.raises(OSError):
+        iio.v3.imopen(tmp_path / "foo.tiff", "w", legacy_mode=False)
+
+    from imageio.plugins.pillow import PillowPlugin
+
+    with iio.v3.imopen(tmp_path / "foo.tiff", "w", legacy_mode=False, plugin=PillowPlugin) as f:
+        assert isinstance(f, PillowPlugin)
+
 run_tests_if_main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -980,5 +980,8 @@ def test_imopen_explicit_plugin_input(clear_plugins, tmp_path):
     ) as f:
         assert isinstance(f, PillowPlugin)
 
+    with pytest.raises(ValueError):
+        iio.v3.imopen(tmp_path / "foo.tiff", "w", legacy_mode=True, plugin=PillowPlugin)
+
 
 run_tests_if_main()


### PR DESCRIPTION
Closes: #679 

Adds the ability to use plugin classes in `imopen`'s `plugin=` kwarg.

```python
iio.imread(url, plugin=MyPlugin)
```