### PR TITLE
BUG: allow TIFF to write bytes and file objects

### DIFF
--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -157,6 +157,7 @@ provide access to new performance improvements and bug fixes.
 import datetime
 
 from ..core import Format
+from ..core.request import URI_BYTES, URI_FILE
 
 import numpy as np
 
@@ -372,7 +373,9 @@ class TiffFormat(Format):
         return True
 
     def _can_write(self, request):
-        if request.extension not in self.extensions:
+        if request._uri_type in [URI_FILE, URI_BYTES]:
+            pass  # special URI
+        elif request.extension not in self.extensions:
             return False
 
         try:

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -144,4 +144,11 @@ def test_imagej_hyperstack(tmp_path):
     assert img.shape == (15, 2, 180, 183)
 
 
+def test_read_bytes(tmp_path):
+    # regression test for: https://github.com/imageio/imageio/issues/703
+
+    some_bytes = iio.imwrite("<bytes>", [[0]], format="tiff")
+    assert some_bytes is not None
+
+
 run_tests_if_main()


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/703

This PR makes `Tifffile._can_write` return `True` for bytes and FileObjects.