### PR TITLE
Use pytest fixture and markers for a simpler test control (closes #700)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
             pip install -q -U simpleitk astropy
       - name: Run All Unit tests
-        run: pytest -v
+        run: pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}
 
   pypy_tests:
     name: "${{ matrix.os }} / ${{ matrix.pyversion }}"
@@ -134,7 +134,7 @@ jobs:
             pypy3 -m pip install .[test,ffmpeg,tifffile]
       - name: Run Unit tests
         run: |
-            invoke test --unit
+            pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}
   
   build_test:
     name: Wheel Building Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
             pip install -q -U simpleitk astropy
       - name: Run All Unit tests
         run: |
-            coverage run -m pytest -v
+            coverage run -m pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}
       - name: Upload coverage to Codecov
         run: |
           curl -s https://codecov.io/bash | bash
@@ -119,4 +119,4 @@ jobs:
             pypy3 -m pip install .[test,ffmpeg,tifffile]
       - name: Run Unit tests
         run: |
-            invoke test --unit
+            pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ __pychache__
 *.dll
 *.dylib
 .*.swp
+*~
 
 # IDE
 .idea

--- a/imageio/testing.py
+++ b/imageio/testing.py
@@ -6,10 +6,6 @@
 
 import os
 import sys
-import inspect
-import shutil
-import atexit
-
 import pytest
 
 # Get root dir
@@ -19,77 +15,6 @@ for i in range(9):
     ROOT_DIR = os.path.dirname(ROOT_DIR)
     if os.path.isfile(os.path.join(ROOT_DIR, ".gitignore")):
         break
-
-
-# Functions to use in tests
-
-
-def run_tests_if_main(show_coverage=False):
-    """Run tests in a given file if it is run as a script
-
-    Coverage is reported for running this single test. Set show_coverage to
-    launch the report in the web browser.
-    """
-    local_vars = inspect.currentframe().f_back.f_locals
-    if not local_vars.get("__name__", "") == "__main__":
-        return
-    # we are in a "__main__"
-    os.chdir(ROOT_DIR)
-    fname = str(local_vars["__file__"])
-    _clear_imageio()
-    _enable_faulthandler()
-    pytest.main(
-        [
-            "-v",
-            "-x",
-            "--color=yes",
-            "--cov",
-            "imageio",
-            "--cov-config",
-            ".coveragerc",
-            "--cov-report",
-            "html",
-            fname,
-        ]
-    )
-    if show_coverage:
-        import webbrowser
-
-        fname = os.path.join(ROOT_DIR, "htmlcov", "index.html")
-        webbrowser.open_new_tab(fname)
-
-
-_the_test_dir = None
-
-
-def get_test_dir():
-    global _the_test_dir
-    if _the_test_dir is None:
-        # Define dir
-        from imageio.core import appdata_dir
-
-        _the_test_dir = os.path.join(appdata_dir("imageio"), "testdir")
-        # Clear and create it now
-        clean_test_dir(True)
-        os.makedirs(_the_test_dir)
-        os.makedirs(os.path.join(_the_test_dir, "images"))
-        # And later
-        atexit.register(clean_test_dir)
-    return _the_test_dir
-
-
-def clean_test_dir(strict=False):
-    if os.path.isdir(_the_test_dir):
-        try:
-            shutil.rmtree(_the_test_dir)
-        except Exception:
-            if strict:
-                raise
-
-
-def need_internet():
-    if os.getenv("IMAGEIO_NO_INTERNET", "").lower() in ("1", "true", "yes"):
-        pytest.skip("No internet")
 
 
 # Functions to use from invoke tasks

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ install_requires = ["numpy", "pillow >= 8.3.2"]
 extras_require = {
     "build": ["wheel"],
     "linting": ["black", "flake8"],
-    "test": ["invoke", "pytest", "pytest-cov", "fsspec"],
+    "test": ["invoke", "pytest", "pytest-cov", "fsspec[github]"],
     "docs": ["sphinx", "numpydoc", "pydata-sphinx-theme"],
     "itk": ["itk"],
     "bsdf": [],

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ install_requires = ["numpy", "pillow >= 8.3.2"]
 extras_require = {
     "build": ["wheel"],
     "linting": ["black", "flake8"],
-    "test": ["invoke", "pytest", "pytest-cov"],
+    "test": ["invoke", "pytest", "pytest-cov", "fsspec"],
     "docs": ["sphinx", "numpydoc", "pydata-sphinx-theme"],
     "itk": ["itk"],
     "bsdf": [],

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -45,7 +45,7 @@ def test(ctx, unit=False, installed=False, style=False, cover=False):
             elif p == ROOT_DIR or p == os.path.dirname(ROOT_DIR):
                 sys.path.remove(p)
         os.environ["IMAGEIO_NO_INTERNET"] = "1"
-        sys.exit(pytest_wrapper())
+        sys.exit(pytest_wrapper(needs_internet=False))
 
     if cover:
         res = pytest_wrapper(cov_report="html")
@@ -98,19 +98,26 @@ def black_wrapper(writeback):
     black.main()
 
 
-def pytest_wrapper(cov_report="term"):
+def pytest_wrapper(cov_report="term", needs_internet=True):
     """Helper function to run tests."""
     import pytest
 
-    return pytest.main(
-        [
-            "-v",
+    # basic opts
+    args = ["-v"]
+    if not needs_internet:
+        args += ["-m", "not needs_internet"]
+
+    # coverage add-on
+    args += [
             "--cov",
             "imageio",
             "--cov-config",
             ".coveragerc",
             "--cov-report",
             cov_report,
-            os.path.join(ROOT_DIR, "tests"),
-        ]
-    )
+            ]
+
+    # test location
+    args += [os.path.join(ROOT_DIR, "tests")]
+
+    return pytest.main(args)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -109,13 +109,13 @@ def pytest_wrapper(cov_report="term", needs_internet=True):
 
     # coverage add-on
     args += [
-            "--cov",
-            "imageio",
-            "--cov-config",
-            ".coveragerc",
-            "--cov-report",
-            cov_report,
-            ]
+        "--cov",
+        "imageio",
+        "--cov-config",
+        ".coveragerc",
+        "--cov-report",
+        cov_report,
+    ]
 
     # test location
     args += [os.path.join(ROOT_DIR, "tests")]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,9 +119,7 @@ def pytest_collection_modifyitems(items):
         if ("image_cache" in getattr(item, "fixturenames", ())) or (
             "image_copy" in getattr(item, "fixturenames", ())
         ):
-            if item.config.getoption("imageio_binaries").startswith(
-                internet_protocols
-            ):
+            if item.config.getoption("imageio_binaries").startswith(internet_protocols):
                 item.add_marker("needs_internet")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def pytest_addoption(parser):
         action="store",
         metavar="GIT_REPO",
         default="https://github.com/imageio/imageio-binaries.git",
-        help="Repository to use for checking out binary data used at tests"
+        help="Repository to use for checking out binary data used for tests"
         " (default: %(default)s).  Use 'file:///path/to/imageio-binaries'"
         " to clone from a local repository and save testing bandwidth.",
     )
@@ -156,23 +156,21 @@ def invalid_file(tmp_path, request):
 def tmp_userdir(tmp_path):
 
     ud = tmp_path / "userdir"
-    os.makedirs(ud, exist_ok=True)
+    ud.mkdir(exist_ok=True)
 
     if sys.platform.startswith("win"):
-        if "LOCALAPPDATA" in os.environ:  # saves it
-            os.environ["OLD_LOCALAPPDATA"] = os.environ["LOCALAPPDATA"]
-        os.environ["LOCALAPPDATA"] = str(ud)
+        user_dir_env = "LOCALAPPDATA"
     else:
-        os.environ["IMAGEIO_USERDIR"] = str(ud)
+        user_dir_env = "IMAGEIO_USERDIR"
+    
+    old_user_dir = os.getenv(user_dir_env, None)
+    os.environ[user_dir_env] = str(ud)
 
     yield ud
 
-    if sys.platform.startswith("win"):
-        del os.environ["LOCALAPPDATA"]
-        if "OLD_LOCALAPPDATA" in os.environ:
-            os.environ["LOCALAPPDATA"] = os.environ["OLD_LOCALAPPDATA"]
-            del os.environ["OLD_LOCALAPPDATA"]
+    if old_user_dir is not None:
+        os.environ[user_dir_env] = old_user_dir
     else:
-        del os.environ["IMAGEIO_USERDIR"]
+        del os.environ[user_dir_env]
 
     shutil.rmtree(ud)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,7 @@
 import os
 import sys
-import stat
 import shutil
 from pathlib import Path
-import contextlib
-import subprocess
 import contextlib
 
 import pytest
@@ -114,11 +111,11 @@ def image_files(test_images, tmp_path):
 
 def pytest_collection_modifyitems(items):
 
-    # all tests using the image_cache fixture, require internet automatically
+    # all tests using the test_images fixture, require internet automatically
     # iff they checkout from the remote repository - everything else does not
     internet_protocols = ("git", "http", "ssh")
     for item in items:
-        if ("image_cache" in getattr(item, "fixturenames", ())) or (
+        if ("test_images" in getattr(item, "fixturenames", ())) or (
             "image_copy" in getattr(item, "fixturenames", ())
         ):
             if item.config.getoption("imageio_binaries").startswith(internet_protocols):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,7 @@ def tmp_userdir(tmp_path):
         user_dir_env = "LOCALAPPDATA"
     else:
         user_dir_env = "IMAGEIO_USERDIR"
-    
+
     old_user_dir = os.getenv(user_dir_env, None)
     os.environ[user_dir_env] = str(ud)
 
@@ -172,5 +172,3 @@ def tmp_userdir(tmp_path):
         os.environ[user_dir_env] = old_user_dir
     else:
         del os.environ[user_dir_env]
-
-    shutil.rmtree(ud)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
-import pytest
 import os
+import pathlib
 import shutil
 from pathlib import Path
 import contextlib
+import subprocess
+import contextlib
+
+import pytest
 
 import imageio as iio
 
@@ -120,3 +124,12 @@ def invalid_file(tmp_path, request):
         file.write("Actually not a file.")
 
     return tmp_path / ("foo" + ext)
+
+
+@pytest.fixture()
+def tmp_userdir(tmp_path):
+    ud = tmp_path / "userdir"
+    os.makedirs(ud, exist_ok=True)
+    os.environ["IMAGEIO_USERDIR"] = str(ud)
+    yield ud
+    shutil.rmtree(ud)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,12 +19,12 @@ def pytest_configure(config):
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--imageio-binaries",
+        "--test-images",
         action="store",
         metavar="GIT_REPO",
-        default="https://github.com/imageio/imageio-binaries.git",
-        help="Repository to use for checking out binary data used for tests"
-        " (default: %(default)s).  Use 'file:///path/to/imageio-binaries'"
+        default="https://github.com/imageio/test_images.git",
+        help="Repository containing the test images "
+        " (default: %(default)s).  Use `file:///path/to/test_images`"
         " to clone from a local repository and save testing bandwidth.",
     )
 
@@ -82,7 +82,8 @@ def test_images(request):
             pass  # dir exist, validate and fail later
         else:
             with working_directory(checkout_dir):
-                os.system("git clone https://github.com/imageio/test_images.git .")
+                repo_location = request.config.getoption("--test-images")
+                os.system(f"git clone {repo_location} .")
 
         request.config.cache.set("imageio_test_binaries", str(checkout_dir))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,7 @@ import imageio as iio
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
-        "needs_internet: mark tests that require internet access "
-        "(deselect with '-m \"not needs_internet\"'",
+        "(deselect with '-m \"not needs_internet\"').",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,7 @@ def tmp_userdir(tmp_path):
     os.makedirs(ud, exist_ok=True)
 
     if sys.platform.startswith("win"):
-        if "LOCALAPPDATA" in os.environ:  #saves it
+        if "LOCALAPPDATA" in os.environ:  # saves it
             os.environ["OLD_LOCALAPPDATA"] = os.environ["LOCALAPPDATA"]
         os.environ["LOCALAPPDATA"] = str(ud)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def test_images(request):
     return checkout_dir
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_files(test_images, tmp_path):
     """A copy of the test images
 
@@ -95,7 +95,7 @@ def image_files(test_images, tmp_path):
     yield tmp_path
 
 
-@pytest.fixture
+@pytest.fixture()
 def clear_plugins():
 
     old_extensions = iio.config.known_extensions.copy()
@@ -122,7 +122,7 @@ def invalid_file(tmp_path, request):
     return tmp_path / ("foo" + ext)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_dir():
     # Define dir
     from imageio.core import appdata_dir
@@ -130,5 +130,7 @@ def test_dir():
     d = os.path.join(appdata_dir("imageio"), "testdir")
     os.makedirs(d)
     os.makedirs(os.path.join(d, "images"))
+
     yield d
+
     shutil.rmtree(d)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import shutil
 from pathlib import Path
 import contextlib

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,8 +153,12 @@ def invalid_file(tmp_path, request):
 
 @pytest.fixture()
 def tmp_userdir(tmp_path):
+
     ud = tmp_path / "userdir"
     os.makedirs(ud, exist_ok=True)
     os.environ["IMAGEIO_USERDIR"] = str(ud)
+
     yield ud
+
+    del os.environ["IMAGEIO_USERDIR"]
     shutil.rmtree(ud)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,17 +120,3 @@ def invalid_file(tmp_path, request):
         file.write("Actually not a file.")
 
     return tmp_path / ("foo" + ext)
-
-
-@pytest.fixture()
-def test_dir():
-    # Define dir
-    from imageio.core import appdata_dir
-
-    d = os.path.join(appdata_dir("imageio"), "testdir")
-    os.makedirs(d)
-    os.makedirs(os.path.join(d, "images"))
-
-    yield d
-
-    shutil.rmtree(d)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import shutil
 from pathlib import Path
 import contextlib
@@ -16,6 +15,18 @@ def pytest_configure(config):
         "markers",
         "needs_internet: Marks a test that requires an active interent connection."
         " (deselect with '-m \"not needs_internet\"').",
+    )
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--imageio-binaries",
+        action="store",
+        metavar="GIT_REPO",
+        default="https://github.com/imageio/imageio-binaries.git",
+        help="Repository to use for checking out binary data used at tests"
+        " (default: %(default)s).  Use 'file:///path/to/imageio-binaries'"
+        " to clone from a local repository and save testing bandwidth.",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,20 @@ def pytest_addoption(parser):
         " to clone from a local repository and save testing bandwidth.",
     )
 
+    parser.addoption(
+        "--github-token",
+        action="store",
+        default=None,
+        help="If set, this value will be used as a token to authenticate with the GitHub API.",
+    )
+
+    parser.addoption(
+        "--github-username",
+        action="store",
+        default=None,
+        help="If set, this value will be used as the username to authenticate with the GitHub API.",
+    )
+
 
 @contextlib.contextmanager
 def working_directory(path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,21 @@ def image_files(test_images, tmp_path):
     yield tmp_path
 
 
+def pytest_collection_modifyitems(items):
+
+    # all tests using the image_cache fixture, require internet automatically
+    # iff they checkout from the remote repository - everything else does not
+    internet_protocols = ("git", "http", "ssh")
+    for item in items:
+        if ("image_cache" in getattr(item, "fixturenames", ())) or (
+            "image_copy" in getattr(item, "fixturenames", ())
+        ):
+            if item.config.getoption("imageio_binaries").startswith(
+                internet_protocols
+            ):
+                item.add_marker("needs_internet")
+
+
 @pytest.fixture()
 def clear_plugins():
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,11 @@ def working_directory(path):
         os.chdir(prev_cwd)
 
 
-@pytest.fixture(scope="session")
+# uses the fixture marking workaround from:
+# https://github.com/pytest-dev/pytest/issues/1368#issuecomment-466339463
+@pytest.fixture(
+    scope="session", params=[pytest.param(0, marks=pytest.mark.needs_internet)]
+)
 def test_images(request):
     """A collection of test images.
 
@@ -107,19 +111,6 @@ def image_files(test_images, tmp_path):
             shutil.copy(item, tmp_path / item.name)
 
     yield tmp_path
-
-
-def pytest_collection_modifyitems(items):
-
-    # all tests using the test_images fixture, require internet automatically
-    # iff they checkout from the remote repository - everything else does not
-    internet_protocols = ("git", "http", "ssh")
-    for item in items:
-        if ("test_images" in getattr(item, "fixturenames", ())) or (
-            "image_copy" in getattr(item, "fixturenames", ())
-        ):
-            if item.config.getoption("imageio_binaries").startswith(internet_protocols):
-                item.add_marker("needs_internet")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,8 @@ import imageio as iio
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
-        "(deselect with '-m \"not needs_internet\"').",
+        "needs_internet: Marks a test that requires an active interent connection."
+        " (deselect with '-m \"not needs_internet\"').",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,14 @@ import contextlib
 import imageio as iio
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "needs_internet: mark tests that require internet access "
+        "(deselect with '-m \"not needs_internet\"'",
+    )
+
+
 @contextlib.contextmanager
 def working_directory(path):
     """
@@ -112,3 +120,15 @@ def invalid_file(tmp_path, request):
         file.write("Actually not a file.")
 
     return tmp_path / ("foo" + ext)
+
+
+@pytest.fixture(scope="module")
+def test_dir():
+    # Define dir
+    from imageio.core import appdata_dir
+
+    d = os.path.join(appdata_dir("imageio"), "testdir")
+    os.makedirs(d)
+    os.makedirs(os.path.join(d, "images"))
+    yield d
+    shutil.rmtree(d)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import stat
 import shutil
 from pathlib import Path
@@ -156,9 +157,22 @@ def tmp_userdir(tmp_path):
 
     ud = tmp_path / "userdir"
     os.makedirs(ud, exist_ok=True)
-    os.environ["IMAGEIO_USERDIR"] = str(ud)
+
+    if sys.platform.startswith("win"):
+        if "LOCALAPPDATA" in os.environ:  #saves it
+            os.environ["OLD_LOCALAPPDATA"] = os.environ["LOCALAPPDATA"]
+        os.environ["LOCALAPPDATA"] = str(ud)
+    else:
+        os.environ["IMAGEIO_USERDIR"] = str(ud)
 
     yield ud
 
-    del os.environ["IMAGEIO_USERDIR"]
+    if sys.platform.startswith("win"):
+        del os.environ["LOCALAPPDATA"]
+        if "OLD_LOCALAPPDATA" in os.environ:
+            os.environ["LOCALAPPDATA"] = os.environ["OLD_LOCALAPPDATA"]
+            del os.environ["OLD_LOCALAPPDATA"]
+    else:
+        del os.environ["IMAGEIO_USERDIR"]
+
     shutil.rmtree(ud)

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -5,14 +5,13 @@
 import numpy as np
 
 from pytest import raises
-from imageio.core import get_remote_file
 from imageio import core
 
 import imageio
 from imageio.plugins import _bsdf as bsdf
 
-
 import pytest
+import pathlib
 import sys
 
 xfail_big_endian = pytest.mark.xfail(
@@ -20,13 +19,12 @@ xfail_big_endian = pytest.mark.xfail(
 )
 
 
-@pytest.mark.needs_internet
-def test_select(tmp_path):
+def test_select(image_cache):
 
     F = imageio.formats["BSDF"]
     assert F.name == "BSDF"
 
-    fname1 = get_remote_file("images/chelsea.bsdf", tmp_path)
+    fname1 = image_cache / "test-images" / "chelsea.bsdf"
 
     assert F.can_read(core.Request(fname1, "rI"))
     assert F.can_write(core.Request(fname1, "wI"))
@@ -70,10 +68,9 @@ def test_not_an_image(tmp_path):
 
 
 @xfail_big_endian
-@pytest.mark.needs_internet
-def test_singleton(tmp_path):
+def test_singleton(image_cache, tmp_path):
 
-    im1 = imageio.imread("imageio:chelsea.png")
+    im1 = imageio.imread(image_cache / "test-images" / "chelsea.png")
 
     fname = str(tmp_path / "chelsea.bsdf")
     imageio.imsave(fname, im1)
@@ -102,10 +99,10 @@ def test_singleton(tmp_path):
 
 
 @xfail_big_endian
-@pytest.mark.needs_internet
-def test_series(tmp_path):
+def test_series(image_cache, tmp_path):
 
-    im1 = imageio.imread("imageio:chelsea.png")
+    im1 = imageio.imread(image_cache / "test-images" / "chelsea.png")
+
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
     fname = str(tmp_path / "chelseam.bsdf")
@@ -136,9 +133,8 @@ def test_series(tmp_path):
 
 
 @xfail_big_endian
-@pytest.mark.needs_internet
-def test_series_unclosed(tmp_path):
-    im1 = imageio.imread("imageio:chelsea.png")
+def test_series_unclosed(image_cache, tmp_path):
+    im1 = imageio.imread(image_cache / "test-images" / "chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
     fname = tmp_path / "chelseam.bsdf"
@@ -167,10 +163,9 @@ def test_series_unclosed(tmp_path):
 
 
 @xfail_big_endian
-@pytest.mark.needs_internet
-def test_random_access(tmp_path):
+def test_random_access(image_cache, tmp_path):
 
-    im1 = imageio.imread("imageio:chelsea.png")
+    im1 = imageio.imread(image_cache / "test-images" / "chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
     fname = tmp_path / "chelseam.bsdf"
@@ -185,10 +180,10 @@ def test_random_access(tmp_path):
 
 
 @xfail_big_endian
-@pytest.mark.needs_internet
-def test_volume(tmp_path):
+def test_volume(image_cache, tmp_path):
 
-    vol1 = imageio.imread("imageio:stent.npz")
+    fname1 = image_cache / "images" / "stent.npz"
+    vol1 = imageio.imread(fname1)
     assert vol1.shape == (256, 128, 128)
 
     fname = tmp_path / "stent.bsdf"
@@ -200,7 +195,7 @@ def test_volume(tmp_path):
 
 
 @pytest.mark.needs_internet
-def test_from_url():
+def test_from_url(image_cache):
 
     im = imageio.imread(
         "https://raw.githubusercontent.com/imageio/"

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -51,7 +51,7 @@ def test_select(tmp_path):
 
 def test_not_an_image(tmp_path):
 
-    fname = os.path.join(tmp_path, "notanimage.bsdf")
+    fname = tmp_path / "notanimage.bsdf"
 
     # Not an image not a list
     bsdf.save(fname, 1)

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -6,7 +6,6 @@ import os
 import numpy as np
 
 from pytest import raises
-from imageio.testing import run_tests_if_main, get_test_dir, need_internet
 from imageio.core import get_remote_file
 from imageio import core
 
@@ -21,20 +20,12 @@ xfail_big_endian = pytest.mark.xfail(
     sys.byteorder == "big", reason="expected failure on big-endian"
 )
 
-test_dir = get_test_dir()
 
-
-def setup_module():
-    if not os.path.isdir(test_dir):
-        os.makedirs(test_dir)
-
-
-def test_select():
+@pytest.mark.needs_internet
+def test_select(test_dir):
 
     F = imageio.formats["BSDF"]
     assert F.name == "BSDF"
-
-    need_internet()
 
     fname1 = get_remote_file("images/chelsea.bsdf", test_dir)
 
@@ -58,7 +49,7 @@ def test_select():
     )
 
 
-def test_not_an_image():
+def test_not_an_image(test_dir):
 
     fname = os.path.join(test_dir, "notanimage.bsdf")
 
@@ -80,7 +71,8 @@ def test_not_an_image():
 
 
 @xfail_big_endian
-def test_singleton():
+@pytest.mark.needs_internet
+def test_singleton(test_dir):
 
     im1 = imageio.imread("imageio:chelsea.png")
 
@@ -111,7 +103,8 @@ def test_singleton():
 
 
 @xfail_big_endian
-def test_series():
+@pytest.mark.needs_internet
+def test_series(test_dir):
 
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
@@ -144,7 +137,8 @@ def test_series():
 
 
 @xfail_big_endian
-def test_series_unclosed():
+@pytest.mark.needs_internet
+def test_series_unclosed(test_dir):
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
@@ -174,7 +168,8 @@ def test_series_unclosed():
 
 
 @xfail_big_endian
-def test_random_access():
+@pytest.mark.needs_internet
+def test_random_access(test_dir):
 
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
@@ -191,7 +186,8 @@ def test_random_access():
 
 
 @xfail_big_endian
-def test_volume():
+@pytest.mark.needs_internet
+def test_volume(test_dir):
 
     vol1 = imageio.imread("imageio:stent.npz")
     assert vol1.shape == (256, 128, 128)
@@ -204,9 +200,8 @@ def test_volume():
     assert np.all(vol1 == vol2)
 
 
+@pytest.mark.needs_internet
 def test_from_url():
-
-    need_internet()
 
     im = imageio.imread(
         "https://raw.githubusercontent.com/imageio/"
@@ -225,6 +220,3 @@ def test_from_url():
     # No rewinding, because we read in streaming mode
     with raises(IndexError):
         r.get_data(9)
-
-
-run_tests_if_main()

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -27,7 +27,7 @@ def test_select(tmp_path):
     F = imageio.formats["BSDF"]
     assert F.name == "BSDF"
 
-    fname1 = get_remote_file("images/chelsea.bsdf", tmp_path)
+    fname1 = readonly_test_images / "chelsea.bsdf"
 
     assert F.can_read(core.Request(fname1, "rI"))
     assert F.can_write(core.Request(fname1, "wI"))

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -11,7 +11,6 @@ import imageio
 from imageio.plugins import _bsdf as bsdf
 
 import pytest
-import pathlib
 import sys
 
 xfail_big_endian = pytest.mark.xfail(

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -109,7 +109,7 @@ def test_series(tmp_path):
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
-    fname = os.path.join(tmp_path, "chelseam.bsdf")
+    fname = tmp_path / "chelseam.bsdf"
     imageio.mimsave(fname, ims1)
 
     # Does it look alright if we open it in bsdf without extensions?

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -76,7 +76,7 @@ def test_singleton(tmp_path):
 
     im1 = imageio.imread("imageio:chelsea.png")
 
-    fname = os.path.join(tmp_path, "chelsea.bsdf")
+    fname = tmp_path / "chelsea.bsdf"
     imageio.imsave(fname, im1)
 
     # Does it look alright if we open it in bsdf without extensions?

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -142,7 +142,7 @@ def test_series_unclosed(tmp_path):
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
-    fname = os.path.join(tmp_path, "chelseam.bsdf")
+    fname = tmp_path / "chelseam.bsdf"
     w = imageio.get_writer(fname)
     for im in ims1:
         w.append_data(im)
@@ -174,7 +174,7 @@ def test_random_access(tmp_path):
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
-    fname = os.path.join(tmp_path, "chelseam.bsdf")
+    fname = tmp_path / "chelseam.bsdf"
     imageio.mimsave(fname, ims1)
 
     r = imageio.get_reader(fname)
@@ -192,7 +192,7 @@ def test_volume(tmp_path):
     vol1 = imageio.imread("imageio:stent.npz")
     assert vol1.shape == (256, 128, 128)
 
-    fname = os.path.join(tmp_path, "stent.bsdf")
+    fname = tmp_path / "stent.bsdf"
     imageio.volsave(fname, vol1)
 
     vol2 = imageio.volread(fname)

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -18,12 +18,12 @@ xfail_big_endian = pytest.mark.xfail(
 )
 
 
-def test_select(image_cache):
+def test_select(test_images):
 
     F = imageio.formats["BSDF"]
     assert F.name == "BSDF"
 
-    fname1 = image_cache / "test-images" / "chelsea.bsdf"
+    fname1 = test_images / "chelsea.bsdf"
 
     assert F.can_read(core.Request(fname1, "rI"))
     assert F.can_write(core.Request(fname1, "wI"))
@@ -67,9 +67,9 @@ def test_not_an_image(tmp_path):
 
 
 @xfail_big_endian
-def test_singleton(image_cache, tmp_path):
+def test_singleton(test_images, tmp_path):
 
-    im1 = imageio.imread(image_cache / "test-images" / "chelsea.png")
+    im1 = imageio.imread(test_images / "chelsea.png")
 
     fname = str(tmp_path / "chelsea.bsdf")
     imageio.imsave(fname, im1)
@@ -98,9 +98,9 @@ def test_singleton(image_cache, tmp_path):
 
 
 @xfail_big_endian
-def test_series(image_cache, tmp_path):
+def test_series(test_images, tmp_path):
 
-    im1 = imageio.imread(image_cache / "test-images" / "chelsea.png")
+    im1 = imageio.imread(test_images / "chelsea.png")
 
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
@@ -132,8 +132,8 @@ def test_series(image_cache, tmp_path):
 
 
 @xfail_big_endian
-def test_series_unclosed(image_cache, tmp_path):
-    im1 = imageio.imread(image_cache / "test-images" / "chelsea.png")
+def test_series_unclosed(test_images, tmp_path):
+    im1 = imageio.imread(test_images / "chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
     fname = tmp_path / "chelseam.bsdf"
@@ -162,9 +162,9 @@ def test_series_unclosed(image_cache, tmp_path):
 
 
 @xfail_big_endian
-def test_random_access(image_cache, tmp_path):
+def test_random_access(test_images, tmp_path):
 
-    im1 = imageio.imread(image_cache / "test-images" / "chelsea.png")
+    im1 = imageio.imread(test_images / "chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
     fname = tmp_path / "chelseam.bsdf"
@@ -179,9 +179,9 @@ def test_random_access(image_cache, tmp_path):
 
 
 @xfail_big_endian
-def test_volume(image_cache, tmp_path):
+def test_volume(test_images, tmp_path):
 
-    fname1 = image_cache / "images" / "stent.npz"
+    fname1 = test_images / "stent.npz"
     vol1 = imageio.imread(fname1)
     assert vol1.shape == (256, 128, 128)
 
@@ -194,7 +194,7 @@ def test_volume(image_cache, tmp_path):
 
 
 @pytest.mark.needs_internet
-def test_from_url(image_cache):
+def test_from_url(test_images):
 
     im = imageio.imread(
         "https://raw.githubusercontent.com/imageio/"

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -22,12 +22,12 @@ xfail_big_endian = pytest.mark.xfail(
 
 
 @pytest.mark.needs_internet
-def test_select(test_dir):
+def test_select(tmp_path):
 
     F = imageio.formats["BSDF"]
     assert F.name == "BSDF"
 
-    fname1 = get_remote_file("images/chelsea.bsdf", test_dir)
+    fname1 = get_remote_file("images/chelsea.bsdf", tmp_path)
 
     assert F.can_read(core.Request(fname1, "rI"))
     assert F.can_write(core.Request(fname1, "wI"))
@@ -49,9 +49,9 @@ def test_select(test_dir):
     )
 
 
-def test_not_an_image(test_dir):
+def test_not_an_image(tmp_path):
 
-    fname = os.path.join(test_dir, "notanimage.bsdf")
+    fname = os.path.join(tmp_path, "notanimage.bsdf")
 
     # Not an image not a list
     bsdf.save(fname, 1)
@@ -72,11 +72,11 @@ def test_not_an_image(test_dir):
 
 @xfail_big_endian
 @pytest.mark.needs_internet
-def test_singleton(test_dir):
+def test_singleton(tmp_path):
 
     im1 = imageio.imread("imageio:chelsea.png")
 
-    fname = os.path.join(test_dir, "chelsea.bsdf")
+    fname = os.path.join(tmp_path, "chelsea.bsdf")
     imageio.imsave(fname, im1)
 
     # Does it look alright if we open it in bsdf without extensions?
@@ -104,12 +104,12 @@ def test_singleton(test_dir):
 
 @xfail_big_endian
 @pytest.mark.needs_internet
-def test_series(test_dir):
+def test_series(tmp_path):
 
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
-    fname = os.path.join(test_dir, "chelseam.bsdf")
+    fname = os.path.join(tmp_path, "chelseam.bsdf")
     imageio.mimsave(fname, ims1)
 
     # Does it look alright if we open it in bsdf without extensions?
@@ -138,11 +138,11 @@ def test_series(test_dir):
 
 @xfail_big_endian
 @pytest.mark.needs_internet
-def test_series_unclosed(test_dir):
+def test_series_unclosed(tmp_path):
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
-    fname = os.path.join(test_dir, "chelseam.bsdf")
+    fname = os.path.join(tmp_path, "chelseam.bsdf")
     w = imageio.get_writer(fname)
     for im in ims1:
         w.append_data(im)
@@ -169,12 +169,12 @@ def test_series_unclosed(test_dir):
 
 @xfail_big_endian
 @pytest.mark.needs_internet
-def test_random_access(test_dir):
+def test_random_access(tmp_path):
 
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
-    fname = os.path.join(test_dir, "chelseam.bsdf")
+    fname = os.path.join(tmp_path, "chelseam.bsdf")
     imageio.mimsave(fname, ims1)
 
     r = imageio.get_reader(fname)
@@ -187,12 +187,12 @@ def test_random_access(test_dir):
 
 @xfail_big_endian
 @pytest.mark.needs_internet
-def test_volume(test_dir):
+def test_volume(tmp_path):
 
     vol1 = imageio.imread("imageio:stent.npz")
     assert vol1.shape == (256, 128, 128)
 
-    fname = os.path.join(test_dir, "stent.bsdf")
+    fname = os.path.join(tmp_path, "stent.bsdf")
     imageio.volsave(fname, vol1)
 
     vol2 = imageio.volread(fname)

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -50,7 +50,7 @@ def test_select(tmp_path):
 
 def test_not_an_image(tmp_path):
 
-    fname = tmp_path / "notanimage.bsdf"
+    fname = str(tmp_path / "notanimage.bsdf")
 
     # Not an image not a list
     bsdf.save(fname, 1)
@@ -75,7 +75,7 @@ def test_singleton(tmp_path):
 
     im1 = imageio.imread("imageio:chelsea.png")
 
-    fname = tmp_path / "chelsea.bsdf"
+    fname = str(tmp_path / "chelsea.bsdf")
     imageio.imsave(fname, im1)
 
     # Does it look alright if we open it in bsdf without extensions?
@@ -108,7 +108,7 @@ def test_series(tmp_path):
     im1 = imageio.imread("imageio:chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
-    fname = tmp_path / "chelseam.bsdf"
+    fname = str(tmp_path / "chelseam.bsdf")
     imageio.mimsave(fname, ims1)
 
     # Does it look alright if we open it in bsdf without extensions?

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -1,7 +1,6 @@
 """ Test BSDF plugin.
 """
 
-import os
 
 import numpy as np
 
@@ -27,7 +26,7 @@ def test_select(tmp_path):
     F = imageio.formats["BSDF"]
     assert F.name == "BSDF"
 
-    fname1 = readonly_test_images / "chelsea.bsdf"
+    fname1 = get_remote_file("images/chelsea.bsdf", tmp_path)
 
     assert F.can_read(core.Request(fname1, "rI"))
     assert F.can_write(core.Request(fname1, "wI"))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -136,9 +136,7 @@ def test_findlib2():
     fi_dir = os.path.join(core.appdata_dir("imageio"), "freeimage")
     if not os.path.isdir(fi_dir):
         os.mkdir(fi_dir)
-    dirs, paths = core.findlib.generate_candidate_libs(
-        ["libfreeimage"], [fi_dir]
-    )
+    dirs, paths = core.findlib.generate_candidate_libs(["libfreeimage"], [fi_dir])
     # assert fi_dir in dirs -> Cannot test: lib may not exist
 
     open(os.path.join(fi_dir, "notalib.test.so"), "wb")
@@ -642,9 +640,7 @@ def test_functions(image_cache, tmp_path):
     W2.close()
     assert type(W1) is type(W2)
     # Fail
-    raises(
-        FileNotFoundError, imageio.save, "~/dirdoesnotexist/wtf.notexistingfile"
-    )
+    raises(FileNotFoundError, imageio.save, "~/dirdoesnotexist/wtf.notexistingfile")
 
     # Test imread()
     im1 = imageio.imread(fname1)
@@ -849,9 +845,7 @@ def test_imopen_no_plugin_found(clear_plugins):
 @pytest.mark.parametrize("invalid_file", [".jpg"], indirect=["invalid_file"])
 def test_imopen_unregistered_plugin(clear_plugins, invalid_file):
     with pytest.raises(ValueError):
-        iio.imopen(
-            invalid_file, "r", plugin="unknown_plugin", legacy_mode=False
-        )
+        iio.imopen(invalid_file, "r", plugin="unknown_plugin", legacy_mode=False)
 
 
 def test_plugin_selection_failure(clear_plugins):
@@ -969,14 +963,10 @@ def test_volwrite_failure():
 
 
 def test_memory_size(image_cache):
-    im = iio.mimread(
-        image_cache / "test-images" / "newtonscradle.gif", memtest=True
-    )
+    im = iio.mimread(image_cache / "test-images" / "newtonscradle.gif", memtest=True)
     assert len(im) == 36
 
-    im = iio.mimread(
-        image_cache / "test-images" / "newtonscradle.gif", memtest=None
-    )
+    im = iio.mimread(image_cache / "test-images" / "newtonscradle.gif", memtest=None)
     assert len(im) == 36
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -59,8 +59,6 @@ def test_fetching(tmp_path):
     """Test fetching of files"""
 
     # Clear image files
-    if os.path.isdir(tmp_path):
-        shutil.rmtree(tmp_path)
 
     # This should download the file (force download, because local cache)
     fname1 = get_remote_file("images/chelsea.png", tmp_path, True)
@@ -94,7 +92,8 @@ def test_fetching(tmp_path):
     _urlopen = core.fetching.urlopen
     _chunk_read = core.fetching._chunk_read
     #
-    raises(IOError, get_remote_file, "this_does_not_exist", tmp_path)
+    with pytest.raises(IOError):
+        get_remote_file("this_does_not_exist", tmp_path)
     #
     try:
         core.fetching.urlopen = None
@@ -247,7 +246,7 @@ def test_request_read_sources(tmp_path):
     bytes = open(filename, "rb").read()
     #
     burl = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/"
-    zipfilename = os.path.join(tmp_path, "test1.zip")
+    zipfilename = tmp_path / "test1.zip"
     with ZipFile(zipfilename, "w") as zf:
         zf.writestr(fname, bytes)
 
@@ -297,8 +296,8 @@ def test_request_save_sources(tmp_path):
 
     # Prepare destinations
     fname2 = fname + ".out"
-    filename2 = os.path.join(tmp_path, fname2)
-    zipfilename2 = os.path.join(tmp_path, "test2.zip")
+    filename2 = tmp_path / fname2
+    zipfilename2 = tmp_path / "test2.zip"
     file2 = None
 
     # Write an image into many different destinations
@@ -700,7 +699,7 @@ def test_functions(tmp_path):
 
     # Test volsave()
     volc = np.zeros((10, 10, 10, 3), np.uint8)  # color volume
-    fname6 = os.path.join(tmp_path, "images", "stent2.npz")
+    fname6 = tmp_path / "images" / "stent2.npz"
     if os.path.isfile(fname6):
         os.remove(fname6)
     assert not os.path.isfile(fname6)
@@ -779,7 +778,7 @@ def test_memtest(tmp_path):
 def test_example_plugin(tmp_path):
     """Test the example plugin"""
 
-    fname = os.path.join(tmp_path, "out.png")
+    fname = tmp_path / "out.png"
     r = Request("imageio:chelsea.png", "r?")
     R = imageio.formats["dummy"].get_reader(r)
     W = imageio.formats["dummy"].get_writer(Request(fname, "w?"))
@@ -902,7 +901,7 @@ def test_imopen_installable_plugin(clear_plugins):
 
 def test_legacy_object_image_writing(tmp_path):
     with pytest.raises(ValueError):
-        iio.mimwrite(os.path.join(tmp_path, "foo.gif"), np.array([[0]], dtype=object))
+        iio.mimwrite(tmp_path / "foo.gif", np.array([[0]], dtype=object))
 
 
 @pytest.mark.needs_internet

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -114,19 +114,6 @@ def test_fetching(tmp_path):
     assert "0 bytes" == core.fetching._sizeof_fmt(0)
 
 
-@pytest.mark.skip(reason="always skip, is tested implicitly anyway")
-def test_findlib1():
-
-    # Lib name would need to be "libc.so.5", or "libc.so.6", or ...
-    # Meh, just skip
-    if not sys.platform.startswith("linux"):
-        skip("test on linux only")
-
-    # Candidate libs for common lib (note, this runs only on linux)
-    _, paths = core.findlib.generate_candidate_libs(["libc"])
-    assert paths
-
-
 def test_findlib2():
 
     if not sys.platform.startswith("linux"):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -152,7 +152,7 @@ def test_findlib2():
 
 
 @pytest.mark.needs_internet
-def test_request(image_cache, tmp_userdir):
+def test_request(test_images, tmp_userdir):
     """Test request object"""
 
     # Check uri-type, this is not a public property, so we test the private
@@ -167,7 +167,7 @@ def test_request(image_cache, tmp_userdir):
     R = Request(imageio.RETURN_BYTES, "wi")
     assert R._uri_type == core.request.URI_BYTES
     #
-    fname = image_cache / "images" / "chelsea.png"
+    fname = test_images / "chelsea.png"
     R = Request(fname, "ri")
     assert R._uri_type == core.request.URI_FILENAME
     R = Request("~/filethatdoesnotexist", "wi")
@@ -234,14 +234,14 @@ def test_request(image_cache, tmp_userdir):
 
 
 @pytest.mark.needs_internet
-def test_request_read_sources(image_cache, tmp_userdir):
+def test_request_read_sources(test_images, tmp_userdir):
 
     # Make an image available in many ways
-    fname = "images/chelsea.png"
-    filename = image_cache / fname
+    fname = "chelsea.png"
+    filename = test_images / fname
     bytes = open(str(filename), "rb").read()
     #
-    burl = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/"
+    burl = "https://raw.githubusercontent.com/imageio/test_images/master/"
     zipfilename = tmp_userdir / "test1.zip"
     with ZipFile(zipfilename, "w") as zf:
         zf.writestr(fname, bytes)
@@ -277,10 +277,10 @@ def test_request_read_sources(image_cache, tmp_userdir):
                     assert all_bytes.startswith(first_bytes)
 
 
-def test_request_save_sources(image_cache, tmp_path):
+def test_request_save_sources(test_images, tmp_path):
 
     # Get test data
-    filename = image_cache / "test-images" / "chelsea.png"
+    filename = test_images / "chelsea.png"
     with open(filename, "rb") as f:
         bytes = f.read()
     assert len(bytes) > 0
@@ -605,14 +605,14 @@ def test_util_has_has_module():
     assert core.has_module("sys")
 
 
-def test_functions(image_cache, tmp_path):
+def test_functions(test_images, tmp_path):
     """Test the user-facing API functions"""
 
     # Test help(), it prints stuff, so we just check whether that goes ok
     imageio.help()  # should print overview
     imageio.help("PNG")  # should print about PNG
 
-    fname1 = image_cache / "test-images" / "chelsea.png"
+    fname1 = test_images / "chelsea.png"
     fname2 = tmp_path / fname1.with_suffix(".jpg").name
     fname3 = tmp_path / fname1.with_suffix(".notavalidext").name
     open(fname3, "wb")
@@ -657,7 +657,7 @@ def test_functions(image_cache, tmp_path):
     assert os.path.isfile(fname2)
 
     # Test mimread()
-    fname3 = image_cache / "images" / "newtonscradle.gif"
+    fname3 = test_images / "newtonscradle.gif"
     ims = imageio.mimread(fname3)
     assert isinstance(ims, list)
     assert len(ims) > 1
@@ -665,9 +665,7 @@ def test_functions(image_cache, tmp_path):
     assert ims[0].shape[2] in (1, 3, 4)
     # Test protection
     with raises(RuntimeError):
-        imageio.mimread(
-            image_cache / "test-images" / "chelsea.png", "dummy", length=np.inf
-        )
+        imageio.mimread(test_images / "chelsea.png", "dummy", length=np.inf)
 
     if IS_PYPY:
         return  # no support for npz format :(
@@ -683,7 +681,7 @@ def test_functions(image_cache, tmp_path):
     assert os.path.isfile(fname5)
 
     # Test volread()
-    fname4 = image_cache / "images" / "stent.npz"
+    fname4 = test_images / "stent.npz"
     vol = imageio.volread(fname4)
     assert vol.ndim == 3
     assert vol.shape[0] == 256
@@ -748,8 +746,8 @@ def test_to_nbytes_incorrect(arg):
         to_nbytes(arg)
 
 
-def test_memtest(image_cache, tmp_path):
-    fname3 = image_cache / "images" / "newtonscradle.gif"
+def test_memtest(test_images, tmp_path):
+    fname3 = test_images / "newtonscradle.gif"
     imageio.mimread(fname3)  # trivial case
     imageio.mimread(fname3, memtest=1000 ** 2 * 256)
     imageio.mimread(fname3, memtest="256MB")
@@ -766,11 +764,11 @@ def test_memtest(image_cache, tmp_path):
         imageio.mimread(fname3, memtest="64b")
 
 
-def test_example_plugin(image_cache, tmp_path):
+def test_example_plugin(test_images, tmp_path):
     """Test the example plugin"""
 
     fname = tmp_path / "out.png"
-    r = Request(image_cache / "test-images" / "chelsea.png", "r?")
+    r = Request(test_images / "chelsea.png", "r?")
     R = imageio.formats["dummy"].get_reader(r)
     W = imageio.formats["dummy"].get_writer(Request(fname, "w?"))
     #
@@ -895,19 +893,19 @@ def test_legacy_object_image_writing(tmp_path):
         iio.mimwrite(tmp_path / "foo.gif", np.array([[0]], dtype=object))
 
 
-def test_imiter(image_cache):
+def test_imiter(test_images):
     # maybe it would be better to load the image without using imageio, e.g.
-    # numpy_im = np.load(image_cache / "test-images" / "newtonscradle_rgb.npy")
+    # numpy_im = np.load(test_images / "newtonscradle_rgb.npy")
 
     full_image = iio.v3.imread(
-        image_cache / "test-images" / "newtonscradle.gif",
+        test_images / "newtonscradle.gif",
         plugin="pillow",
         mode="RGB",
     )
 
     for idx, im in enumerate(
         iio.v3.imiter(
-            image_cache / "test-images" / "newtonscradle.gif",
+            test_images / "newtonscradle.gif",
             plugin="pillow",
             mode="RGB",
         )
@@ -929,7 +927,7 @@ def test_faulty_legacy_mode_access():
 
 
 @pytest.mark.needs_internet
-def test_mvolread_out_of_bytes(image_cache):
+def test_mvolread_out_of_bytes(test_images):
     with pytest.raises(RuntimeError):
         imageio.mvolread(
             "https://github.com/imageio/imageio-binaries/blob/master/images/multipage_rgb.tif?raw=true",
@@ -962,11 +960,11 @@ def test_volwrite_failure():
         iio.volwrite("foo.jpg", not_image_data)
 
 
-def test_memory_size(image_cache):
-    im = iio.mimread(image_cache / "test-images" / "newtonscradle.gif", memtest=True)
+def test_memory_size(test_images):
+    im = iio.mimread(test_images / "newtonscradle.gif", memtest=True)
     assert len(im) == 36
 
-    im = iio.mimread(image_cache / "test-images" / "newtonscradle.gif", memtest=None)
+    im = iio.mimread(test_images / "newtonscradle.gif", memtest=None)
     assert len(im) == 36
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -141,9 +141,7 @@ def test_findlib2():
     fi_dir = os.path.join(core.appdata_dir("imageio"), "freeimage")
     if not os.path.isdir(fi_dir):
         os.mkdir(fi_dir)
-    dirs, paths = core.findlib.generate_candidate_libs(
-        ["libfreeimage"], [fi_dir]
-    )
+    dirs, paths = core.findlib.generate_candidate_libs(["libfreeimage"], [fi_dir])
     # assert fi_dir in dirs -> Cannot test: lib may not exist
 
     open(os.path.join(fi_dir, "notalib.test.so"), "wb")
@@ -653,9 +651,7 @@ def test_functions(test_dir):
     W2.close()
     assert type(W1) is type(W2)
     # Fail
-    raises(
-        FileNotFoundError, imageio.save, "~/dirdoesnotexist/wtf.notexistingfile"
-    )
+    raises(FileNotFoundError, imageio.save, "~/dirdoesnotexist/wtf.notexistingfile")
 
     # Test imread()
     im1 = imageio.imread(fname1)
@@ -859,9 +855,7 @@ def test_imopen_no_plugin_found(clear_plugins):
 @pytest.mark.parametrize("invalid_file", [".jpg"], indirect=["invalid_file"])
 def test_imopen_unregistered_plugin(clear_plugins, invalid_file):
     with pytest.raises(ValueError):
-        iio.imopen(
-            invalid_file, "r", plugin="unknown_plugin", legacy_mode=False
-        )
+        iio.imopen(invalid_file, "r", plugin="unknown_plugin", legacy_mode=False)
 
 
 def test_plugin_selection_failure(clear_plugins):
@@ -908,9 +902,7 @@ def test_imopen_installable_plugin(clear_plugins):
 
 def test_legacy_object_image_writing(tmp_path):
     with pytest.raises(ValueError):
-        iio.mimwrite(
-            os.path.join(tmp_path, "foo.gif"), np.array([[0]], dtype=object)
-        )
+        iio.mimwrite(os.path.join(tmp_path, "foo.gif"), np.array([[0]], dtype=object))
 
 
 @pytest.mark.needs_internet
@@ -923,9 +915,7 @@ def test_imiter(image_files: Path):
     )
 
     for idx, im in enumerate(
-        iio.v3.imiter(
-            image_files / "newtonscradle.gif", plugin="pillow", mode="RGB"
-        )
+        iio.v3.imiter(image_files / "newtonscradle.gif", plugin="pillow", mode="RGB")
     ):
         assert np.allclose(full_image[idx, ...], im)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,23 +55,23 @@ class BrokenDummyPlugin:
 
 
 @pytest.mark.needs_internet
-def test_fetching(tmp_userdir):
+def test_fetching(tmp_path):
     """Test fetching of files"""
 
     # This should download the file (force download, because local cache)
-    fname1 = get_remote_file("images/chelsea.png", tmp_userdir, True)
+    fname1 = get_remote_file("images/chelsea.png", tmp_path, True)
     mtime1 = os.path.getmtime(fname1)
     # This should reuse it
-    fname2 = get_remote_file("images/chelsea.png", tmp_userdir)
+    fname2 = get_remote_file("images/chelsea.png", tmp_path)
     mtime2 = os.path.getmtime(fname2)
     # This should overwrite
-    fname3 = get_remote_file("images/chelsea.png", tmp_userdir, True)
+    fname3 = get_remote_file("images/chelsea.png", tmp_path, True)
     mtime3 = os.path.getmtime(fname3)
     # This should too (update this if imageio is still around in 1000 years)
-    fname4 = get_remote_file("images/chelsea.png", tmp_userdir, "3014-01-01")
+    fname4 = get_remote_file("images/chelsea.png", tmp_path, "3014-01-01")
     mtime4 = os.path.getmtime(fname4)
     # This should not
-    fname5 = get_remote_file("images/chelsea.png", tmp_userdir, "2014-01-01")
+    fname5 = get_remote_file("images/chelsea.png", tmp_path, "2014-01-01")
     mtime5 = os.path.getmtime(fname4)
     #
     assert os.path.isfile(fname1)
@@ -91,7 +91,7 @@ def test_fetching(tmp_userdir):
     _chunk_read = core.fetching._chunk_read
     #
     with pytest.raises(IOError):
-        get_remote_file("this_does_not_exist", tmp_userdir)
+        get_remote_file("this_does_not_exist", tmp_path)
     #
     try:
         core.fetching.urlopen = None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,27 +55,27 @@ class BrokenDummyPlugin:
 
 
 @pytest.mark.needs_internet
-def test_fetching(test_dir):
+def test_fetching(tmp_path):
     """Test fetching of files"""
 
     # Clear image files
-    if os.path.isdir(test_dir):
-        shutil.rmtree(test_dir)
+    if os.path.isdir(tmp_path):
+        shutil.rmtree(tmp_path)
 
     # This should download the file (force download, because local cache)
-    fname1 = get_remote_file("images/chelsea.png", test_dir, True)
+    fname1 = get_remote_file("images/chelsea.png", tmp_path, True)
     mtime1 = os.path.getmtime(fname1)
     # This should reuse it
-    fname2 = get_remote_file("images/chelsea.png", test_dir)
+    fname2 = get_remote_file("images/chelsea.png", tmp_path)
     mtime2 = os.path.getmtime(fname2)
     # This should overwrite
-    fname3 = get_remote_file("images/chelsea.png", test_dir, True)
+    fname3 = get_remote_file("images/chelsea.png", tmp_path, True)
     mtime3 = os.path.getmtime(fname3)
     # This should too (update this if imageio is still around in 1000 years)
-    fname4 = get_remote_file("images/chelsea.png", test_dir, "3014-01-01")
+    fname4 = get_remote_file("images/chelsea.png", tmp_path, "3014-01-01")
     mtime4 = os.path.getmtime(fname4)
     # This should not
-    fname5 = get_remote_file("images/chelsea.png", test_dir, "2014-01-01")
+    fname5 = get_remote_file("images/chelsea.png", tmp_path, "2014-01-01")
     mtime5 = os.path.getmtime(fname4)
     #
     assert os.path.isfile(fname1)
@@ -94,7 +94,7 @@ def test_fetching(test_dir):
     _urlopen = core.fetching.urlopen
     _chunk_read = core.fetching._chunk_read
     #
-    raises(IOError, get_remote_file, "this_does_not_exist", test_dir)
+    raises(IOError, get_remote_file, "this_does_not_exist", tmp_path)
     #
     try:
         core.fetching.urlopen = None
@@ -157,7 +157,7 @@ def test_findlib2():
 
 
 @pytest.mark.needs_internet
-def test_request(test_dir):
+def test_request(tmp_path):
     """Test request object"""
 
     # Check uri-type, this is not a public property, so we test the private
@@ -172,7 +172,7 @@ def test_request(test_dir):
     R = Request(imageio.RETURN_BYTES, "wi")
     assert R._uri_type == core.request.URI_BYTES
     #
-    fname = get_remote_file("images/chelsea.png", test_dir)
+    fname = get_remote_file("images/chelsea.png", tmp_path)
     R = Request(fname, "ri")
     assert R._uri_type == core.request.URI_FILENAME
     R = Request("~/filethatdoesnotexist", "wi")
@@ -239,15 +239,15 @@ def test_request(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_request_read_sources(test_dir):
+def test_request_read_sources(tmp_path):
 
     # Make an image available in many ways
     fname = "images/chelsea.png"
-    filename = get_remote_file(fname, test_dir)
+    filename = get_remote_file(fname, tmp_path)
     bytes = open(filename, "rb").read()
     #
     burl = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/"
-    zipfilename = os.path.join(test_dir, "test1.zip")
+    zipfilename = os.path.join(tmp_path, "test1.zip")
     with ZipFile(zipfilename, "w") as zf:
         zf.writestr(fname, bytes)
 
@@ -286,19 +286,19 @@ def test_request_read_sources(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_request_save_sources(test_dir):
+def test_request_save_sources(tmp_path):
 
     # Get test data
     fname = "images/chelsea.png"
-    filename = get_remote_file(fname, test_dir)
+    filename = get_remote_file(fname, tmp_path)
     with open(filename, "rb") as f:
         bytes = f.read()
     assert len(bytes) > 0
 
     # Prepare destinations
     fname2 = fname + ".out"
-    filename2 = os.path.join(test_dir, fname2)
-    zipfilename2 = os.path.join(test_dir, "test2.zip")
+    filename2 = os.path.join(tmp_path, fname2)
+    zipfilename2 = os.path.join(tmp_path, "test2.zip")
     file2 = None
 
     # Write an image into many different destinations
@@ -616,14 +616,14 @@ def test_util_has_has_module():
 
 
 @pytest.mark.needs_internet
-def test_functions(test_dir):
+def test_functions(tmp_path):
     """Test the user-facing API functions"""
 
     # Test help(), it prints stuff, so we just check whether that goes ok
     imageio.help()  # should print overview
     imageio.help("PNG")  # should print about PNG
 
-    fname1 = get_remote_file("images/chelsea.png", test_dir)
+    fname1 = get_remote_file("images/chelsea.png", tmp_path)
     fname2 = fname1[:-3] + "jpg"
     fname3 = fname1[:-3] + "notavalidext"
     open(fname3, "wb")
@@ -668,7 +668,7 @@ def test_functions(test_dir):
     assert os.path.isfile(fname2)
 
     # Test mimread()
-    fname3 = get_remote_file("images/newtonscradle.gif", test_dir)
+    fname3 = get_remote_file("images/newtonscradle.gif", tmp_path)
     ims = imageio.mimread(fname3)
     assert isinstance(ims, list)
     assert len(ims) > 1
@@ -691,7 +691,7 @@ def test_functions(test_dir):
     assert os.path.isfile(fname5)
 
     # Test volread()
-    fname4 = get_remote_file("images/stent.npz", test_dir)
+    fname4 = get_remote_file("images/stent.npz", tmp_path)
     vol = imageio.volread(fname4)
     assert vol.ndim == 3
     assert vol.shape[0] == 256
@@ -700,7 +700,7 @@ def test_functions(test_dir):
 
     # Test volsave()
     volc = np.zeros((10, 10, 10, 3), np.uint8)  # color volume
-    fname6 = os.path.join(test_dir, "images", "stent2.npz")
+    fname6 = os.path.join(tmp_path, "images", "stent2.npz")
     if os.path.isfile(fname6):
         os.remove(fname6)
     assert not os.path.isfile(fname6)
@@ -757,8 +757,8 @@ def test_to_nbytes_incorrect(arg):
 
 
 @pytest.mark.needs_internet
-def test_memtest(test_dir):
-    fname3 = get_remote_file("images/newtonscradle.gif", test_dir)
+def test_memtest(tmp_path):
+    fname3 = get_remote_file("images/newtonscradle.gif", tmp_path)
     imageio.mimread(fname3)  # trivial case
     imageio.mimread(fname3, memtest=1000 ** 2 * 256)
     imageio.mimread(fname3, memtest="256MB")
@@ -776,10 +776,10 @@ def test_memtest(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_example_plugin(test_dir):
+def test_example_plugin(tmp_path):
     """Test the example plugin"""
 
-    fname = os.path.join(test_dir, "out.png")
+    fname = os.path.join(tmp_path, "out.png")
     r = Request("imageio:chelsea.png", "r?")
     R = imageio.formats["dummy"].get_reader(r)
     W = imageio.formats["dummy"].get_writer(Request(fname, "w?"))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -987,9 +987,7 @@ def test_imopen_explicit_plugin_input(clear_plugins, tmp_path):
         assert isinstance(f, PillowPlugin)
 
     with pytest.raises(ValueError):
-        iio.v3.imopen(
-            tmp_path / "foo.tiff", "w", legacy_mode=True, plugin=PillowPlugin
-        )
+        iio.v3.imopen(tmp_path / "foo.tiff", "w", legacy_mode=True, plugin=PillowPlugin)
 
 
 def test_sort_order_restore():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -237,7 +237,7 @@ def test_request(image_cache, tmp_userdir):
 def test_request_read_sources(image_cache, tmp_userdir):
 
     # Make an image available in many ways
-    fname = os.path.join("images", "chelsea.png")
+    fname = "images/chelsea.png"
     filename = image_cache / fname
     bytes = open(str(filename), "rb").read()
     #

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -29,7 +29,7 @@ def examples(tmp_path_factory):
 
     # folder 1
     ZipFile(fname1).extractall(dname1)
-    
+
     # folder 2
     ZipFile(fname1).extractall(dname2)
     ZipFile(fname2).extractall(dname2)
@@ -44,10 +44,6 @@ def examples(tmp_path_factory):
     # tmp_path_fixture will persist during the session
     # so we need to clean up after ourselves
     shutil.rmtree(workdir)
-
-
-
-
 
 
 def test_read_empty_dir(tmp_path):
@@ -95,7 +91,7 @@ def test_selection(tmp_path, examples):
     # Expected fails
     fname = get_remote_file("images/dicom_file90.dcm")
     with pytest.raises(RuntimeError):
-        imageio.imread(fname) # 1.2.840.10008.1.2.4.91
+        imageio.imread(fname)  # 1.2.840.10008.1.2.4.91
     fname = get_remote_file("images/dicom_file91.dcm")
     with pytest.raises(RuntimeError):
         imageio.imread(fname)  # not pixel data

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -2,7 +2,6 @@
 """
 
 import os
-import shutil
 import tempfile
 from zipfile import ZipFile
 

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -13,14 +13,14 @@ import imageio.plugins.dicom
 
 
 @pytest.fixture(scope="module")
-def examples(image_cache, tmp_path_factory):
+def examples(test_images, tmp_path_factory):
     """Create two dirs, one with one dataset and one with two datasets"""
 
     workdir = tmp_path_factory.getbasetemp() / "test_dicom"
 
     # Prepare sources
-    fname1 = image_cache / "images" / "dicom_sample1.zip"
-    fname2 = image_cache / "images" / "dicom_sample2.zip"
+    fname1 = test_images / "dicom_sample1.zip"
+    fname2 = test_images / "dicom_sample2.zip"
     dname1 = workdir / "dicom_sample1"
     dname2 = workdir / "dicom_sample2"
 
@@ -51,7 +51,7 @@ def test_dcmtk():
     imageio.plugins.dicom.get_dcmdjpeg_exe()
 
 
-def test_selection(image_cache, tmp_path, examples):
+def test_selection(test_images, tmp_path, examples):
 
     dname1, dname2, fname1, fname2 = examples
 
@@ -73,24 +73,24 @@ def test_selection(image_cache, tmp_path, examples):
         F.get_reader(core.Request(fname2, "ri"))
 
     # Test special files with other formats
-    im = imageio.imread(image_cache / "images" / "dicom_file01.dcm")
+    im = imageio.imread(test_images / "dicom_file01.dcm")
     assert im.shape == (512, 512)
-    im = imageio.imread(image_cache / "images" / "dicom_file03.dcm")
+    im = imageio.imread(test_images / "dicom_file03.dcm")
     assert im.shape == (512, 512)
-    im = imageio.imread(image_cache / "images" / "dicom_file04.dcm")
+    im = imageio.imread(test_images / "dicom_file04.dcm")
     assert im.shape == (512, 512)
 
     # Expected fails
-    fname = image_cache / "images" / "dicom_file90.dcm"
+    fname = test_images / "dicom_file90.dcm"
     with pytest.raises(RuntimeError):
         imageio.imread(fname)  # 1.2.840.10008.1.2.4.91
-    fname = image_cache / "images" / "dicom_file91.dcm"
+    fname = test_images / "dicom_file91.dcm"
     with pytest.raises(RuntimeError):
         imageio.imread(fname)  # not pixel data
 
     # This one *should* work, but does not, see issue #18
     try:
-        imageio.imread(image_cache / "images" / "dicom_file02.dcm")
+        imageio.imread(test_images / "dicom_file02.dcm")
     except Exception:
         pass
 

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -41,7 +41,7 @@ def examples(image_cache, tmp_path_factory):
 
     # tmp_path_fixture will persist during the session
     # so we need to clean up after ourselves
-    shutil.rmtree(workdir)
+    shutil.rmtree(workdir, ignore_errors=True)
 
 
 def test_read_empty_dir(tmp_path):

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,7 +1,6 @@
 """ Test DICOM functionality.
 """
 
-import os
 import shutil
 from zipfile import ZipFile
 

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -10,19 +10,18 @@ import pytest
 
 import imageio
 from imageio import core
-from imageio.core import get_remote_file
 import imageio.plugins.dicom
 
 
 @pytest.fixture(scope="module")
-def examples(tmp_path_factory):
+def examples(image_cache, tmp_path_factory):
     """Create two dirs, one with one dataset and one with two datasets"""
 
     workdir = tmp_path_factory.getbasetemp() / "test_dicom"
 
     # Prepare sources
-    fname1 = get_remote_file("images/dicom_sample1.zip")
-    fname2 = get_remote_file("images/dicom_sample2.zip")
+    fname1 = image_cache / "images" / "dicom_sample1.zip"
+    fname2 = image_cache / "images" / "dicom_sample2.zip"
     dname1 = workdir / "dicom_sample1"
     dname2 = workdir / "dicom_sample2"
 
@@ -57,8 +56,7 @@ def test_dcmtk():
     imageio.plugins.dicom.get_dcmdjpeg_exe()
 
 
-@pytest.mark.needs_internet
-def test_selection(tmp_path, examples):
+def test_selection(image_cache, tmp_path, examples):
 
     dname1, dname2, fname1, fname2 = examples
 
@@ -80,29 +78,28 @@ def test_selection(tmp_path, examples):
         F.get_reader(core.Request(fname2, "ri"))
 
     # Test special files with other formats
-    im = imageio.imread(get_remote_file("images/dicom_file01.dcm"))
+    im = imageio.imread(image_cache / "images" / "dicom_file01.dcm")
     assert im.shape == (512, 512)
-    im = imageio.imread(get_remote_file("images/dicom_file03.dcm"))
+    im = imageio.imread(image_cache / "images" / "dicom_file03.dcm")
     assert im.shape == (512, 512)
-    im = imageio.imread(get_remote_file("images/dicom_file04.dcm"))
+    im = imageio.imread(image_cache / "images" / "dicom_file04.dcm")
     assert im.shape == (512, 512)
 
     # Expected fails
-    fname = get_remote_file("images/dicom_file90.dcm")
+    fname = image_cache / "images" / "dicom_file90.dcm"
     with pytest.raises(RuntimeError):
         imageio.imread(fname)  # 1.2.840.10008.1.2.4.91
-    fname = get_remote_file("images/dicom_file91.dcm")
+    fname = image_cache / "images" / "dicom_file91.dcm"
     with pytest.raises(RuntimeError):
         imageio.imread(fname)  # not pixel data
 
     # This one *should* work, but does not, see issue #18
     try:
-        imageio.imread(get_remote_file("images/dicom_file02.dcm"))
+        imageio.imread(image_cache / "images" / "dicom_file02.dcm")
     except Exception:
         pass
 
 
-@pytest.mark.needs_internet
 def test_progress(examples):
 
     dname1, dname2, fname1, fname2 = examples
@@ -114,7 +111,6 @@ def test_progress(examples):
         imageio.imread(fname1, progress=3)
 
 
-@pytest.mark.needs_internet
 def test_different_read_modes(examples):
 
     dname1, dname2, fname1, fname2 = examples
@@ -152,7 +148,6 @@ def test_different_read_modes(examples):
         assert sum([v.shape[0] for v in vols]) == len(ims)
 
 
-@pytest.mark.needs_internet
 def test_different_read_modes_with_readers(examples):
 
     dname1, dname2, fname1, fname2 = examples

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,7 +1,6 @@
 """ Test DICOM functionality.
 """
 
-import shutil
 from zipfile import ZipFile
 
 import numpy as np
@@ -38,10 +37,6 @@ def examples(image_cache, tmp_path_factory):
     fname2 = str(next(dname2.iterdir()))
 
     yield dname1, dname2, fname1, fname2
-
-    # tmp_path_fixture will persist during the session
-    # so we need to clean up after ourselves
-    shutil.rmtree(workdir, ignore_errors=True)
 
 
 def test_read_empty_dir(tmp_path):

--- a/tests/test_fei_tiff.py
+++ b/tests/test_fei_tiff.py
@@ -6,14 +6,12 @@ from __future__ import unicode_literals
 
 import pytest
 import numpy as np
-from imageio.core import get_remote_file
 
 import imageio
 
 
-@pytest.mark.needs_internet
-def test_fei_file_reading():
-    fei_filename = get_remote_file("images/fei-sem-rbc.tif")
+def test_fei_file_reading(image_cache):
+    fei_filename = image_cache / "images" / "fei-sem-rbc.tif"
     reader = imageio.get_reader(fei_filename, format="fei")
     image = reader.get_data(0)  # imageio.Image object
     assert image.shape == (1024, 1536)

--- a/tests/test_fei_tiff.py
+++ b/tests/test_fei_tiff.py
@@ -30,8 +30,8 @@ def test_fei_file_reading():
     assert reader.get_data(0, discard_watermark=False).shape == (1094, 1536)
 
 
-def test_fei_file_fail(test_dir):
-    normal_tif = os.path.join(test_dir, "test_tiff.tiff")
+def test_fei_file_fail(tmp_path):
+    normal_tif = os.path.join(tmp_path, "test_tiff.tiff")
     imageio.imsave(normal_tif, np.zeros((5, 5), dtype=np.uint8))
     bad_reader = imageio.get_reader(normal_tif, format="fei")
     assert pytest.raises(ValueError, bad_reader._get_meta_data)

--- a/tests/test_fei_tiff.py
+++ b/tests/test_fei_tiff.py
@@ -4,7 +4,6 @@ FEI TIFFs contain metadata as ASCII plaintext at the end of the file.
 """
 from __future__ import unicode_literals
 
-import os
 import pytest
 import numpy as np
 from imageio.core import get_remote_file

--- a/tests/test_fei_tiff.py
+++ b/tests/test_fei_tiff.py
@@ -31,7 +31,8 @@ def test_fei_file_reading():
 
 
 def test_fei_file_fail(tmp_path):
-    normal_tif = os.path.join(tmp_path, "test_tiff.tiff")
+    normal_tif = tmp_path / "test_tiff.tiff"
     imageio.imsave(normal_tif, np.zeros((5, 5), dtype=np.uint8))
     bad_reader = imageio.get_reader(normal_tif, format="fei")
-    assert pytest.raises(ValueError, bad_reader._get_meta_data)
+    with pytest.raises(ValueError):
+        bad_reader._get_meta_data()

--- a/tests/test_fei_tiff.py
+++ b/tests/test_fei_tiff.py
@@ -5,16 +5,15 @@ FEI TIFFs contain metadata as ASCII plaintext at the end of the file.
 from __future__ import unicode_literals
 
 import os
-from pytest import raises
+import pytest
 import numpy as np
-from imageio.testing import run_tests_if_main, get_test_dir, need_internet
 from imageio.core import get_remote_file
 
 import imageio
 
 
+@pytest.mark.needs_internet
 def test_fei_file_reading():
-    need_internet()  # We keep a test image in the imageio-binaries repo
     fei_filename = get_remote_file("images/fei-sem-rbc.tif")
     reader = imageio.get_reader(fei_filename, format="fei")
     image = reader.get_data(0)  # imageio.Image object
@@ -31,11 +30,8 @@ def test_fei_file_reading():
     assert reader.get_data(0, discard_watermark=False).shape == (1094, 1536)
 
 
-def test_fei_file_fail():
-    normal_tif = os.path.join(get_test_dir(), "test_tiff.tiff")
+def test_fei_file_fail(test_dir):
+    normal_tif = os.path.join(test_dir, "test_tiff.tiff")
     imageio.imsave(normal_tif, np.zeros((5, 5), dtype=np.uint8))
     bad_reader = imageio.get_reader(normal_tif, format="fei")
-    assert raises(ValueError, bad_reader._get_meta_data)
-
-
-run_tests_if_main()
+    assert pytest.raises(ValueError, bad_reader._get_meta_data)

--- a/tests/test_fei_tiff.py
+++ b/tests/test_fei_tiff.py
@@ -10,8 +10,8 @@ import numpy as np
 import imageio
 
 
-def test_fei_file_reading(image_cache):
-    fei_filename = image_cache / "images" / "fei-sem-rbc.tif"
+def test_fei_file_reading(test_images):
+    fei_filename = test_images / "fei-sem-rbc.tif"
     reader = imageio.get_reader(fei_filename, format="fei")
     image = reader.get_data(0)  # imageio.Image object
     assert image.shape == (1024, 1536)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -580,7 +580,7 @@ def test_webcam_resource_warnings():
             with imageio.get_reader("<video0>"):
                 pass
     except IndexError:
-        skip("no webcam")
+        pytest.skip("no webcam")
 
     import imageio_ffmpeg
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -79,9 +79,9 @@ def test_get_exe_env():
 
 
 @pytest.mark.needs_internet
-def test_select(test_dir):
+def test_select(tmp_path):
 
-    fname1 = get_remote_file("images/cockatoo.mp4", test_dir)
+    fname1 = get_remote_file("images/cockatoo.mp4", tmp_path)
 
     F = imageio.formats["ffmpeg"]
     assert F.name == "FFMPEG"
@@ -112,12 +112,12 @@ def test_integer_reader_length():
 
 
 @pytest.mark.needs_internet
-def test_read_and_write(test_dir):
+def test_read_and_write(tmp_path):
 
     R = imageio.read(get_remote_file("images/cockatoo.mp4"), "ffmpeg")
     assert isinstance(R.format, type(imageio.formats["ffmpeg"]))
 
-    fname1 = get_remote_file("images/cockatoo.mp4", test_dir)
+    fname1 = get_remote_file("images/cockatoo.mp4", tmp_path)
     fname2 = fname1[:-4] + ".out.mp4"
 
     frame1, frame2, frame3 = 41, 131, 227
@@ -182,12 +182,12 @@ def test_read_and_write(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_write_not_contiguous(test_dir):
+def test_write_not_contiguous(tmp_path):
 
     R = imageio.read(get_remote_file("images/cockatoo.mp4"), "ffmpeg")
     assert isinstance(R.format, type(imageio.formats["ffmpeg"]))
 
-    fname1 = get_remote_file("images/cockatoo.mp4", test_dir)
+    fname1 = get_remote_file("images/cockatoo.mp4", tmp_path)
     fname2 = fname1[:-4] + ".out.mp4"
 
     # Read
@@ -220,9 +220,9 @@ def test_write_not_contiguous(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_reader_more(test_dir):
+def test_reader_more(tmp_path):
 
-    fname1 = get_remote_file("images/cockatoo.mp4", test_dir)
+    fname1 = get_remote_file("images/cockatoo.mp4", tmp_path)
     fname3 = fname1[:-4] + ".stub.mp4"
 
     # Get meta data
@@ -295,9 +295,9 @@ def test_reader_more(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_writer_more(test_dir):
+def test_writer_more(tmp_path):
 
-    fname1 = get_remote_file("images/cockatoo.mp4", test_dir)
+    fname1 = get_remote_file("images/cockatoo.mp4", tmp_path)
     fname2 = fname1[:-4] + ".out.mp4"
 
     W = imageio.save(fname2, "ffmpeg")

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -238,8 +238,10 @@ def test_reader_more(tmp_path):
     assert im.shape == (50, 50, 3)
     im = imageio.read(fname1, "ffmpeg", size="40x40").get_data(0)
     assert im.shape == (40, 40, 3)
-    pytest.raises(ValueError, imageio.read, fname1, "ffmpeg", size=20)
-    pytest.raises(ValueError, imageio.read, fname1, "ffmpeg", pixelformat=20)
+    with pytest.raises(ValueError):
+        imageio.read(fname1, "ffmpeg", size=20)
+    with pytest.raises(ValueError):
+        imageio.read(fname1, "ffmpeg", pixelformat=20)
 
     # Read all frames and test length
     R = imageio.read(get_remote_file("images/realshort.mp4"), "ffmpeg")
@@ -253,7 +255,8 @@ def test_reader_more(tmp_path):
             count += 1
     assert count == R.count_frames()
     assert count in (35, 36)  # allow one frame off size that we know
-    pytest.raises(IndexError, R.get_data, -1)  # Test index error -1
+    with pytest.raises(IndexError):
+        R.get_data(-1)  # Test index error -1
 
     # Now read beyond (simulate broken file)
     with pytest.raises(StopIteration):
@@ -271,7 +274,8 @@ def test_reader_more(tmp_path):
         else:
             count2 += 1
     assert count2 == count
-    pytest.raises(IndexError, R.get_data, -1)  # Test index error -1
+    with pytest.raises(IndexError)
+        R.get_data(-1)  # Test index error -1
 
     # Test loop
     R = imageio.read(get_remote_file("images/realshort.mp4"), "ffmpeg", loop=1)
@@ -288,7 +292,8 @@ def test_reader_more(tmp_path):
 
     # Read invalid
     open(fname3, "wb")
-    pytest.raises(IOError, imageio.read, fname3, "ffmpeg")
+    with pytest.raises(IOError):
+        imageio.read(fname3, "ffmpeg")
 
     # Read printing info
     imageio.read(fname1, "ffmpeg", print_info=True)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -18,9 +18,13 @@ import imageio
 from imageio import core
 from imageio.core import IS_PYPY
 
-psutil = pytest.importorskip("psutil", reason="ffmpeg support cannot be tested without psutil")
+psutil = pytest.importorskip(
+    "psutil", reason="ffmpeg support cannot be tested without psutil"
+)
 
-imageio_ffmpeg = pytest.importorskip("imageio_ffmpeg", reason="imageio-ffmpeg is not installed")
+imageio_ffmpeg = pytest.importorskip(
+    "imageio_ffmpeg", reason="imageio-ffmpeg is not installed"
+)
 
 
 def get_ffmpeg_pids():
@@ -31,7 +35,9 @@ def get_ffmpeg_pids():
     return pids
 
 
-@pytest.mark.skipif(platform.machine() == "aarch64", reason="Can't download binary on aarch64")
+@pytest.mark.skipif(
+    platform.machine() == "aarch64", reason="Can't download binary on aarch64"
+)
 def test_get_exe_installed():
     # backup any user-defined path
     if "IMAGEIO_FFMPEG_EXE" in os.environ:
@@ -70,9 +76,9 @@ def test_get_exe_env():
     assert path == path2
 
 
-def test_select(image_cache):
+def test_select(test_images):
 
-    fname1 = image_cache / "images" / "cockatoo.mp4"
+    fname1 = test_images / "cockatoo.mp4"
 
     F = imageio.formats["ffmpeg"]
     assert F.name == "FFMPEG"
@@ -92,9 +98,9 @@ def test_select(image_cache):
     )
 
 
-def test_integer_reader_length(image_cache):
+def test_integer_reader_length(test_images):
     # Avoid regression for #280
-    r = imageio.get_reader(image_cache / "images" / "cockatoo.mp4")
+    r = imageio.get_reader(test_images / "cockatoo.mp4")
     assert r.get_length() == float("inf")
     assert isinstance(len(r), int)
     assert len(r) == sys.maxsize
@@ -102,9 +108,9 @@ def test_integer_reader_length(image_cache):
     assert True if r else False
 
 
-def test_read_and_write(image_cache):
+def test_read_and_write(test_images):
 
-    fname1 = image_cache / "images" / "cockatoo.mp4"
+    fname1 = test_images / "cockatoo.mp4"
 
     R = imageio.read(fname1, "ffmpeg")
     assert isinstance(R.format, type(imageio.formats["ffmpeg"]))
@@ -172,9 +178,9 @@ def test_read_and_write(image_cache):
             assert diff.mean() < 2.5
 
 
-def test_write_not_contiguous(image_cache):
+def test_write_not_contiguous(test_images):
 
-    fname1 = image_cache / "images" / "cockatoo.mp4"
+    fname1 = test_images / "cockatoo.mp4"
 
     R = imageio.read(fname1, "ffmpeg")
     assert isinstance(R.format, type(imageio.formats["ffmpeg"]))
@@ -210,9 +216,9 @@ def test_write_not_contiguous(image_cache):
             assert diff.mean() < 2.5
 
 
-def test_reader_more(image_cache):
+def test_reader_more(test_images):
 
-    fname1 = image_cache / "images" / "cockatoo.mp4"
+    fname1 = test_images / "cockatoo.mp4"
 
     fname3 = fname1.with_suffix(".stub.mp4")
 
@@ -235,7 +241,7 @@ def test_reader_more(image_cache):
         imageio.read(fname1, "ffmpeg", pixelformat=20)
 
     # Read all frames and test length
-    R = imageio.read(image_cache / "images" / "realshort.mp4", "ffmpeg")
+    R = imageio.read(test_images / "realshort.mp4", "ffmpeg")
     count = 0
     while True:
         try:
@@ -269,7 +275,7 @@ def test_reader_more(image_cache):
         R.get_data(-1)  # Test index error -1
 
     # Test loop
-    R = imageio.read(image_cache / "images" / "realshort.mp4", "ffmpeg", loop=1)
+    R = imageio.read(test_images / "realshort.mp4", "ffmpeg", loop=1)
     im1 = R.get_next_data()
     for i in range(1, len(R)):
         R.get_next_data()
@@ -290,9 +296,9 @@ def test_reader_more(image_cache):
     imageio.read(fname1, "ffmpeg", print_info=True)
 
 
-def test_writer_more(image_cache):
+def test_writer_more(test_images):
 
-    fname1 = image_cache / "images" / "cockatoo.mp4"
+    fname1 = test_images / "cockatoo.mp4"
     fname2 = fname1.with_suffix(".out.mp4")
 
     W = imageio.save(fname2, "ffmpeg")
@@ -512,12 +518,12 @@ def test_webcam_get_next_data():
     reader.close()
 
 
-def test_process_termination(image_cache):
+def test_process_termination(test_images):
 
     pids0 = get_ffmpeg_pids()
 
-    r1 = imageio.get_reader(image_cache / "images" / "cockatoo.mp4")
-    r2 = imageio.get_reader(image_cache / "images" / "cockatoo.mp4")
+    r1 = imageio.get_reader(test_images / "cockatoo.mp4")
+    r2 = imageio.get_reader(test_images / "cockatoo.mp4")
 
     assert len(get_ffmpeg_pids().difference(pids0)) == 2
 
@@ -526,8 +532,8 @@ def test_process_termination(image_cache):
 
     assert len(get_ffmpeg_pids().difference(pids0)) == 0
 
-    r1 = imageio.get_reader(image_cache / "images" / "cockatoo.mp4")
-    r2 = imageio.get_reader(image_cache / "images" / "cockatoo.mp4")
+    r1 = imageio.get_reader(test_images / "cockatoo.mp4")
+    r2 = imageio.get_reader(test_images / "cockatoo.mp4")
 
     assert len(get_ffmpeg_pids().difference(pids0)) == 2
 
@@ -585,8 +591,8 @@ def test_webcam_resource_warnings():
     assert not [w.message for w in warnings]
 
 
-def show_in_console(image_cache):
-    reader = imageio.read(image_cache / "images" / "cockatoo.mp4", "ffmpeg")
+def show_in_console(test_images):
+    reader = imageio.read(test_images / "cockatoo.mp4", "ffmpeg")
     # reader = imageio.read('<video0>')
     im = reader.get_next_data()
     while True:
@@ -597,8 +603,8 @@ def show_in_console(image_cache):
         )
 
 
-def show_in_visvis(image_cache):
-    # reader = imageio.read(image_cache / "images" / "cockatoo.mp4", "ffmpeg")
+def show_in_visvis(test_images):
+    # reader = imageio.read(test_images / "cockatoo.mp4", "ffmpeg")
     reader = imageio.read("<video0>", fps=20)
 
     import visvis as vv

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -18,13 +18,9 @@ import imageio
 from imageio import core
 from imageio.core import get_remote_file, IS_PYPY
 
-pytest.importorskip(
-    "psutil", reason="ffmpeg support cannot be tested without psutil"
-)
+pytest.importorskip("psutil", reason="ffmpeg support cannot be tested without psutil")
 
-pytest.importorskip(
-    "imageio_ffmpeg", reason="imageio-ffmpeg is not installed"
-)
+pytest.importorskip("imageio_ffmpeg", reason="imageio-ffmpeg is not installed")
 
 
 def get_ffmpeg_pids():
@@ -100,9 +96,9 @@ def test_select(test_dir):
     assert type(
         imageio.formats.search_write_format(core.Request(fname1, "wI"))
     ) is type(F)
-    assert type(
-        imageio.formats.search_read_format(core.Request(fname1, "rI"))
-    ) is type(F)
+    assert type(imageio.formats.search_read_format(core.Request(fname1, "rI"))) is type(
+        F
+    )
 
 
 def test_integer_reader_length():
@@ -352,9 +348,7 @@ def test_writer_pixelformat_size_verbose(tmpdir):
     assert "yuv420p" == W._meta["pix_fmt"]
 
     # Now check that macroblock size gets turned off if requested
-    W = imageio.get_writer(
-        str(tmpf), macro_block_size=1, ffmpeg_log_level="warning"
-    )
+    W = imageio.get_writer(str(tmpf), macro_block_size=1, ffmpeg_log_level="warning")
     for i in range(nframes):
         W.append_data(np.zeros((100, 106, 3), np.uint8))
     W.close()
@@ -364,9 +358,7 @@ def test_writer_pixelformat_size_verbose(tmpdir):
     assert "yuv420p" == W._meta["pix_fmt"]
 
     # Now double check values different than default work
-    W = imageio.get_writer(
-        str(tmpf), macro_block_size=4, ffmpeg_log_level="warning"
-    )
+    W = imageio.get_writer(str(tmpf), macro_block_size=4, ffmpeg_log_level="warning")
     for i in range(nframes):
         W.append_data(np.zeros((64, 65, 3), np.uint8))
     W.close()
@@ -451,9 +443,7 @@ def test_framecatcher():
     assert file.__next__() == b"v" * N
 
     file = FakeGenerator(N)
-    T = imageio.plugins.ffmpeg.FrameCatcher(
-        file
-    )  # the file looks like a generator
+    T = imageio.plugins.ffmpeg.FrameCatcher(file)  # the file looks like a generator
 
     # Init None
     time.sleep(0.1)
@@ -472,9 +462,7 @@ def test_framecatcher():
     # Read frame that has not been updated
     frame, is_new = T.get_frame()
     assert frame == b"x" * N, "frame content should be the same as before"
-    assert (
-        not is_new
-    ), "is_new should be False if the frame has already been retrieved"
+    assert not is_new, "is_new should be False if the frame has already been retrieved"
 
     # Read frame when we pass plenty of data
     file.write_and_rewind(b"y" * N * 3)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -576,7 +576,7 @@ def test_webcam_resource_warnings():
      (see https://github.com/pytest-dev/pytest/issues/9404)
     """
     try:
-        with warns(None) as warnings:
+        with pytest.warns(None) as warnings:
             with imageio.get_reader("<video0>"):
                 pass
     except IndexError:

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -274,7 +274,7 @@ def test_reader_more(tmp_path):
         else:
             count2 += 1
     assert count2 == count
-    with pytest.raises(IndexError)
+    with pytest.raises(IndexError):
         R.get_data(-1)  # Test index error -1
 
     # Test loop

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -595,7 +595,7 @@ def test_webcam_resource_warnings():
     assert not [w.message for w in warnings]
 
 
-def show_in_console():
+def show_in_console(image_cache):
     reader = imageio.read(image_cache / "images" / "cockatoo.mp4", "ffmpeg")
     # reader = imageio.read('<video0>')
     im = reader.get_next_data()

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -6,9 +6,7 @@ import pytest
 import imageio
 
 
-pytest.importorskip(
-    "imageio_ffmpeg", reason="imageio-ffmpeg is not installed"
-)
+pytest.importorskip("imageio_ffmpeg", reason="imageio-ffmpeg is not installed")
 
 
 def dedent(text, dedent=8):

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -45,10 +45,10 @@ def test_webcam_parse_device_names():
     assert len(device_names) == 2
 
 
-def test_overload_fps(image_cache):
+def test_overload_fps(test_images):
 
     # Native
-    r = imageio.get_reader(image_cache / "images" / "cockatoo.mp4")
+    r = imageio.get_reader(test_images / "cockatoo.mp4")
     assert r.count_frames() == 280  # native
     assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 280
     ims = [im for im in r]
@@ -56,7 +56,7 @@ def test_overload_fps(image_cache):
     # imageio.mimwrite('~/parot280.gif', ims[:30])
 
     # Less
-    r = imageio.get_reader(image_cache / "images" / "cockatoo.mp4", fps=8)
+    r = imageio.get_reader(test_images / "cockatoo.mp4", fps=8)
     # assert r.count_frames() == 112  # cant :(
     assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 112  # note the mismatch
     ims = [im for im in r]
@@ -64,7 +64,7 @@ def test_overload_fps(image_cache):
     # imageio.mimwrite('~/parot112.gif', ims[:30])
 
     # More
-    r = imageio.get_reader(image_cache / "images" / "cockatoo.mp4", fps=24)
+    r = imageio.get_reader(test_images / "cockatoo.mp4", fps=24)
     # assert r.count_frames() == 336  # cant :(
     ims = [im for im in r]
     assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 336
@@ -75,7 +75,7 @@ def test_overload_fps(image_cache):
     # read beyond what it thinks how many frames it has. But this at least
     # makes sure that this works.
     for fps in (8.0, 8.02, 8.04, 8.06, 8.08):
-        r = imageio.get_reader(image_cache / "images" / "cockatoo.mp4", fps=fps)
+        r = imageio.get_reader(test_images / "cockatoo.mp4", fps=fps)
         n = int(r._meta["fps"] * r._meta["duration"] + 0.5)
         i = 0
         try:

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -2,9 +2,13 @@
 """ Tests specific to parsing ffmpeg info.
 """
 
-from imageio.testing import run_tests_if_main, need_internet
-
+import pytest
 import imageio
+
+
+pytest.importorskip(
+    "imageio_ffmpeg", reason="imageio-ffmpeg is not installed"
+)
 
 
 def dedent(text, dedent=8):
@@ -43,8 +47,8 @@ def test_webcam_parse_device_names():
     assert len(device_names) == 2
 
 
+@pytest.mark.needs_internet
 def test_overload_fps():
-    need_internet()
 
     # Native
     r = imageio.get_reader("imageio:cockatoo.mp4")
@@ -85,6 +89,3 @@ def test_overload_fps():
             pass
         # print(r._meta['duration'], r._meta['fps'], r._meta['duration'] * fps, r._meta['nframes'], n)
         assert n - 2 <= i <= n + 2
-
-
-run_tests_if_main()

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -45,11 +45,10 @@ def test_webcam_parse_device_names():
     assert len(device_names) == 2
 
 
-@pytest.mark.needs_internet
-def test_overload_fps():
+def test_overload_fps(image_cache):
 
     # Native
-    r = imageio.get_reader("imageio:cockatoo.mp4")
+    r = imageio.get_reader(image_cache / "images" / "cockatoo.mp4")
     assert r.count_frames() == 280  # native
     assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 280
     ims = [im for im in r]
@@ -57,7 +56,7 @@ def test_overload_fps():
     # imageio.mimwrite('~/parot280.gif', ims[:30])
 
     # Less
-    r = imageio.get_reader("imageio:cockatoo.mp4", fps=8)
+    r = imageio.get_reader(image_cache / "images" / "cockatoo.mp4", fps=8)
     # assert r.count_frames() == 112  # cant :(
     assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 112  # note the mismatch
     ims = [im for im in r]
@@ -65,7 +64,7 @@ def test_overload_fps():
     # imageio.mimwrite('~/parot112.gif', ims[:30])
 
     # More
-    r = imageio.get_reader("imageio:cockatoo.mp4", fps=24)
+    r = imageio.get_reader(image_cache / "images" / "cockatoo.mp4", fps=24)
     # assert r.count_frames() == 336  # cant :(
     ims = [im for im in r]
     assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 336
@@ -76,7 +75,7 @@ def test_overload_fps():
     # read beyond what it thinks how many frames it has. But this at least
     # makes sure that this works.
     for fps in (8.0, 8.02, 8.04, 8.06, 8.08):
-        r = imageio.get_reader("imageio:cockatoo.mp4", fps=fps)
+        r = imageio.get_reader(image_cache / "images" / "cockatoo.mp4", fps=fps)
         n = int(r._meta["fps"] * r._meta["duration"] + 0.5)
         i = 0
         try:

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -3,7 +3,7 @@
 import pytest
 
 import imageio
-from imageio.core import get_remote_file, Request, IS_PYPY
+from imageio.core import Request, IS_PYPY
 
 import numpy as np
 
@@ -29,8 +29,7 @@ def normal_plugin_order():
     setup_module()
 
 
-@pytest.mark.needs_internet
-def test_fits_format():
+def test_fits_format(image_cache):
 
     # Test selection
     for name in ["fits", ".fits"]:
@@ -39,21 +38,20 @@ def test_fits_format():
         assert format.__module__.endswith(".fits")
 
     # Test cannot read
-    png = get_remote_file("images/chelsea.png")
+    png = image_cache / "test-images" / "chelsea.png"
     assert not format.can_read(Request(png, "ri"))
     assert not format.can_write(Request(png, "wi"))
 
 
-@pytest.mark.needs_internet
-def test_fits_reading():
+def test_fits_reading(image_cache):
     """Test reading fits"""
 
     if IS_PYPY:
         return  # no support for fits format :(
 
-    simple = get_remote_file("images/simple.fits")
-    multi = get_remote_file("images/multi.fits")
-    compressed = get_remote_file("images/compressed.fits.fz")
+    simple = image_cache / "images" / "simple.fits"
+    multi = image_cache / "images" / "multi.fits"
+    compressed = image_cache / "images" / "compressed.fits.fz"
 
     # One image
     im = imageio.imread(simple, format="fits")

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -13,6 +13,7 @@ pytest.importorskip("astropy", reason="astropy is not installed")
 def setup_module():
     # During this test, pretend that FITS is the default format
     import astropy.io.fits
+
     imageio.formats.sort("FITS")
 
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -1,26 +1,18 @@
 """ Test fits plugin functionality.
 """
 import pytest
-from imageio.testing import run_tests_if_main, get_test_dir, need_internet
 
 import imageio
 from imageio.core import get_remote_file, Request, IS_PYPY
 
 import numpy as np
 
-test_dir = get_test_dir()
-
-try:
-    import astropy
-
-    # io is not imported by default
-    import astropy.io.fits
-except ImportError:
-    astropy = None
+pytest.importorskip("astropy", reason="astropy is not installed")
 
 
 def setup_module():
     # During this test, pretend that FITS is the default format
+    import astropy.io.fits
     imageio.formats.sort("FITS")
 
 
@@ -38,9 +30,8 @@ def normal_plugin_order():
     setup_module()
 
 
-@pytest.mark.skipif("astropy is None")
+@pytest.mark.needs_internet
 def test_fits_format():
-    need_internet()  # We keep the fits files in the imageio-binary repo
 
     # Test selection
     for name in ["fits", ".fits"]:
@@ -54,11 +45,9 @@ def test_fits_format():
     assert not format.can_write(Request(png, "wi"))
 
 
-@pytest.mark.skipif("astropy is None")
+@pytest.mark.needs_internet
 def test_fits_reading():
     """Test reading fits"""
-
-    need_internet()  # We keep the fits files in the imageio-binary repo
 
     if IS_PYPY:
         return  # no support for fits format :(
@@ -94,12 +83,12 @@ def test_fits_reading():
     assert im.shape == (2042, 3054)
 
 
-@pytest.mark.skipif("astropy is None")
 @pytest.mark.skipif("IS_PYPY", reason="pypy doesn't support astropy.fits.")
 def test_fits_get_reader(normal_plugin_order, tmp_path):
     """Test reading fits with get_reader method
     This is a regression test that closes GitHub issue #636
     """
+    import astropy.io.fits
 
     sigma = 10
     xx, yy = np.meshgrid(np.arange(512), np.arange(512))
@@ -112,6 +101,3 @@ def test_fits_get_reader(normal_plugin_order, tmp_path):
     hdul = astropy.io.fits.HDUList([phdu, ihdu])
     hdul.writeto(tmp_path / "test.fits")
     imageio.get_reader(tmp_path / "test.fits", format="fits")
-
-
-run_tests_if_main()

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -3,11 +3,11 @@
 import pytest
 
 import imageio
-from imageio.core import Request, IS_PYPY
+from imageio.core import Request
 
 import numpy as np
 
-pytest.importorskip("astropy", reason="astropy is not installed")
+fits = pytest.importorskip("astropy.io.fits", reason="astropy is not installed")
 
 
 def setup_module():
@@ -46,9 +46,6 @@ def test_fits_format(image_cache):
 def test_fits_reading(image_cache):
     """Test reading fits"""
 
-    if IS_PYPY:
-        return  # no support for fits format :(
-
     simple = image_cache / "images" / "simple.fits"
     multi = image_cache / "images" / "multi.fits"
     compressed = image_cache / "images" / "compressed.fits.fz"
@@ -80,12 +77,10 @@ def test_fits_reading(image_cache):
     assert im.shape == (2042, 3054)
 
 
-@pytest.mark.skipif("IS_PYPY", reason="pypy doesn't support astropy.fits.")
 def test_fits_get_reader(normal_plugin_order, tmp_path):
     """Test reading fits with get_reader method
     This is a regression test that closes GitHub issue #636
     """
-    import astropy.io.fits
 
     sigma = 10
     xx, yy = np.meshgrid(np.arange(512), np.arange(512))
@@ -93,8 +88,8 @@ def test_fits_get_reader(normal_plugin_order, tmp_path):
         -((xx ** 2) + (yy ** 2)) / (2 * (sigma ** 2))
     )
     img = np.log(z)
-    phdu = astropy.io.fits.PrimaryHDU()
-    ihdu = astropy.io.fits.ImageHDU(img)
-    hdul = astropy.io.fits.HDUList([phdu, ihdu])
+    phdu = fits.PrimaryHDU()
+    ihdu = fits.ImageHDU(img)
+    hdul = fits.HDUList([phdu, ihdu])
     hdul.writeto(tmp_path / "test.fits")
     imageio.get_reader(tmp_path / "test.fits", format="fits")

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -29,7 +29,7 @@ def normal_plugin_order():
     setup_module()
 
 
-def test_fits_format(image_cache):
+def test_fits_format(test_images):
 
     # Test selection
     for name in ["fits", ".fits"]:
@@ -38,17 +38,17 @@ def test_fits_format(image_cache):
         assert format.__module__.endswith(".fits")
 
     # Test cannot read
-    png = image_cache / "test-images" / "chelsea.png"
+    png = test_images / "chelsea.png"
     assert not format.can_read(Request(png, "ri"))
     assert not format.can_write(Request(png, "wi"))
 
 
-def test_fits_reading(image_cache):
+def test_fits_reading(test_images):
     """Test reading fits"""
 
-    simple = image_cache / "images" / "simple.fits"
-    multi = image_cache / "images" / "multi.fits"
-    compressed = image_cache / "images" / "compressed.fits.fz"
+    simple = test_images / "simple.fits"
+    multi = test_images / "multi.fits"
+    compressed = test_images / "compressed.fits.fz"
 
     # One image
     im = imageio.imread(simple, format="fits")

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -12,8 +12,6 @@ pytest.importorskip("astropy", reason="astropy is not installed")
 
 def setup_module():
     # During this test, pretend that FITS is the default format
-    import astropy.io.fits
-
     imageio.formats.sort("FITS")
 
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -78,10 +78,10 @@ class MyFormat(Format):
             self._meta = meta
 
 
-def test_format(image_cache, tmp_path):
+def test_format(test_images, tmp_path):
     """Test the working of the Format class"""
 
-    filename1 = image_cache / "test-images" / "chelsea.png"
+    filename1 = test_images / "chelsea.png"
     filename2 = tmp_path / "chelsea.out"
 
     # Test basic format creation
@@ -148,10 +148,10 @@ def test_format(image_cache, tmp_path):
     assert set(ids) == set(F._closed)
 
 
-def test_reader_and_writer(image_cache, tmp_path):
+def test_reader_and_writer(test_images, tmp_path):
 
     # Prepare
-    filename1 = image_cache / "test-images" / "chelsea.png"
+    filename1 = test_images / "chelsea.png"
     filename2 = tmp_path / "chelsea.out"
     F = MyFormat("test", "", modes="i")
 
@@ -240,10 +240,10 @@ def test_default_can_read_and_can_write(tmp_path):
     assert not F.can_write(Request(filename1 + ".foo", "wi"))
 
 
-def test_format_selection(image_cache, tmp_path):
+def test_format_selection(test_images, tmp_path):
 
     formats = imageio.formats
-    fname1 = image_cache / "test-images" / "chelsea.png"
+    fname1 = test_images / "chelsea.png"
     fname2 = tmp_path / "test.selectext1"
     fname3 = tmp_path / "test.haha"
     open(fname2, "wb")
@@ -277,7 +277,7 @@ def test_format_selection(image_cache, tmp_path):
 # Format manager
 
 
-def test_format_manager(image_cache):
+def test_format_manager(test_images):
     """Test working of the format manager"""
 
     formats = imageio.formats
@@ -299,7 +299,7 @@ def test_format_manager(image_cache):
         assert format.name in smalldocs
         # assert format.name in fulldocs
 
-    fname = image_cache / "test-images" / "chelsea.png"
+    fname = test_images / "chelsea.png"
     fname2 = fname.with_suffix(".noext")
     shutil.copy(fname, fname2)
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -225,7 +225,7 @@ def test_default_can_read_and_can_write(tmp_path):
     F = imageio.plugins.example.DummyFormat("test", "", "foo bar", "v")
 
     # Prepare files
-    filename1 = os.path.join(tmp_path, "test")
+    filename1 = tmp_path / "test"
     open(filename1 + ".foo", "wb")
     open(filename1 + ".bar", "wb")
     open(filename1 + ".spam", "wb")
@@ -248,8 +248,8 @@ def test_format_selection(tmp_path):
 
     formats = imageio.formats
     fname1 = get_remote_file("images/chelsea.png", tmp_path)
-    fname2 = os.path.join(tmp_path, "test.selectext1")
-    fname3 = os.path.join(tmp_path, "test.haha")
+    fname2 = tmp_path / "test.selectext1"
+    fname3 = tmp_path / "test.haha"
     open(fname2, "wb")
     open(fname3, "wb")
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,7 +1,6 @@
 from pytest import raises
 import pytest
 
-import os
 import gc
 import shutil
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,6 +1,5 @@
 from pytest import raises
 import pytest
-from imageio.testing import run_tests_if_main, get_test_dir
 
 import os
 import gc
@@ -14,14 +13,10 @@ from imageio.core import Format, FormatManager, Request
 from imageio.core import get_remote_file
 
 
-test_dir = get_test_dir()
-
-
-def setup_module():
+@pytest.fixture(scope="module", autouse=True)
+def resort():
     imageio.formats.sort()
-
-
-def teardown_module():
+    yield
     imageio.formats.sort()
 
 
@@ -84,7 +79,8 @@ class MyFormat(Format):
             self._meta = meta
 
 
-def test_format():
+@pytest.mark.needs_internet
+def test_format(test_dir):
     """Test the working of the Format class"""
 
     filename1 = get_remote_file("images/chelsea.png", test_dir)
@@ -154,7 +150,8 @@ def test_format():
     assert set(ids) == set(F._closed)
 
 
-def test_reader_and_writer():
+@pytest.mark.needs_internet
+def test_reader_and_writer(test_dir):
 
     # Prepare
     filename1 = get_remote_file("images/chelsea.png", test_dir)
@@ -223,7 +220,7 @@ def test_reader_and_writer():
     raises(ValueError, W.set_meta_data, "not a dict")
 
 
-def test_default_can_read_and_can_write():
+def test_default_can_read_and_can_write(test_dir):
 
     F = imageio.plugins.example.DummyFormat("test", "", "foo bar", "v")
 
@@ -246,7 +243,8 @@ def test_default_can_read_and_can_write():
     assert not F.can_write(Request(filename1 + ".foo", "wi"))
 
 
-def test_format_selection():
+@pytest.mark.needs_internet
+def test_format_selection(test_dir):
 
     formats = imageio.formats
     fname1 = get_remote_file("images/chelsea.png", test_dir)
@@ -283,7 +281,8 @@ def test_format_selection():
 # Format manager
 
 
-def test_format_manager():
+@pytest.mark.needs_internet
+def test_format_manager(test_dir):
     """Test working of the format manager"""
 
     formats = imageio.formats
@@ -429,6 +428,3 @@ def test_write_format_search_fail(tmp_path):
 
 def test_format_by_filename():
     iio.formats["test.jpg"]
-
-
-run_tests_if_main()

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -3,7 +3,7 @@ import pytest
 
 import gc
 import shutil
-import pathlib
+from pathlib import Path
 
 import numpy as np
 
@@ -116,8 +116,8 @@ def test_format(image_cache, tmp_path):
     assert isinstance(W, MyFormat.Writer)
     assert R.format is F
     assert W.format is F
-    assert pathlib.Path(R.request.filename) == filename1
-    assert pathlib.Path(W.request.filename) == filename2
+    assert Path(R.request.filename) == filename1
+    assert Path(W.request.filename) == filename2
     # Fail
     raises(RuntimeError, F.get_reader, Request(filename1, "rI"))
     raises(RuntimeError, F.get_writer, Request(filename2, "wI"))

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -80,10 +80,10 @@ class MyFormat(Format):
 
 
 @pytest.mark.needs_internet
-def test_format(test_dir):
+def test_format(tmp_path):
     """Test the working of the Format class"""
 
-    filename1 = get_remote_file("images/chelsea.png", test_dir)
+    filename1 = get_remote_file("images/chelsea.png", tmp_path)
     filename2 = filename1 + ".out"
 
     # Test basic format creation
@@ -151,10 +151,10 @@ def test_format(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_reader_and_writer(test_dir):
+def test_reader_and_writer(tmp_path):
 
     # Prepare
-    filename1 = get_remote_file("images/chelsea.png", test_dir)
+    filename1 = get_remote_file("images/chelsea.png", tmp_path)
     filename2 = filename1 + ".out"
     F = MyFormat("test", "", modes="i")
 
@@ -220,12 +220,12 @@ def test_reader_and_writer(test_dir):
     raises(ValueError, W.set_meta_data, "not a dict")
 
 
-def test_default_can_read_and_can_write(test_dir):
+def test_default_can_read_and_can_write(tmp_path):
 
     F = imageio.plugins.example.DummyFormat("test", "", "foo bar", "v")
 
     # Prepare files
-    filename1 = os.path.join(test_dir, "test")
+    filename1 = os.path.join(tmp_path, "test")
     open(filename1 + ".foo", "wb")
     open(filename1 + ".bar", "wb")
     open(filename1 + ".spam", "wb")
@@ -244,12 +244,12 @@ def test_default_can_read_and_can_write(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_format_selection(test_dir):
+def test_format_selection(tmp_path):
 
     formats = imageio.formats
-    fname1 = get_remote_file("images/chelsea.png", test_dir)
-    fname2 = os.path.join(test_dir, "test.selectext1")
-    fname3 = os.path.join(test_dir, "test.haha")
+    fname1 = get_remote_file("images/chelsea.png", tmp_path)
+    fname2 = os.path.join(tmp_path, "test.selectext1")
+    fname3 = os.path.join(tmp_path, "test.haha")
     open(fname2, "wb")
     open(fname3, "wb")
 
@@ -282,7 +282,7 @@ def test_format_selection(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_format_manager(test_dir):
+def test_format_manager(tmp_path):
     """Test working of the format manager"""
 
     formats = imageio.formats
@@ -304,7 +304,7 @@ def test_format_manager(test_dir):
         assert format.name in smalldocs
         # assert format.name in fulldocs
 
-    fname = get_remote_file("images/chelsea.png", test_dir)
+    fname = get_remote_file("images/chelsea.png", tmp_path)
     fname2 = fname[:-3] + "noext"
     shutil.copy(fname, fname2)
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -224,7 +224,7 @@ def test_default_can_read_and_can_write(tmp_path):
     F = imageio.plugins.example.DummyFormat("test", "", "foo bar", "v")
 
     # Prepare files
-    filename1 = tmp_path / "test"
+    filename1 = str(tmp_path / "test")
     open(filename1 + ".foo", "wb")
     open(filename1 + ".bar", "wb")
     open(filename1 + ".spam", "wb")
@@ -263,14 +263,14 @@ def test_format_selection(tmp_path):
     formats.add_format(format)
 
     # Select this format for files it said it could handle in extensions
-    assert ".selectext1" in fname2
+    assert ".selectext1" in str(fname2)
     F = formats.search_read_format(Request(fname2, "ri"))
     assert type(F) is type(format)
     F = formats.search_write_format(Request(fname2, "ri"))
     assert type(F) is type(format)
 
     # But this custom format also can deal with .haha files
-    assert ".haha" in fname3
+    assert ".haha" in str(fname3)
     F = formats.search_read_format(Request(fname3, "ri"))
     assert type(F) is type(format)
     F = formats.search_write_format(Request(fname3, "ri"))

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -16,7 +16,7 @@ from pytest import raises, skip
 
 
 @pytest.fixture(scope="module")
-def vendored_lib(tmp_path_factory):
+def vendored_lib(request, tmp_path_factory):
     lib_dir = tmp_path_factory.mktemp("freeimage_dir")
 
     if platform.system() == "Linux":
@@ -30,7 +30,8 @@ def vendored_lib(tmp_path_factory):
         "github",
         org="imageio",
         repo="imageio-binaries",
-        token=os.environ.get("GITHUB_TOKEN"),
+        username=request.config.getoption("--github-username"),
+        token=request.config.getoption("--github-token"),
     )
     fs.get(
         [x for x in fs.ls("freeimage/") if x.endswith(lib_extension)],

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -14,7 +14,7 @@ from imageio import core
 from imageio.core import get_remote_file, IS_PYPY
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def get_library():
     # During this test, pretend that FI is the default format
     imageio.formats.sort("-FI")
@@ -80,7 +80,7 @@ def assert_close(im1, im2, tol=0.0):
 
 
 @pytest.mark.needs_internet
-def test_download(get_library):
+def test_download():
     # this is a regression test
     # see: https://github.com/imageio/imageio/issues/690
 
@@ -88,7 +88,7 @@ def test_download(get_library):
 
 
 @pytest.mark.needs_internet
-def test_get_ref_im(get_library):
+def test_get_ref_im():
     """A test for our function to get test images"""
 
     crop = 0
@@ -126,9 +126,9 @@ def test_get_fi_lib():
 
 
 @pytest.mark.needs_internet
-def test_freeimage_format(tmp_path, get_library):
+def test_freeimage_format(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     # Format
     F = imageio.formats["PNG-FI"]
@@ -150,7 +150,7 @@ def test_freeimage_format(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_freeimage_lib(get_library):
+def test_freeimage_lib():
 
     fi = imageio.plugins.freeimage.fi
 
@@ -167,9 +167,9 @@ def test_freeimage_lib(get_library):
 
 
 @pytest.mark.needs_internet
-def test_png(tmp_path, get_library):
+def test_png(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -230,9 +230,9 @@ def test_png(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_png_dtypes(tmp_path, get_library):
+def test_png_dtypes(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     # See issue #44
 
@@ -270,9 +270,9 @@ def test_png_dtypes(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_jpg(tmp_path, get_library):
+def test_jpg(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -319,9 +319,9 @@ def test_jpg(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_jpg_more(tmp_path, get_library):
+def test_jpg_more(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     # Test broken JPEG
     fname = fnamebase + "_broken.jpg"
@@ -353,9 +353,9 @@ def test_jpg_more(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_bmp(tmp_path, get_library):
+def test_bmp(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -393,9 +393,9 @@ def test_bmp(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_gif(tmp_path, get_library):
+def test_gif(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     # The not-animated gif
 
@@ -429,9 +429,9 @@ def test_gif(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_animated_gif(tmp_path, get_library):
+def test_animated_gif(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     if sys.platform.startswith("darwin"):
         skip("On OSX quantization of freeimage is unstable")
@@ -503,9 +503,9 @@ def test_animated_gif(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_ico(tmp_path, get_library):
+def test_ico(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     for isfloat in (False, True):
         for crop in (0,):
@@ -549,9 +549,9 @@ def test_ico(tmp_path, get_library):
     reason="Windows has a known issue with multi-icon files",
 )
 @pytest.mark.needs_internet
-def test_multi_icon_ico(tmp_path, get_library):
+def test_multi_icon_ico(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     im = get_ref_im(4, 0, 0)[:32, :32]
     ims = [np.repeat(np.repeat(im, i, 1), i, 0) for i in (1, 2)]  # SegF on win
@@ -569,9 +569,9 @@ def test_mng(get_library):
 
 
 @pytest.mark.needs_internet
-def test_pnm(tmp_path, get_library):
+def test_pnm(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     for useAscii in (True, False):
         for crop in (0, 1, 2):
@@ -602,8 +602,8 @@ def test_pnm(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_other(tmp_path, get_library):
-    fnamebase = os.path.join(tmp_path, "test")
+def test_other(tmp_path):
+    fnamebase = tmp_path / "test"
 
     # Cannot save float
     im = get_ref_im(3, 0, 1)
@@ -611,7 +611,7 @@ def test_other(tmp_path, get_library):
 
 
 @pytest.mark.needs_internet
-def test_gamma_correction(get_library):
+def test_gamma_correction():
 
     fname = get_remote_file("images/kodim03.png")
 

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -35,13 +35,9 @@ def setup_library(tmp_path_factory, image_cache):
         os.environ["IMAGEIO_USERDIR"] = str(ud)
         add = core.appdata_dir("imageio")
         os.makedirs(add, exist_ok=True)
-        shutil.copytree(
-            image_cache / "freeimage", os.path.join(add, "freeimage")
-        )
+        shutil.copytree(image_cache / "freeimage", os.path.join(add, "freeimage"))
         fi.load_freeimage()
-        assert (
-            fi.has_lib()
-        ), "imageio-binaries' version of libfreeimage was not found"
+        assert fi.has_lib(), "imageio-binaries' version of libfreeimage was not found"
 
     yield
 
@@ -147,9 +143,7 @@ def test_get_fi_lib(image_cache, tmp_userdir):
 
     add = core.appdata_dir("imageio")
     os.makedirs(add, exist_ok=True)
-    shutil.copytree(
-        image_cache / "freeimage", os.path.join(add, "freeimage")
-    )
+    shutil.copytree(image_cache / "freeimage", os.path.join(add, "freeimage"))
 
     lib = get_freeimage_lib()
     assert os.path.isfile(lib)
@@ -224,9 +218,7 @@ def test_png(setup_library, image_cache, tmp_path):
         imageio.plugins._freeimage.TEST_NUMPY_NO_STRIDES = False
 
     # Parameters
-    im = imageio.imread(
-        image_cache / "images" / "chelsea.png", ignoregamma=True
-    )
+    im = imageio.imread(image_cache / "images" / "chelsea.png", ignoregamma=True)
     imageio.imsave(fnamebase + ".png", im, interlaced=True)
 
     # Parameter fail
@@ -446,9 +438,7 @@ def test_gif(setup_library, tmp_path):
                 assert_close(rim * mul, im, 1.1)  # lossless
 
     # Parameter fail
-    raises(
-        TypeError, imageio.imread, fname, notavalidkwarg=True, format="GIF-FI"
-    )
+    raises(TypeError, imageio.imread, fname, notavalidkwarg=True, format="GIF-FI")
     raises(
         TypeError,
         imageio.imsave,
@@ -492,12 +482,8 @@ def test_animated_gif(setup_library, tmp_path):
 
     # We can also store grayscale
     fname = fnamebase + ".animated.%i.gif" % 1
-    imageio.mimsave(
-        fname, [x[:, :, 0] for x in ims], duration=0.2, format="GIF-FI"
-    )
-    imageio.mimsave(
-        fname, [x[:, :, :1] for x in ims], duration=0.2, format="GIF-FI"
-    )
+    imageio.mimsave(fname, [x[:, :, 0] for x in ims], duration=0.2, format="GIF-FI")
+    imageio.mimsave(fname, [x[:, :, :1] for x in ims], duration=0.2, format="GIF-FI")
 
     # Irragular duration. You probably want to check this manually (I did)
     duration = [0.1 for i in ims]
@@ -529,20 +515,14 @@ def test_animated_gif(setup_library, tmp_path):
         quantizer="foo",
         format="GIF-FI",
     )
-    raises(
-        ValueError, imageio.mimsave, fname, ims, duration="foo", format="GIF-FI"
-    )
+    raises(ValueError, imageio.mimsave, fname, ims, duration="foo", format="GIF-FI")
 
     # Add one duplicate image to ims to touch subractangle with not change
     ims.append(ims[-1])
 
     # Test subrectangles
-    imageio.mimsave(
-        fnamebase + ".subno.gif", ims, subrectangles=False, format="GIF-FI"
-    )
-    imageio.mimsave(
-        fnamebase + ".subyes.gif", ims, subrectangles=True, format="GIF-FI"
-    )
+    imageio.mimsave(fnamebase + ".subno.gif", ims, subrectangles=False, format="GIF-FI")
+    imageio.mimsave(fnamebase + ".subyes.gif", ims, subrectangles=True, format="GIF-FI")
     s1 = os.stat(fnamebase + ".subno.gif").st_size
     s2 = os.stat(fnamebase + ".subyes.gif").st_size
     assert s2 < s1
@@ -576,15 +556,11 @@ def test_ico(setup_library, tmp_path):
     writer.close()
 
     # Parameters. Note that with makealpha, RGBA images are read in incorrectly
-    im = imageio.imread(
-        fnamebase + "0.0.1.ico", makealpha=True, format="ICO-FI"
-    )
+    im = imageio.imread(fnamebase + "0.0.1.ico", makealpha=True, format="ICO-FI")
     assert im.ndim == 3 and im.shape[-1] == 4
 
     # Parameter fail
-    raises(
-        TypeError, imageio.imread, fname, notavalidkwarg=True, format="ICO-FI"
-    )
+    raises(TypeError, imageio.imread, fname, notavalidkwarg=True, format="ICO-FI")
     raises(
         TypeError,
         imageio.imsave,

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -22,6 +22,7 @@ def get_library(tmp_path_factory):
 
     # This tests requires our version of the FI lib
     ud = tmp_path_factory.getbasetemp() / "userdir"
+    os.makedirs(ud, exist_ok=True)
     os.environ["IMAGEIO_USERDIR"] = str(ud)
     imageio.plugins.freeimage.download()
 

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -128,7 +128,7 @@ def test_get_fi_lib():
 @pytest.mark.needs_internet
 def test_freeimage_format(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     # Format
     F = imageio.formats["PNG-FI"]
@@ -169,7 +169,7 @@ def test_freeimage_lib():
 @pytest.mark.needs_internet
 def test_png(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -232,7 +232,7 @@ def test_png(tmp_path):
 @pytest.mark.needs_internet
 def test_png_dtypes(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     # See issue #44
 
@@ -272,7 +272,7 @@ def test_png_dtypes(tmp_path):
 @pytest.mark.needs_internet
 def test_jpg(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -321,7 +321,7 @@ def test_jpg(tmp_path):
 @pytest.mark.needs_internet
 def test_jpg_more(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     # Test broken JPEG
     fname = fnamebase + "_broken.jpg"
@@ -355,7 +355,7 @@ def test_jpg_more(tmp_path):
 @pytest.mark.needs_internet
 def test_bmp(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -395,7 +395,7 @@ def test_bmp(tmp_path):
 @pytest.mark.needs_internet
 def test_gif(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     # The not-animated gif
 
@@ -431,7 +431,7 @@ def test_gif(tmp_path):
 @pytest.mark.needs_internet
 def test_animated_gif(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     if sys.platform.startswith("darwin"):
         skip("On OSX quantization of freeimage is unstable")
@@ -505,7 +505,7 @@ def test_animated_gif(tmp_path):
 @pytest.mark.needs_internet
 def test_ico(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
         for crop in (0,):
@@ -551,7 +551,7 @@ def test_ico(tmp_path):
 @pytest.mark.needs_internet
 def test_multi_icon_ico(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     im = get_ref_im(4, 0, 0)[:32, :32]
     ims = [np.repeat(np.repeat(im, i, 1), i, 0) for i in (1, 2)]  # SegF on win
@@ -571,7 +571,7 @@ def test_mng(get_library):
 @pytest.mark.needs_internet
 def test_pnm(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     for useAscii in (True, False):
         for crop in (0, 1, 2):
@@ -603,7 +603,7 @@ def test_pnm(tmp_path):
 
 @pytest.mark.needs_internet
 def test_other(tmp_path):
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     # Cannot save float
     im = get_ref_im(3, 0, 1)

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -21,9 +21,7 @@ def setup_library(tmp_path_factory, image_cache):
     # Checks if freeimage is installed by the system
     from imageio.plugins.freeimage import fi
 
-    use_imageio_binary = False
-    if not fi.has_lib():
-        use_imageio_binary = True
+    use_imageio_binary = not fi.has_lib()
 
     # During this test, pretend that FI is the default format
     imageio.formats.sort("-FI")
@@ -31,7 +29,7 @@ def setup_library(tmp_path_factory, image_cache):
     if use_imageio_binary:
 
         # Setup from image_cache/freeimage
-        ud = tmp_path_factory.getbasetemp() / "userdir"
+        ud = tmp_path_factory.mktemp("userdir")
         if sys.platform.startswith("win"):
             if "LOCALAPPDATA" in os.environ:  # saves it
                 os.environ["OLD_LOCALAPPDATA"] = os.environ["LOCALAPPDATA"]

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -565,7 +565,7 @@ def test_multi_icon_ico(tmp_path, get_library):
 @pytest.mark.skip("MNG seems broken in FreeImage")
 @pytest.mark.needs_internet
 def test_mng(get_library):
-    ims = imageio.imread(get_remote_file("images/mngexample.mng"))
+    imageio.imread(get_remote_file("images/mngexample.mng"))
 
 
 @pytest.mark.needs_internet

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -126,9 +126,9 @@ def test_get_fi_lib():
 
 
 @pytest.mark.needs_internet
-def test_freeimage_format(test_dir, get_library):
+def test_freeimage_format(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     # Format
     F = imageio.formats["PNG-FI"]
@@ -167,9 +167,9 @@ def test_freeimage_lib(get_library):
 
 
 @pytest.mark.needs_internet
-def test_png(test_dir, get_library):
+def test_png(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -230,9 +230,9 @@ def test_png(test_dir, get_library):
 
 
 @pytest.mark.needs_internet
-def test_png_dtypes(test_dir, get_library):
+def test_png_dtypes(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     # See issue #44
 
@@ -270,9 +270,9 @@ def test_png_dtypes(test_dir, get_library):
 
 
 @pytest.mark.needs_internet
-def test_jpg(test_dir, get_library):
+def test_jpg(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -319,9 +319,9 @@ def test_jpg(test_dir, get_library):
 
 
 @pytest.mark.needs_internet
-def test_jpg_more(test_dir, get_library):
+def test_jpg_more(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     # Test broken JPEG
     fname = fnamebase + "_broken.jpg"
@@ -353,9 +353,9 @@ def test_jpg_more(test_dir, get_library):
 
 
 @pytest.mark.needs_internet
-def test_bmp(test_dir, get_library):
+def test_bmp(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -393,9 +393,9 @@ def test_bmp(test_dir, get_library):
 
 
 @pytest.mark.needs_internet
-def test_gif(test_dir, get_library):
+def test_gif(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     # The not-animated gif
 
@@ -429,9 +429,9 @@ def test_gif(test_dir, get_library):
 
 
 @pytest.mark.needs_internet
-def test_animated_gif(test_dir, get_library):
+def test_animated_gif(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     if sys.platform.startswith("darwin"):
         skip("On OSX quantization of freeimage is unstable")
@@ -503,9 +503,9 @@ def test_animated_gif(test_dir, get_library):
 
 
 @pytest.mark.needs_internet
-def test_ico(test_dir, get_library):
+def test_ico(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     for isfloat in (False, True):
         for crop in (0,):
@@ -549,9 +549,9 @@ def test_ico(test_dir, get_library):
     reason="Windows has a known issue with multi-icon files",
 )
 @pytest.mark.needs_internet
-def test_multi_icon_ico(test_dir, get_library):
+def test_multi_icon_ico(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     im = get_ref_im(4, 0, 0)[:32, :32]
     ims = [np.repeat(np.repeat(im, i, 1), i, 0) for i in (1, 2)]  # SegF on win
@@ -569,9 +569,9 @@ def test_mng(get_library):
 
 
 @pytest.mark.needs_internet
-def test_pnm(test_dir, get_library):
+def test_pnm(tmp_path, get_library):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     for useAscii in (True, False):
         for crop in (0, 1, 2):
@@ -602,8 +602,8 @@ def test_pnm(test_dir, get_library):
 
 
 @pytest.mark.needs_internet
-def test_other(test_dir, get_library):
-    fnamebase = os.path.join(test_dir, "test")
+def test_other(tmp_path, get_library):
+    fnamebase = os.path.join(tmp_path, "test")
 
     # Cannot save float
     im = get_ref_im(3, 0, 1)

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -34,7 +34,7 @@ def setup_library(tmp_path_factory, image_cache):
         # Setup from image_cache/freeimage
         ud = tmp_path_factory.getbasetemp() / "userdir"
         if sys.platform.startswith("win"):
-            if "LOCALAPPDATA" in os.environ:  #saves it
+            if "LOCALAPPDATA" in os.environ:  # saves it
                 os.environ["OLD_LOCALAPPDATA"] = os.environ["LOCALAPPDATA"]
             os.environ["LOCALAPPDATA"] = str(ud)
         else:

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -201,9 +201,7 @@ def test_png(image_cache, tmp_path):
         imageio.plugins._freeimage.TEST_NUMPY_NO_STRIDES = False
 
     # Parameters
-    im = imageio.imread(
-        image_cache / "images" / "chelsea.png", ignoregamma=True
-    )
+    im = imageio.imread(image_cache / "images" / "chelsea.png", ignoregamma=True)
     imageio.imsave(fnamebase + ".png", im, interlaced=True)
 
     # Parameter fail
@@ -423,9 +421,7 @@ def test_gif(tmp_path):
                 assert_close(rim * mul, im, 1.1)  # lossless
 
     # Parameter fail
-    raises(
-        TypeError, imageio.imread, fname, notavalidkwarg=True, format="GIF-FI"
-    )
+    raises(TypeError, imageio.imread, fname, notavalidkwarg=True, format="GIF-FI")
     raises(
         TypeError,
         imageio.imsave,
@@ -469,12 +465,8 @@ def test_animated_gif(tmp_path):
 
     # We can also store grayscale
     fname = fnamebase + ".animated.%i.gif" % 1
-    imageio.mimsave(
-        fname, [x[:, :, 0] for x in ims], duration=0.2, format="GIF-FI"
-    )
-    imageio.mimsave(
-        fname, [x[:, :, :1] for x in ims], duration=0.2, format="GIF-FI"
-    )
+    imageio.mimsave(fname, [x[:, :, 0] for x in ims], duration=0.2, format="GIF-FI")
+    imageio.mimsave(fname, [x[:, :, :1] for x in ims], duration=0.2, format="GIF-FI")
 
     # Irragular duration. You probably want to check this manually (I did)
     duration = [0.1 for i in ims]
@@ -506,20 +498,14 @@ def test_animated_gif(tmp_path):
         quantizer="foo",
         format="GIF-FI",
     )
-    raises(
-        ValueError, imageio.mimsave, fname, ims, duration="foo", format="GIF-FI"
-    )
+    raises(ValueError, imageio.mimsave, fname, ims, duration="foo", format="GIF-FI")
 
     # Add one duplicate image to ims to touch subractangle with not change
     ims.append(ims[-1])
 
     # Test subrectangles
-    imageio.mimsave(
-        fnamebase + ".subno.gif", ims, subrectangles=False, format="GIF-FI"
-    )
-    imageio.mimsave(
-        fnamebase + ".subyes.gif", ims, subrectangles=True, format="GIF-FI"
-    )
+    imageio.mimsave(fnamebase + ".subno.gif", ims, subrectangles=False, format="GIF-FI")
+    imageio.mimsave(fnamebase + ".subyes.gif", ims, subrectangles=True, format="GIF-FI")
     s1 = os.stat(fnamebase + ".subno.gif").st_size
     s2 = os.stat(fnamebase + ".subyes.gif").st_size
     assert s2 < s1
@@ -553,15 +539,11 @@ def test_ico(tmp_path):
     writer.close()
 
     # Parameters. Note that with makealpha, RGBA images are read in incorrectly
-    im = imageio.imread(
-        fnamebase + "0.0.1.ico", makealpha=True, format="ICO-FI"
-    )
+    im = imageio.imread(fnamebase + "0.0.1.ico", makealpha=True, format="ICO-FI")
     assert im.ndim == 3 and im.shape[-1] == 4
 
     # Parameter fail
-    raises(
-        TypeError, imageio.imread, fname, notavalidkwarg=True, format="ICO-FI"
-    )
+    raises(TypeError, imageio.imread, fname, notavalidkwarg=True, format="ICO-FI")
     raises(
         TypeError,
         imageio.imsave,

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import shutil
 
 import numpy as np
 
@@ -11,17 +12,23 @@ import pytest
 
 import imageio
 from imageio import core
-from imageio.core import get_remote_file, IS_PYPY
+from imageio.core import IS_PYPY
 
 
 @pytest.fixture(scope="module", autouse=True)
-def get_library():
+def get_library(tmp_path_factory):
     # During this test, pretend that FI is the default format
     imageio.formats.sort("-FI")
 
     # This tests requires our version of the FI lib
+    ud = tmp_path_factory.getbasetemp() / "userdir"
+    os.environ["IMAGEIO_USERDIR"] = str(ud)
     imageio.plugins.freeimage.download()
+
     yield
+
+    del os.environ["IMAGEIO_USERDIR"]
+    shutil.rmtree(ud)
 
     # Sort formats back to normal
     imageio.formats.sort()
@@ -87,7 +94,6 @@ def test_download():
     assert hasattr(imageio.plugins.freeimage, "download")
 
 
-@pytest.mark.needs_internet
 def test_get_ref_im():
     """A test for our function to get test images"""
 
@@ -125,8 +131,7 @@ def test_get_fi_lib():
     assert os.path.isfile(lib)
 
 
-@pytest.mark.needs_internet
-def test_freeimage_format(tmp_path):
+def test_freeimage_format(image_cache, tmp_path):
 
     fnamebase = str(tmp_path / "test")
 
@@ -135,7 +140,7 @@ def test_freeimage_format(tmp_path):
     assert F.name == "PNG-FI"
 
     # Reader
-    R = F.get_reader(core.Request("imageio:chelsea.png", "ri"))
+    R = F.get_reader(core.Request(image_cache / "images" / "chelsea.png", "ri"))
     assert len(R) == 1
     assert isinstance(R.get_meta_data(), dict)
     assert isinstance(R.get_meta_data(0), dict)
@@ -166,8 +171,7 @@ def test_freeimage_lib():
     raises(ValueError, fi.getFIF, "foo.iff", "w")  # We cannot write iff
 
 
-@pytest.mark.needs_internet
-def test_png(tmp_path):
+def test_png(image_cache, tmp_path):
 
     fnamebase = str(tmp_path / "test")
 
@@ -197,11 +201,18 @@ def test_png(tmp_path):
         imageio.plugins._freeimage.TEST_NUMPY_NO_STRIDES = False
 
     # Parameters
-    im = imageio.imread("imageio:chelsea.png", ignoregamma=True)
+    im = imageio.imread(
+        image_cache / "images" / "chelsea.png", ignoregamma=True
+    )
     imageio.imsave(fnamebase + ".png", im, interlaced=True)
 
     # Parameter fail
-    raises(TypeError, imageio.imread, "imageio:chelsea.png", notavalidk=True)
+    raises(
+        TypeError,
+        imageio.imread,
+        image_cache / "images" / "chelsea.png",
+        notavalidk=True,
+    )
     raises(TypeError, imageio.imsave, fnamebase + ".png", im, notavalidk=True)
 
     # Compression
@@ -229,7 +240,6 @@ def test_png(tmp_path):
     raises(ValueError, imageio.imsave, fname, im[:, :, 0], quantize=100)
 
 
-@pytest.mark.needs_internet
 def test_png_dtypes(tmp_path):
 
     fnamebase = str(tmp_path / "test")
@@ -269,7 +279,6 @@ def test_png_dtypes(tmp_path):
     assert_close(im1, imageio.imread(fname))  # scaled
 
 
-@pytest.mark.needs_internet
 def test_jpg(tmp_path):
 
     fnamebase = str(tmp_path / "test")
@@ -318,8 +327,7 @@ def test_jpg(tmp_path):
     raises(ValueError, imageio.imsave, fnamebase + ".jpg", im, quality=120)
 
 
-@pytest.mark.needs_internet
-def test_jpg_more(tmp_path):
+def test_jpg_more(image_cache, tmp_path):
 
     fnamebase = str(tmp_path / "test")
 
@@ -337,7 +345,7 @@ def test_jpg_more(tmp_path):
     raises(Exception, imageio.imread, fname)
 
     # Test EXIF stuff
-    fname = get_remote_file("images/rommel.jpg")
+    fname = image_cache / "images" / "rommel.jpg"
     im = imageio.imread(fname)
     assert im.shape[0] > im.shape[1]
     im = imageio.imread(fname, exifrotate=False)
@@ -352,7 +360,6 @@ def test_jpg_more(tmp_path):
     assert im.meta.EXIF_MAIN
 
 
-@pytest.mark.needs_internet
 def test_bmp(tmp_path):
 
     fnamebase = str(tmp_path / "test")
@@ -392,7 +399,6 @@ def test_bmp(tmp_path):
     )
 
 
-@pytest.mark.needs_internet
 def test_gif(tmp_path):
 
     fnamebase = str(tmp_path / "test")
@@ -417,7 +423,9 @@ def test_gif(tmp_path):
                 assert_close(rim * mul, im, 1.1)  # lossless
 
     # Parameter fail
-    raises(TypeError, imageio.imread, fname, notavalidkwarg=True, format="GIF-FI")
+    raises(
+        TypeError, imageio.imread, fname, notavalidkwarg=True, format="GIF-FI"
+    )
     raises(
         TypeError,
         imageio.imsave,
@@ -428,7 +436,6 @@ def test_gif(tmp_path):
     )
 
 
-@pytest.mark.needs_internet
 def test_animated_gif(tmp_path):
 
     fnamebase = str(tmp_path / "test")
@@ -462,8 +469,12 @@ def test_animated_gif(tmp_path):
 
     # We can also store grayscale
     fname = fnamebase + ".animated.%i.gif" % 1
-    imageio.mimsave(fname, [x[:, :, 0] for x in ims], duration=0.2, format="GIF-FI")
-    imageio.mimsave(fname, [x[:, :, :1] for x in ims], duration=0.2, format="GIF-FI")
+    imageio.mimsave(
+        fname, [x[:, :, 0] for x in ims], duration=0.2, format="GIF-FI"
+    )
+    imageio.mimsave(
+        fname, [x[:, :, :1] for x in ims], duration=0.2, format="GIF-FI"
+    )
 
     # Irragular duration. You probably want to check this manually (I did)
     duration = [0.1 for i in ims]
@@ -479,21 +490,36 @@ def test_animated_gif(tmp_path):
     )
     R = imageio.read(fnamebase + ".animated.loop2.gif", format="GIF-FI")
     W = imageio.save(
-        fnamebase + ".animated.palettes100.gif", palettesize=100, format="GIF-FI"
+        fnamebase + ".animated.palettes100.gif",
+        palettesize=100,
+        format="GIF-FI",
     )
     assert W._palettesize == 128
     # Fail
     raises(IndexError, R.get_meta_data, -1)
     raises(ValueError, imageio.mimsave, fname, ims, palettesize=300)
-    raises(ValueError, imageio.mimsave, fname, ims, quantizer="foo", format="GIF-FI")
-    raises(ValueError, imageio.mimsave, fname, ims, duration="foo", format="GIF-FI")
+    raises(
+        ValueError,
+        imageio.mimsave,
+        fname,
+        ims,
+        quantizer="foo",
+        format="GIF-FI",
+    )
+    raises(
+        ValueError, imageio.mimsave, fname, ims, duration="foo", format="GIF-FI"
+    )
 
     # Add one duplicate image to ims to touch subractangle with not change
     ims.append(ims[-1])
 
     # Test subrectangles
-    imageio.mimsave(fnamebase + ".subno.gif", ims, subrectangles=False, format="GIF-FI")
-    imageio.mimsave(fnamebase + ".subyes.gif", ims, subrectangles=True, format="GIF-FI")
+    imageio.mimsave(
+        fnamebase + ".subno.gif", ims, subrectangles=False, format="GIF-FI"
+    )
+    imageio.mimsave(
+        fnamebase + ".subyes.gif", ims, subrectangles=True, format="GIF-FI"
+    )
     s1 = os.stat(fnamebase + ".subno.gif").st_size
     s2 = os.stat(fnamebase + ".subyes.gif").st_size
     assert s2 < s1
@@ -502,7 +528,6 @@ def test_animated_gif(tmp_path):
     assert isinstance(imageio.read(fname).get_meta_data(), dict)
 
 
-@pytest.mark.needs_internet
 def test_ico(tmp_path):
 
     fnamebase = str(tmp_path / "test")
@@ -528,11 +553,15 @@ def test_ico(tmp_path):
     writer.close()
 
     # Parameters. Note that with makealpha, RGBA images are read in incorrectly
-    im = imageio.imread(fnamebase + "0.0.1.ico", makealpha=True, format="ICO-FI")
+    im = imageio.imread(
+        fnamebase + "0.0.1.ico", makealpha=True, format="ICO-FI"
+    )
     assert im.ndim == 3 and im.shape[-1] == 4
 
     # Parameter fail
-    raises(TypeError, imageio.imread, fname, notavalidkwarg=True, format="ICO-FI")
+    raises(
+        TypeError, imageio.imread, fname, notavalidkwarg=True, format="ICO-FI"
+    )
     raises(
         TypeError,
         imageio.imsave,
@@ -548,7 +577,6 @@ def test_ico(tmp_path):
     sys.platform.startswith("win"),
     reason="Windows has a known issue with multi-icon files",
 )
-@pytest.mark.needs_internet
 def test_multi_icon_ico(tmp_path):
 
     fnamebase = str(tmp_path / "test")
@@ -563,12 +591,10 @@ def test_multi_icon_ico(tmp_path):
 
 
 @pytest.mark.skip("MNG seems broken in FreeImage")
-@pytest.mark.needs_internet
-def test_mng(get_library):
-    imageio.imread(get_remote_file("images/mngexample.mng"))
+def test_mng(image_cache):
+    imageio.imread(image_cache / "images" / "mngexample.mng")
 
 
-@pytest.mark.needs_internet
 def test_pnm(tmp_path):
 
     fnamebase = str(tmp_path / "test")
@@ -601,7 +627,6 @@ def test_pnm(tmp_path):
                 )
 
 
-@pytest.mark.needs_internet
 def test_other(tmp_path):
     fnamebase = str(tmp_path / "test")
 
@@ -610,10 +635,9 @@ def test_other(tmp_path):
     raises(Exception, imageio.imsave, fnamebase + ".jng", im, "JNG")
 
 
-@pytest.mark.needs_internet
-def test_gamma_correction():
+def test_gamma_correction(image_cache):
 
-    fname = get_remote_file("images/kodim03.png")
+    fname = image_cache / "images" / "kodim03.png"
 
     # Load image three times
     im1 = imageio.imread(fname, format="PNG-FI")

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -26,7 +26,12 @@ def vendored_lib(tmp_path_factory):
     elif platform.system() == "Windows":
         lib_extension = ".dll"
 
-    fs = fsspec.filesystem("github", org="imageio", repo="imageio-binaries")
+    fs = fsspec.filesystem(
+        "github",
+        org="imageio",
+        repo="imageio-binaries",
+        token=os.environ.get("GITHUB_TOKEN"),
+    )
     fs.get(
         [x for x in fs.ls("freeimage/") if x.endswith(lib_extension)],
         lib_dir.as_posix(),

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -120,6 +120,7 @@ def test_get_ref_im(get_library):
 def test_get_fi_lib():
 
     from imageio.plugins._freeimage import get_freeimage_lib
+
     lib = get_freeimage_lib()
     assert os.path.isfile(lib)
 
@@ -564,7 +565,7 @@ def test_multi_icon_ico(test_dir, get_library):
 @pytest.mark.skip("MNG seems broken in FreeImage")
 @pytest.mark.needs_internet
 def test_mng(get_library):
-     ims = imageio.imread(get_remote_file('images/mngexample.mng'))
+    ims = imageio.imread(get_remote_file("images/mngexample.mng"))
 
 
 @pytest.mark.needs_internet

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import stat
 import shutil
 
 import numpy as np

--- a/tests/test_freeimage_suite.py
+++ b/tests/test_freeimage_suite.py
@@ -5,14 +5,7 @@ import os
 import sys
 import zipfile
 import shutil
-
-from pytest import raises  # noqa
-from imageio.testing import get_test_dir
-
 import imageio
-from imageio.core import get_remote_file, IS_PYPY, urlopen  # noqa
-
-test_dir = get_test_dir()
 
 # During this test, pretend that FI is the default format?
 # imageio.formats.sort('-FI')

--- a/tests/test_freeimage_suite.py
+++ b/tests/test_freeimage_suite.py
@@ -6,6 +6,7 @@ import sys
 import zipfile
 import shutil
 import imageio
+import urllib.request
 
 # During this test, pretend that FI is the default format?
 # imageio.formats.sort('-FI')
@@ -62,7 +63,7 @@ def run_feeimage_test_suite():
         # Make sure that the file is there
         if not os.path.isfile(fname):
             print("Downloading %s.zip" % name)
-            f1 = urlopen(ulr + name + ".zip")
+            f1 = urllib.request.urlopen(ulr + name + ".zip")
             f2 = open(fname, "wb")
             shutil.copyfileobj(f1, f2)
             f1.close()

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -2,16 +2,14 @@
 """
 import pytest
 import imageio
-from imageio.core import get_remote_file
 
 pytest.importorskip("osgeo", reason="gdal is not installed")
 
 
-@pytest.mark.needs_internet
-def test_gdal_reading():
+def test_gdal_reading(image_cache):
     """Test reading gdal"""
 
-    filename = get_remote_file("images/geotiff.tif")
+    filename = image_cache / "images" / "geotiff.tif"
 
     im = imageio.imread(filename, "gdal")
     assert im.shape == (929, 699)

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -22,6 +22,7 @@ def test_gdal_reading():
     assert "TIFFTAG_XRESOLUTION" in meta_data
 
     # Fail
-    raises = pytest.raises
-    raises(IndexError, R.get_data, -1)
-    raises(IndexError, R.get_data, 3)
+    with pytest.raises(IndexError):
+        R.get_data(-1)
+    with pytest.raises(IndexError):
+        R.get_data(3)

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -1,24 +1,16 @@
 """ Test gdal plugin functionality.
 """
 import pytest
-from imageio.testing import run_tests_if_main, get_test_dir, need_internet
-
 import imageio
 from imageio.core import get_remote_file
 
-test_dir = get_test_dir()
+pytest.importorskip("osgeo", reason="gdal is not installed")
 
-
-try:
-    from osgeo import gdal
-except ImportError:
-    gdal = None
-
-
-@pytest.mark.skipif("gdal is None")
+@pytest.mark.needs_internet
 def test_gdal_reading():
     """Test reading gdal"""
-    need_internet()
+
+    from osgeo import gdal
 
     filename = get_remote_file("images/geotiff.tif")
 
@@ -34,6 +26,3 @@ def test_gdal_reading():
     raises = pytest.raises
     raises(IndexError, R.get_data, -1)
     raises(IndexError, R.get_data, 3)
-
-
-run_tests_if_main()

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -6,10 +6,10 @@ import imageio
 pytest.importorskip("osgeo", reason="gdal is not installed")
 
 
-def test_gdal_reading(image_cache):
+def test_gdal_reading(test_images):
     """Test reading gdal"""
 
-    filename = image_cache / "images" / "geotiff.tif"
+    filename = test_images / "geotiff.tif"
 
     im = imageio.imread(filename, "gdal")
     assert im.shape == (929, 699)

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -6,6 +6,7 @@ from imageio.core import get_remote_file
 
 pytest.importorskip("osgeo", reason="gdal is not installed")
 
+
 @pytest.mark.needs_internet
 def test_gdal_reading():
     """Test reading gdal"""

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -11,8 +11,6 @@ pytest.importorskip("osgeo", reason="gdal is not installed")
 def test_gdal_reading():
     """Test reading gdal"""
 
-    from osgeo import gdal
-
     filename = get_remote_file("images/geotiff.tif")
 
     im = imageio.imread(filename, "gdal")

--- a/tests/test_grab.py
+++ b/tests/test_grab.py
@@ -3,7 +3,6 @@ import sys
 import numpy as np
 
 from pytest import raises
-from imageio.testing import run_tests_if_main
 
 import imageio
 import imageio.plugins.grab
@@ -93,6 +92,3 @@ def test_grab_simulated():
         imageio.plugins.grab.BaseGrabFormat._ImageGrab = None
         imageio.plugins.grab.BaseGrabFormat._pillow_imported = False
         FakeImageGrab.has_clipboard = True
-
-
-run_tests_if_main()

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -10,26 +10,26 @@ from imageio.core import Request
 
 
 # Set file names for test images in imageio-binaries repo
-LFR_FILENAME = "images/Ankylosaurus_&_Stegosaurus.LFR"
-THUMB_FILENAME = "images/Ankylosaurus_&_Stegosaurus_Thumbnail.jpg"
-RAW_ILLUM_FILENAME = "images/lenslet_whiteimage.RAW"
-RAW_ILLUM_META_FILENAME = "images/lenslet_whiteimage.TXT"
-LFP_FILENAME = "images/Guitar.lfp"
-RAW_F0_FILENAME = "images/IMG_0001__frame.raw"
-RAW_F0_META_FILENAME = "images/IMG_0001__frame.json"
-PNG_FILENAME = "images/chelsea.png"
+LFR_FILENAME = "Ankylosaurus_&_Stegosaurus.LFR"
+THUMB_FILENAME = "Ankylosaurus_&_Stegosaurus_Thumbnail.jpg"
+RAW_ILLUM_FILENAME = "lenslet_whiteimage.RAW"
+RAW_ILLUM_META_FILENAME = "lenslet_whiteimage.TXT"
+LFP_FILENAME = "Guitar.lfp"
+RAW_F0_FILENAME = "IMG_0001__frame.raw"
+RAW_F0_META_FILENAME = "IMG_0001__frame.json"
+PNG_FILENAME = "chelsea.png"
 
 
-def test_lytro_lfr_format(image_cache):
+def test_lytro_lfr_format(test_images):
     """
     Test basic read/write properties of LytroLfrFormat
     """
     # Get test images
-    lfr_file = image_cache / LFR_FILENAME
-    raw_illum_file = image_cache / RAW_ILLUM_FILENAME
-    lfp_file = image_cache / LFP_FILENAME
-    raw_f01_file = image_cache / RAW_F0_FILENAME
-    png_file = image_cache / PNG_FILENAME
+    lfr_file = test_images / LFR_FILENAME
+    raw_illum_file = test_images / RAW_ILLUM_FILENAME
+    lfp_file = test_images / LFP_FILENAME
+    raw_f01_file = test_images / RAW_F0_FILENAME
+    png_file = test_images / PNG_FILENAME
 
     # Test lytro lfr format
     format = imageio.formats["lytro-lfr"]
@@ -55,16 +55,16 @@ def test_lytro_lfr_format(image_cache):
     assert not format.can_write(Request(png_file, "wi"))
 
 
-def test_lytro_illum_raw_format(image_cache):
+def test_lytro_illum_raw_format(test_images):
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
-    lfr_file = image_cache / LFR_FILENAME
-    raw_illum_file = image_cache / RAW_ILLUM_FILENAME
-    lfp_file = image_cache / LFP_FILENAME
-    raw_f01_file = image_cache / RAW_F0_FILENAME
-    png_file = image_cache / PNG_FILENAME
+    lfr_file = test_images / LFR_FILENAME
+    raw_illum_file = test_images / RAW_ILLUM_FILENAME
+    lfp_file = test_images / LFP_FILENAME
+    raw_f01_file = test_images / RAW_F0_FILENAME
+    png_file = test_images / PNG_FILENAME
 
     # Test lytro raw format
     format = imageio.formats["lytro-illum-raw"]
@@ -89,16 +89,16 @@ def test_lytro_illum_raw_format(image_cache):
     assert not format.can_write(Request(png_file, "wi"))
 
 
-def test_lytro_f01_raw_format(image_cache):
+def test_lytro_f01_raw_format(test_images):
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
-    lfr_file = image_cache / LFR_FILENAME
-    raw_illum_file = image_cache / RAW_ILLUM_FILENAME
-    lfp_file = image_cache / LFP_FILENAME
-    raw_f01_file = image_cache / RAW_F0_FILENAME
-    png_file = image_cache / PNG_FILENAME
+    lfr_file = test_images / LFR_FILENAME
+    raw_illum_file = test_images / RAW_ILLUM_FILENAME
+    lfp_file = test_images / LFP_FILENAME
+    raw_f01_file = test_images / RAW_F0_FILENAME
+    png_file = test_images / PNG_FILENAME
 
     # Test lytro raw format
     format = imageio.formats["lytro-illum-raw"]
@@ -123,16 +123,16 @@ def test_lytro_f01_raw_format(image_cache):
     assert not format.can_write(Request(png_file, "wi"))
 
 
-def test_lytro_lfp_format(image_cache):
+def test_lytro_lfp_format(test_images):
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
-    lfr_file = image_cache / LFR_FILENAME
-    raw_illum_file = image_cache / RAW_ILLUM_FILENAME
-    lfp_file = image_cache / LFP_FILENAME
-    raw_f01_file = image_cache / RAW_F0_FILENAME
-    png_file = image_cache / PNG_FILENAME
+    lfr_file = test_images / LFR_FILENAME
+    raw_illum_file = test_images / RAW_ILLUM_FILENAME
+    lfp_file = test_images / LFP_FILENAME
+    raw_f01_file = test_images / RAW_F0_FILENAME
+    png_file = test_images / PNG_FILENAME
 
     # Test lytro raw format
     format = imageio.formats["lytro-lfp"]
@@ -158,11 +158,11 @@ def test_lytro_lfp_format(image_cache):
     assert not format.can_write(Request(png_file, "wi"))
 
 
-def test_lytro_lfr_reading(image_cache):
+def test_lytro_lfr_reading(test_images):
     """Test reading of lytro .lfr file"""
     # Get test images
-    lfr_file = image_cache / LFR_FILENAME
-    thumb_file = image_cache / THUMB_FILENAME
+    lfr_file = test_images / LFR_FILENAME
+    thumb_file = test_images / THUMB_FILENAME
 
     # Read image and thumbnail
     img = imageio.imread(lfr_file, format="lytro-lfr")
@@ -445,10 +445,10 @@ def test_lytro_lfr_reading(image_cache):
         test_reader.get_data(3)
 
 
-def test_lytro_lfp_reading(image_cache):
+def test_lytro_lfp_reading(test_images):
     """Test reading of lytro .lfr file"""
     # Get test images
-    lfp_file = image_cache / LFP_FILENAME
+    lfp_file = test_images / LFP_FILENAME
 
     # Read image and thumbnail
     img = imageio.imread(lfp_file, format="lytro-lfp")
@@ -604,11 +604,11 @@ def test_lytro_lfp_reading(image_cache):
         test_reader.get_data(3)
 
 
-def test_lytro_raw_illum_reading(image_cache):
+def test_lytro_raw_illum_reading(test_images):
     """Test reading of lytro .raw file"""
     # Get test images
-    raw_file = image_cache / RAW_ILLUM_FILENAME
-    raw_meta_file = image_cache / RAW_ILLUM_META_FILENAME
+    raw_file = test_images / RAW_ILLUM_FILENAME
+    raw_meta_file = test_images / RAW_ILLUM_META_FILENAME
 
     # Read image and metadata file
     img = imageio.imread(raw_file, format="lytro-illum-raw")
@@ -644,11 +644,11 @@ def test_lytro_raw_illum_reading(image_cache):
         test_reader.get_data(3)
 
 
-def test_lytro_raw_f0_reading(image_cache):
+def test_lytro_raw_f0_reading(test_images):
     """Test reading of lytro .raw file"""
     # Get test images
-    raw_file = image_cache / RAW_F0_FILENAME
-    raw_meta_file = image_cache / RAW_F0_META_FILENAME
+    raw_file = test_images / RAW_F0_FILENAME
+    raw_meta_file = test_images / RAW_F0_META_FILENAME
 
     # Read image and metadata file
     img = imageio.imread(raw_file, format="lytro-f01-raw")

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -443,8 +443,11 @@ def test_lytro_lfr_reading():
 
     # Test fail
     test_reader = imageio.read(lfr_file, "lytro-lfr")
-    pytest.raises(IndexError, test_reader.get_data, -1)
-    pytest.raises(IndexError, test_reader.get_data, 3)
+    with pytest.raises(IndexError):
+        test_reader.get_data(-1)
+        
+    with pytest.raises(IndexError):
+        test_reader.get_data(3)
 
 
 @pytest.mark.needs_internet
@@ -601,8 +604,10 @@ def test_lytro_lfp_reading():
 
     # Test fail
     test_reader = imageio.read(lfp_file, "lytro-lfp")
-    pytest.raises(IndexError, test_reader.get_data, -1)
-    pytest.raises(IndexError, test_reader.get_data, 3)
+    with pytest.raises(IndexError):
+        test_reader.get_data(-1)
+    with pytest.raises(IndexError):
+        test_reader.get_data(3)
 
 
 @pytest.mark.needs_internet
@@ -639,8 +644,11 @@ def test_lytro_raw_illum_reading():
 
     # Test fail
     test_reader = imageio.read(raw_file, "lytro-illum-raw")
-    pytest.raises(IndexError, test_reader.get_data, -1)
-    pytest.raises(IndexError, test_reader.get_data, 3)
+    with pytest.raises(IndexError):
+        test_reader.get_data(-1)
+        
+    with pytest.raises(IndexError):
+        test_reader.get_data(3)
 
 
 @pytest.mark.needs_internet
@@ -677,5 +685,8 @@ def test_lytro_raw_f0_reading():
 
     # Test fail
     test_reader = imageio.read(raw_file, "lytro-f01-raw")
-    pytest.raises(IndexError, test_reader.get_data, -1)
-    pytest.raises(IndexError, test_reader.get_data, 3)
+    with pytest.raises(IndexError):
+        test_reader.get_data(-1)
+        
+    with pytest.raises(IndexError):
+        test_reader.get_data(3)

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 import imageio
-from imageio.core import get_remote_file, Request
+from imageio.core import Request
 
 
 # Set file names for test images in imageio-binaries repo
@@ -20,17 +20,16 @@ RAW_F0_META_FILENAME = "images/IMG_0001__frame.json"
 PNG_FILENAME = "images/chelsea.png"
 
 
-@pytest.mark.needs_internet
-def test_lytro_lfr_format():
+def test_lytro_lfr_format(image_cache):
     """
     Test basic read/write properties of LytroLfrFormat
     """
     # Get test images
-    lfr_file = get_remote_file(LFR_FILENAME)
-    raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
-    lfp_file = get_remote_file(LFP_FILENAME)
-    raw_f01_file = get_remote_file(RAW_F0_FILENAME)
-    png_file = get_remote_file(PNG_FILENAME)
+    lfr_file = image_cache / LFR_FILENAME
+    raw_illum_file = image_cache / RAW_ILLUM_FILENAME
+    lfp_file = image_cache / LFP_FILENAME
+    raw_f01_file = image_cache / RAW_F0_FILENAME
+    png_file = image_cache / PNG_FILENAME
 
     # Test lytro lfr format
     format = imageio.formats["lytro-lfr"]
@@ -56,17 +55,16 @@ def test_lytro_lfr_format():
     assert not format.can_write(Request(png_file, "wi"))
 
 
-@pytest.mark.needs_internet
-def test_lytro_illum_raw_format():
+def test_lytro_illum_raw_format(image_cache):
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
-    lfr_file = get_remote_file(LFR_FILENAME)
-    raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
-    lfp_file = get_remote_file(LFP_FILENAME)
-    raw_f01_file = get_remote_file(RAW_F0_FILENAME)
-    png_file = get_remote_file(PNG_FILENAME)
+    lfr_file = image_cache / LFR_FILENAME
+    raw_illum_file = image_cache / RAW_ILLUM_FILENAME
+    lfp_file = image_cache / LFP_FILENAME
+    raw_f01_file = image_cache / RAW_F0_FILENAME
+    png_file = image_cache / PNG_FILENAME
 
     # Test lytro raw format
     format = imageio.formats["lytro-illum-raw"]
@@ -91,17 +89,16 @@ def test_lytro_illum_raw_format():
     assert not format.can_write(Request(png_file, "wi"))
 
 
-@pytest.mark.needs_internet
-def test_lytro_f01_raw_format():
+def test_lytro_f01_raw_format(image_cache):
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
-    lfr_file = get_remote_file(LFR_FILENAME)
-    raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
-    lfp_file = get_remote_file(LFP_FILENAME)
-    raw_f01_file = get_remote_file(RAW_F0_FILENAME)
-    png_file = get_remote_file(PNG_FILENAME)
+    lfr_file = image_cache / LFR_FILENAME
+    raw_illum_file = image_cache / RAW_ILLUM_FILENAME
+    lfp_file = image_cache / LFP_FILENAME
+    raw_f01_file = image_cache / RAW_F0_FILENAME
+    png_file = image_cache / PNG_FILENAME
 
     # Test lytro raw format
     format = imageio.formats["lytro-illum-raw"]
@@ -126,17 +123,16 @@ def test_lytro_f01_raw_format():
     assert not format.can_write(Request(png_file, "wi"))
 
 
-@pytest.mark.needs_internet
-def test_lytro_lfp_format():
+def test_lytro_lfp_format(image_cache):
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
-    lfr_file = get_remote_file(LFR_FILENAME)
-    raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
-    lfp_file = get_remote_file(LFP_FILENAME)
-    raw_f01_file = get_remote_file(RAW_F0_FILENAME)
-    png_file = get_remote_file(PNG_FILENAME)
+    lfr_file = image_cache / LFR_FILENAME
+    raw_illum_file = image_cache / RAW_ILLUM_FILENAME
+    lfp_file = image_cache / LFP_FILENAME
+    raw_f01_file = image_cache / RAW_F0_FILENAME
+    png_file = image_cache / PNG_FILENAME
 
     # Test lytro raw format
     format = imageio.formats["lytro-lfp"]
@@ -162,12 +158,11 @@ def test_lytro_lfp_format():
     assert not format.can_write(Request(png_file, "wi"))
 
 
-@pytest.mark.needs_internet
-def test_lytro_lfr_reading():
+def test_lytro_lfr_reading(image_cache):
     """Test reading of lytro .lfr file"""
     # Get test images
-    lfr_file = get_remote_file(LFR_FILENAME)
-    thumb_file = get_remote_file(THUMB_FILENAME)
+    lfr_file = image_cache / LFR_FILENAME
+    thumb_file = image_cache / THUMB_FILENAME
 
     # Read image and thumbnail
     img = imageio.imread(lfr_file, format="lytro-lfr")
@@ -450,11 +445,10 @@ def test_lytro_lfr_reading():
         test_reader.get_data(3)
 
 
-@pytest.mark.needs_internet
-def test_lytro_lfp_reading():
+def test_lytro_lfp_reading(image_cache):
     """Test reading of lytro .lfr file"""
     # Get test images
-    lfp_file = get_remote_file(LFP_FILENAME)
+    lfp_file = image_cache / LFP_FILENAME
 
     # Read image and thumbnail
     img = imageio.imread(lfp_file, format="lytro-lfp")
@@ -610,12 +604,11 @@ def test_lytro_lfp_reading():
         test_reader.get_data(3)
 
 
-@pytest.mark.needs_internet
-def test_lytro_raw_illum_reading():
+def test_lytro_raw_illum_reading(image_cache):
     """Test reading of lytro .raw file"""
     # Get test images
-    raw_file = get_remote_file(RAW_ILLUM_FILENAME)
-    raw_meta_file = get_remote_file(RAW_ILLUM_META_FILENAME)
+    raw_file = image_cache / RAW_ILLUM_FILENAME
+    raw_meta_file = image_cache / RAW_ILLUM_META_FILENAME
 
     # Read image and metadata file
     img = imageio.imread(raw_file, format="lytro-illum-raw")
@@ -651,12 +644,11 @@ def test_lytro_raw_illum_reading():
         test_reader.get_data(3)
 
 
-@pytest.mark.needs_internet
-def test_lytro_raw_f0_reading():
+def test_lytro_raw_f0_reading(image_cache):
     """Test reading of lytro .raw file"""
     # Get test images
-    raw_file = get_remote_file(RAW_F0_FILENAME)
-    raw_meta_file = get_remote_file(RAW_F0_META_FILENAME)
+    raw_file = image_cache / RAW_F0_FILENAME
+    raw_meta_file = image_cache / RAW_F0_META_FILENAME
 
     # Read image and metadata file
     img = imageio.imread(raw_file, format="lytro-f01-raw")

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -356,9 +356,7 @@ def test_lytro_lfr_reading():
                 "meter": {
                     "mode": "evaluative",
                     "roiMode": "af",
-                    "roi": [
-                        {"top": 0.0, "left": 0.0, "bottom": 1.0, "right": 1.0}
-                    ],
+                    "roi": [{"top": 0.0, "left": 0.0, "bottom": 1.0, "right": 1.0}],
                 },
                 "bracketEnable": False,
                 "bracketStep": 1.0,

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -445,7 +445,7 @@ def test_lytro_lfr_reading():
     test_reader = imageio.read(lfr_file, "lytro-lfr")
     with pytest.raises(IndexError):
         test_reader.get_data(-1)
-        
+
     with pytest.raises(IndexError):
         test_reader.get_data(3)
 
@@ -646,7 +646,7 @@ def test_lytro_raw_illum_reading():
     test_reader = imageio.read(raw_file, "lytro-illum-raw")
     with pytest.raises(IndexError):
         test_reader.get_data(-1)
-        
+
     with pytest.raises(IndexError):
         test_reader.get_data(3)
 
@@ -687,6 +687,6 @@ def test_lytro_raw_f0_reading():
     test_reader = imageio.read(raw_file, "lytro-f01-raw")
     with pytest.raises(IndexError):
         test_reader.get_data(-1)
-        
+
     with pytest.raises(IndexError):
         test_reader.get_data(3)

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -3,9 +3,8 @@
 from __future__ import division
 import numpy as np
 import json
+import pytest
 
-from pytest import raises
-from imageio.testing import run_tests_if_main, need_internet
 import imageio
 from imageio.core import get_remote_file, Request
 
@@ -21,12 +20,12 @@ RAW_F0_META_FILENAME = "images/IMG_0001__frame.json"
 PNG_FILENAME = "images/chelsea.png"
 
 
+@pytest.mark.needs_internet
 def test_lytro_lfr_format():
     """
     Test basic read/write properties of LytroLfrFormat
     """
     # Get test images
-    need_internet()
     lfr_file = get_remote_file(LFR_FILENAME)
     raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
     lfp_file = get_remote_file(LFP_FILENAME)
@@ -57,12 +56,12 @@ def test_lytro_lfr_format():
     assert not format.can_write(Request(png_file, "wi"))
 
 
+@pytest.mark.needs_internet
 def test_lytro_illum_raw_format():
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
-    need_internet()
     lfr_file = get_remote_file(LFR_FILENAME)
     raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
     lfp_file = get_remote_file(LFP_FILENAME)
@@ -92,12 +91,12 @@ def test_lytro_illum_raw_format():
     assert not format.can_write(Request(png_file, "wi"))
 
 
+@pytest.mark.needs_internet
 def test_lytro_f01_raw_format():
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
-    need_internet()
     lfr_file = get_remote_file(LFR_FILENAME)
     raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
     lfp_file = get_remote_file(LFP_FILENAME)
@@ -127,12 +126,12 @@ def test_lytro_f01_raw_format():
     assert not format.can_write(Request(png_file, "wi"))
 
 
+@pytest.mark.needs_internet
 def test_lytro_lfp_format():
     """
     Test basic read/write properties of LytroRawFormat
     """
     # Get test images
-    need_internet()
     lfr_file = get_remote_file(LFR_FILENAME)
     raw_illum_file = get_remote_file(RAW_ILLUM_FILENAME)
     lfp_file = get_remote_file(LFP_FILENAME)
@@ -163,10 +162,10 @@ def test_lytro_lfp_format():
     assert not format.can_write(Request(png_file, "wi"))
 
 
+@pytest.mark.needs_internet
 def test_lytro_lfr_reading():
     """Test reading of lytro .lfr file"""
     # Get test images
-    need_internet()
     lfr_file = get_remote_file(LFR_FILENAME)
     thumb_file = get_remote_file(THUMB_FILENAME)
 
@@ -230,9 +229,16 @@ def test_lytro_lfr_reading():
         "generator": "lightning",
         "schema": "http://schema.lytro.com/lfp/lytro_illum_public/"
         + "1.3.5/lytro_illum_public_schema.json",
-        "camera": {"make": "Lytro, Inc.", "model": "ILLUM", "firmware": "1.1.1 (23)"},
+        "camera": {
+            "make": "Lytro, Inc.",
+            "model": "ILLUM",
+            "firmware": "1.1.1 (23)",
+        },
         "devices": {
-            "clock": {"zuluTime": "2015-05-17T13:31:37.412Z", "isTimeValid": True},
+            "clock": {
+                "zuluTime": "2015-05-17T13:31:37.412Z",
+                "isTimeValid": True,
+            },
             "sensor": {
                 "pixelPitch": 1.4e-06,
                 "normalizedResponses": [
@@ -350,7 +356,9 @@ def test_lytro_lfr_reading():
                 "meter": {
                     "mode": "evaluative",
                     "roiMode": "af",
-                    "roi": [{"top": 0.0, "left": 0.0, "bottom": 1.0, "right": 1.0}],
+                    "roi": [
+                        {"top": 0.0, "left": 0.0, "bottom": 1.0, "right": 1.0}
+                    ],
                 },
                 "bracketEnable": False,
                 "bracketStep": 1.0,
@@ -437,14 +445,14 @@ def test_lytro_lfr_reading():
 
     # Test fail
     test_reader = imageio.read(lfr_file, "lytro-lfr")
-    raises(IndexError, test_reader.get_data, -1)
-    raises(IndexError, test_reader.get_data, 3)
+    pytest.raises(IndexError, test_reader.get_data, -1)
+    pytest.raises(IndexError, test_reader.get_data, 3)
 
 
+@pytest.mark.needs_internet
 def test_lytro_lfp_reading():
     """Test reading of lytro .lfr file"""
     # Get test images
-    need_internet()
     lfp_file = get_remote_file(LFP_FILENAME)
 
     # Read image and thumbnail
@@ -553,8 +561,16 @@ def test_lytro_lfp_reading():
         "modes": {
             "creative": "tap",
             "regionOfInterestArray": [
-                {"type": "exposure", "x": 0.5125047564506531, "y": 0.723964273929596},
-                {"type": "creative", "x": 0.5125047564506531, "y": 0.723964273929596},
+                {
+                    "type": "exposure",
+                    "x": 0.5125047564506531,
+                    "y": 0.723964273929596,
+                },
+                {
+                    "type": "creative",
+                    "x": 0.5125047564506531,
+                    "y": 0.723964273929596,
+                },
             ],
             "manualControls": False,
             "exposureDurationMode": "auto",
@@ -587,14 +603,14 @@ def test_lytro_lfp_reading():
 
     # Test fail
     test_reader = imageio.read(lfp_file, "lytro-lfp")
-    raises(IndexError, test_reader.get_data, -1)
-    raises(IndexError, test_reader.get_data, 3)
+    pytest.raises(IndexError, test_reader.get_data, -1)
+    pytest.raises(IndexError, test_reader.get_data, 3)
 
 
+@pytest.mark.needs_internet
 def test_lytro_raw_illum_reading():
     """Test reading of lytro .raw file"""
     # Get test images
-    need_internet()
     raw_file = get_remote_file(RAW_ILLUM_FILENAME)
     raw_meta_file = get_remote_file(RAW_ILLUM_META_FILENAME)
 
@@ -625,14 +641,14 @@ def test_lytro_raw_illum_reading():
 
     # Test fail
     test_reader = imageio.read(raw_file, "lytro-illum-raw")
-    raises(IndexError, test_reader.get_data, -1)
-    raises(IndexError, test_reader.get_data, 3)
+    pytest.raises(IndexError, test_reader.get_data, -1)
+    pytest.raises(IndexError, test_reader.get_data, 3)
 
 
+@pytest.mark.needs_internet
 def test_lytro_raw_f0_reading():
     """Test reading of lytro .raw file"""
     # Get test images
-    need_internet()
     raw_file = get_remote_file(RAW_F0_FILENAME)
     raw_meta_file = get_remote_file(RAW_F0_META_FILENAME)
 
@@ -663,8 +679,5 @@ def test_lytro_raw_f0_reading():
 
     # Test fail
     test_reader = imageio.read(raw_file, "lytro-f01-raw")
-    raises(IndexError, test_reader.get_data, -1)
-    raises(IndexError, test_reader.get_data, 3)
-
-
-run_tests_if_main()
+    pytest.raises(IndexError, test_reader.get_data, -1)
+    pytest.raises(IndexError, test_reader.get_data, 3)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -8,7 +8,6 @@ import sys
 import subprocess
 
 from pytest import raises  # noqa
-from imageio.testing import run_tests_if_main
 
 import imageio
 
@@ -102,6 +101,3 @@ def test_import_modules():
     # Test that modules that should not be imported are indeed not imported
     assert "imageio.freeze" not in modnames
     assert "imageio.testing" not in modnames
-
-
-run_tests_if_main()

--- a/tests/test_npz.py
+++ b/tests/test_npz.py
@@ -2,18 +2,17 @@
 """
 
 import os
+import pytest
 
 import numpy as np
 
 from pytest import raises
-from imageio.testing import run_tests_if_main, get_test_dir
 
 import imageio
 from imageio.core import get_remote_file, Request, IS_PYPY
 
-test_dir = get_test_dir()
 
-
+@pytest.mark.needs_internet
 def test_npz_format():
 
     # Test selection
@@ -28,7 +27,7 @@ def test_npz_format():
     assert not format.can_write(Request(png, "wi"))
 
 
-def test_npz_reading_writing():
+def test_npz_reading_writing(test_dir):
     """Test reading and saveing npz"""
 
     if IS_PYPY:
@@ -81,6 +80,3 @@ def test_npz_reading_writing():
     raises(IndexError, R.get_data, 3)
     raises(RuntimeError, R.get_meta_data, None)  # no meta data support
     raises(RuntimeError, R.get_meta_data, 0)  # no meta data support
-
-
-run_tests_if_main()

--- a/tests/test_npz.py
+++ b/tests/test_npz.py
@@ -37,7 +37,7 @@ def test_npz_reading_writing(tmp_path):
     im3 = np.ones((10, 10, 10), np.uint8) * 3
     im4 = np.ones((10, 10, 10, 10), np.uint8) * 4
 
-    filename1 = os.path.join(tmp_path, "test_npz.npz")
+    filename1 = tmp_path / "test_npz.npz"
 
     # One image
     imageio.imsave(filename1, im2)

--- a/tests/test_npz.py
+++ b/tests/test_npz.py
@@ -8,11 +8,10 @@ import numpy as np
 from pytest import raises
 
 import imageio
-from imageio.core import get_remote_file, Request, IS_PYPY
+from imageio.core import Request, IS_PYPY
 
 
-@pytest.mark.needs_internet
-def test_npz_format():
+def test_npz_format(image_cache):
 
     # Test selection
     for name in ["npz", ".npz"]:
@@ -21,7 +20,7 @@ def test_npz_format():
         assert format.__module__.endswith(".npz")
 
     # Test cannot read
-    png = get_remote_file("images/chelsea.png")
+    png = image_cache / "test-images" / "chelsea.png"
     assert not format.can_read(Request(png, "ri"))
     assert not format.can_write(Request(png, "wi"))
 

--- a/tests/test_npz.py
+++ b/tests/test_npz.py
@@ -1,7 +1,6 @@
 """ Test npz plugin functionality.
 """
 
-import os
 import pytest
 
 import numpy as np

--- a/tests/test_npz.py
+++ b/tests/test_npz.py
@@ -9,7 +9,7 @@ import imageio
 from imageio.core import Request, IS_PYPY
 
 
-def test_npz_format(image_cache):
+def test_npz_format(test_images):
 
     # Test selection
     for name in ["npz", ".npz"]:
@@ -18,7 +18,7 @@ def test_npz_format(image_cache):
         assert format.__module__.endswith(".npz")
 
     # Test cannot read
-    png = image_cache / "test-images" / "chelsea.png"
+    png = test_images / "chelsea.png"
     assert not format.can_read(Request(png, "ri"))
     assert not format.can_write(Request(png, "wi"))
 

--- a/tests/test_npz.py
+++ b/tests/test_npz.py
@@ -27,7 +27,7 @@ def test_npz_format():
     assert not format.can_write(Request(png, "wi"))
 
 
-def test_npz_reading_writing(test_dir):
+def test_npz_reading_writing(tmp_path):
     """Test reading and saveing npz"""
 
     if IS_PYPY:
@@ -37,7 +37,7 @@ def test_npz_reading_writing(test_dir):
     im3 = np.ones((10, 10, 10), np.uint8) * 3
     im4 = np.ones((10, 10, 10, 10), np.uint8) * 4
 
-    filename1 = os.path.join(test_dir, "test_npz.npz")
+    filename1 = os.path.join(tmp_path, "test_npz.npz")
 
     # One image
     imageio.imsave(filename1, im2)

--- a/tests/test_npz.py
+++ b/tests/test_npz.py
@@ -5,8 +5,6 @@ import pytest
 
 import numpy as np
 
-from pytest import raises
-
 import imageio
 from imageio.core import Request, IS_PYPY
 
@@ -64,7 +62,7 @@ def test_npz_reading_writing(tmp_path):
     W.append_data(im2)
     W.append_data(im3)
     W.append_data(im4)
-    raises(RuntimeError, W.set_meta_data, {})  # no meta data support
+    pytest.raises(RuntimeError, W.set_meta_data, {})  # no meta data support
     W.close()
     #
     R = imageio.read(filename1)
@@ -74,7 +72,7 @@ def test_npz_reading_writing(tmp_path):
     assert (ims[1] == im3).all()
     assert (ims[2] == im4).all()
     # Fail
-    raises(IndexError, R.get_data, -1)
-    raises(IndexError, R.get_data, 3)
-    raises(RuntimeError, R.get_meta_data, None)  # no meta data support
-    raises(RuntimeError, R.get_meta_data, 0)  # no meta data support
+    pytest.raises(IndexError, R.get_data, -1)
+    pytest.raises(IndexError, R.get_data, 3)
+    pytest.raises(RuntimeError, R.get_meta_data, None)  # no meta data support
+    pytest.raises(RuntimeError, R.get_meta_data, 0)  # no meta data support

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -24,9 +24,7 @@ from imageio.core.request import InitializationError
     ],
 )
 @pytest.mark.needs_internet
-def test_write_single_frame(
-    image_files: Path, im_npy: str, im_out: str, im_comp: str
-):
+def test_write_single_frame(image_files: Path, im_npy: str, im_out: str, im_comp: str):
     # the base image as numpy array
     im = np.load(image_files / im_npy)
     # written with imageio
@@ -54,9 +52,7 @@ def test_write_single_frame(
     ],
 )
 @pytest.mark.needs_internet
-def test_write_multiframe(
-    image_files: Path, im_npy: str, im_out: str, im_comp: str
-):
+def test_write_multiframe(image_files: Path, im_npy: str, im_out: str, im_comp: str):
     # the base image as numpy array
     im = np.load(image_files / im_npy)
     # written with imageio
@@ -217,9 +213,7 @@ def test_png_gamma_correction(image_files: Path):
         im1 = f.read()
         im1_meta = f.get_meta()
 
-    im2 = iio.v3.imread(
-        image_files / "kodim03.png", plugin="pillow", apply_gamma=True
-    )
+    im2 = iio.v3.imread(image_files / "kodim03.png", plugin="pillow", apply_gamma=True)
 
     # Test result depending of application of gamma
     assert im1_meta["gamma"] < 1
@@ -301,9 +295,7 @@ def test_gif_rgb_vs_rgba(image_files: Path):
 @pytest.mark.needs_internet
 def test_gif_gray(image_files: Path):
     # Note: There was no assert here; we test that it doesn't crash?
-    im = iio.v3.imread(
-        image_files / "newtonscradle.gif", plugin="pillow", mode="L"
-    )
+    im = iio.v3.imread(image_files / "newtonscradle.gif", plugin="pillow", mode="L")
 
     iio.v3.imwrite(
         image_files / "test.gif",
@@ -316,9 +308,7 @@ def test_gif_gray(image_files: Path):
 
 @pytest.mark.needs_internet
 def test_gif_irregular_duration(image_files: Path):
-    im = iio.v3.imread(
-        image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA"
-    )
+    im = iio.v3.imread(image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA")
     duration = [0.5 if idx in [2, 5, 7] else 0.1 for idx in range(im.shape[0])]
 
     with iio.imopen(image_files / "test.gif", "w", plugin="pillow") as file:
@@ -330,13 +320,9 @@ def test_gif_irregular_duration(image_files: Path):
 
 @pytest.mark.needs_internet
 def test_gif_palletsize(image_files: Path):
-    im = iio.v3.imread(
-        image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA"
-    )
+    im = iio.v3.imread(image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA")
 
-    iio.v3.imwrite(
-        image_files / "test.gif", im, plugin="pillow", palletsize=100
-    )
+    iio.v3.imwrite(image_files / "test.gif", im, plugin="pillow", palletsize=100)
     # TODO: assert pallet size is 128
 
 
@@ -345,9 +331,7 @@ def test_gif_loop_and_fps(image_files: Path):
     # Note: I think this test tests pillow kwargs, not imageio functionality
     # maybe we should drop it?
 
-    im = iio.v3.imread(
-        image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA"
-    )
+    im = iio.v3.imread(image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA")
 
     with iio.imopen(image_files / "test.gif", "w", plugin="pillow") as file:
         for frame in im:
@@ -361,9 +345,7 @@ def test_gif_indexed_read(image_files: Path):
     idx = 0
     numpy_im = np.load(image_files / "newtonscradle_rgb.npy")[idx, ...]
 
-    with iio.imopen(
-        image_files / "newtonscradle.gif", "r", plugin="pillow"
-    ) as file:
+    with iio.imopen(image_files / "newtonscradle.gif", "r", plugin="pillow") as file:
         # exists to touch branch, would be better two write an explicit test
         meta = file.get_meta(index=idx)
         assert "version" in meta
@@ -376,9 +358,7 @@ def test_gif_indexed_read(image_files: Path):
 @pytest.mark.needs_internet
 def test_unknown_image(image_files: Path):
     with open(image_files / "foo.unknown", "w") as file:
-        file.write(
-            "This image, which is actually no image, has an unknown image type."
-        )
+        file.write("This image, which is actually no image, has an unknown image type.")
 
     with pytest.raises(InitializationError):
         r = Request(image_files / "foo.unknown", "r")
@@ -473,9 +453,7 @@ def test_legacy_exif_orientation(image_files: Path):
 
 def test_incomatible_write_format(tmp_path):
     with pytest.raises(IOError):
-        iio.v3.imopen(
-            tmp_path / "foo.mp3", "w", plugin="pillow", legacy_mode=False
-        )
+        iio.v3.imopen(tmp_path / "foo.mp3", "w", plugin="pillow", legacy_mode=False)
 
 
 def test_write_to_bytes():
@@ -504,9 +482,7 @@ def test_write_to_bytes_rgba():
 
     # writing to bytes with imageIO
     with io.BytesIO() as output:
-        iio.v3.imwrite(
-            output, image, plugin="pillow", format="PNG", mode="RGBA"
-        )
+        iio.v3.imwrite(output, image, plugin="pillow", format="PNG", mode="RGBA")
         iio_contents = output.getvalue()
 
     assert iio_contents == contents
@@ -521,9 +497,7 @@ def test_write_to_bytes_imwrite():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite(
-        "<bytes>", image, plugin="pillow", format="PNG"
-    )
+    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format="PNG")
 
     assert contents == bytes_string
 
@@ -537,9 +511,7 @@ def test_write_to_bytes_jpg():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite(
-        "<bytes>", image, plugin="pillow", format="JPEG"
-    )
+    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format="JPEG")
 
     assert contents == bytes_string
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -357,9 +357,7 @@ def test_gif_loop_and_fps(image_cache, tmp_path):
 
 def test_gif_indexed_read(image_cache):
     idx = 0
-    numpy_im = np.load(image_cache / "test-images" / "newtonscradle_rgb.npy")[
-        idx, ...
-    ]
+    numpy_im = np.load(image_cache / "test-images" / "newtonscradle_rgb.npy")[idx, ...]
 
     with iio.imopen(
         image_cache / "test-images" / "newtonscradle.gif", "r", plugin="pillow"
@@ -375,9 +373,7 @@ def test_gif_indexed_read(image_cache):
 
 def test_unknown_image(tmp_path):
     with open(tmp_path / "foo.unknown", "w") as file:
-        file.write(
-            "This image, which is actually no image, has an unknown image type."
-        )
+        file.write("This image, which is actually no image, has an unknown image type.")
 
     with pytest.raises(InitializationError):
         r = Request(tmp_path / "foo.unknown", "r")
@@ -469,9 +465,7 @@ def test_legacy_exif_orientation(image_cache, tmp_path):
 
 def test_incomatible_write_format(tmp_path):
     with pytest.raises(IOError):
-        iio.v3.imopen(
-            tmp_path / "foo.mp3", "w", plugin="pillow", legacy_mode=False
-        )
+        iio.v3.imopen(tmp_path / "foo.mp3", "w", plugin="pillow", legacy_mode=False)
 
 
 def test_write_to_bytes():
@@ -500,9 +494,7 @@ def test_write_to_bytes_rgba():
 
     # writing to bytes with imageIO
     with io.BytesIO() as output:
-        iio.v3.imwrite(
-            output, image, plugin="pillow", format="PNG", mode="RGBA"
-        )
+        iio.v3.imwrite(output, image, plugin="pillow", format="PNG", mode="RGBA")
         iio_contents = output.getvalue()
 
     assert iio_contents == contents
@@ -517,9 +509,7 @@ def test_write_to_bytes_imwrite():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite(
-        "<bytes>", image, plugin="pillow", format="PNG"
-    )
+    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format="PNG")
 
     assert contents == bytes_string
 
@@ -533,9 +523,7 @@ def test_write_to_bytes_jpg():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite(
-        "<bytes>", image, plugin="pillow", format="JPEG"
-    )
+    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format="JPEG")
 
     assert contents == bytes_string
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -6,7 +6,6 @@ import os
 import io
 import pytest
 import numpy as np
-from pathlib import Path
 from PIL import Image, ImageSequence
 
 import imageio as iio

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -22,10 +22,10 @@ from imageio.core.request import InitializationError
         ("chelsea.npy", "iio.bmp", "pil.bmp"),
     ],
 )
-def test_write_single_frame(image_cache, tmp_path, im_npy, im_out, im_comp):
+def test_write_single_frame(test_images, tmp_path, im_npy, im_out, im_comp):
 
     # the base image as numpy array
-    im = np.load(image_cache / "test-images" / im_npy)
+    im = np.load(test_images / im_npy)
     # written with imageio
     iio_file = tmp_path / im_out
     iio.v3.imwrite(iio_file, im, plugin="pillow")
@@ -51,10 +51,10 @@ def test_write_single_frame(image_cache, tmp_path, im_npy, im_out, im_comp):
     ],
 )
 @pytest.mark.needs_internet
-def test_write_multiframe(image_cache, tmp_path, im_npy, im_out, im_comp):
+def test_write_multiframe(test_images, tmp_path, im_npy, im_out, im_comp):
 
     # the base image as numpy array
-    im = np.load(image_cache / "test-images" / im_npy)
+    im = np.load(test_images / im_npy)
     # written with imageio
     iio_file = tmp_path / im_out
     iio.v3.imwrite(iio_file, im, plugin="pillow")
@@ -81,8 +81,8 @@ def test_write_multiframe(image_cache, tmp_path, im_npy, im_out, im_comp):
         ("newtonscradle.gif", "RGBA"),
     ],
 )
-def test_read(image_cache, im_in, mode):
-    im_path = image_cache / "test-images" / im_in
+def test_read(test_images, im_in, mode):
+    im_path = test_images / im_in
     iio_im = iio.v3.imread(im_path, plugin="pillow", mode=mode)
 
     pil_im = np.asarray(
@@ -104,7 +104,7 @@ def test_read(image_cache, im_in, mode):
         ("newtonscradle.gif", "RGBA"),
     ],
 )
-def test_gif_legacy_pillow(image_cache, im_in, mode):
+def test_gif_legacy_pillow(test_images, im_in, mode):
     """
     This test tests backwards compatibility of using the new API
     with a legacy plugin. IN particular reading ndimages
@@ -112,7 +112,7 @@ def test_gif_legacy_pillow(image_cache, im_in, mode):
     I'm not sure where this test should live, so it is here for now.
     """
 
-    im_path = image_cache / "test-images" / im_in
+    im_path = test_images / im_in
     with iio.imopen(im_path, "r", legacy_mode=True, plugin="GIF-PIL") as file:
         iio_im = file.read(pilmode=mode)
 
@@ -128,10 +128,10 @@ def test_gif_legacy_pillow(image_cache, im_in, mode):
     assert np.allclose(iio_im, pil_im)
 
 
-def test_png_compression(image_cache, tmp_path):
+def test_png_compression(test_images, tmp_path):
     # Note: Note sure if we should test this or pillow
 
-    im = np.load(image_cache / "test-images" / "chelsea.npy")
+    im = np.load(test_images / "chelsea.npy")
 
     iio.v3.imwrite(tmp_path / "1.png", im, plugin="pillow", compress_level=0)
     iio.v3.imwrite(tmp_path / "2.png", im, plugin="pillow", compress_level=9)
@@ -141,10 +141,10 @@ def test_png_compression(image_cache, tmp_path):
     assert size_2 < size_1
 
 
-def test_png_quantization(image_cache, tmp_path):
+def test_png_quantization(test_images, tmp_path):
     # Note: Note sure if we should test this or pillow
 
-    im = np.load(image_cache / "test-images" / "chelsea.npy")
+    im = np.load(test_images / "chelsea.npy")
 
     iio.v3.imwrite(tmp_path / "1.png", im, plugin="pillow", bits=8)
     iio.v3.imwrite(tmp_path / "2.png", im, plugin="pillow", bits=2)
@@ -154,9 +154,9 @@ def test_png_quantization(image_cache, tmp_path):
     assert size_2 < size_1
 
 
-def test_png_16bit(image_cache, tmp_path):
+def test_png_16bit(test_images, tmp_path):
     # 16b bit images
-    im = np.load(image_cache / "test-images" / "chelsea.npy")[..., 0]
+    im = np.load(test_images / "chelsea.npy")[..., 0]
 
     iio.v3.imwrite(
         tmp_path / "1.png",
@@ -193,25 +193,23 @@ def test_png_remote():
     assert im.shape == (300, 451, 3)
 
 
-def test_png_transparent_pixel(image_cache):
+def test_png_transparent_pixel(test_images):
     # see issue #245
     im = iio.v3.imread(
-        image_cache / "test-images" / "imageio_issue246.png",
+        test_images / "imageio_issue246.png",
         plugin="pillow",
         mode="RGBA",
     )
     assert im.shape == (24, 30, 4)
 
 
-def test_png_gamma_correction(image_cache):
-    with iio.imopen(
-        image_cache / "test-images" / "kodim03.png", "r", plugin="pillow"
-    ) as f:
+def test_png_gamma_correction(test_images):
+    with iio.imopen(test_images / "kodim03.png", "r", plugin="pillow") as f:
         im1 = f.read()
         im1_meta = f.get_meta()
 
     im2 = iio.v3.imread(
-        image_cache / "test-images" / "kodim03.png",
+        test_images / "kodim03.png",
         plugin="pillow",
         apply_gamma=True,
     )
@@ -226,10 +224,10 @@ def test_png_gamma_correction(image_cache):
     assert im2.dtype == "uint8"
 
 
-def test_jpg_compression(image_cache, tmp_path):
+def test_jpg_compression(test_images, tmp_path):
     # Note: Note sure if we should test this or pillow
 
-    im = np.load(image_cache / "test-images" / "chelsea.npy")
+    im = np.load(test_images / "chelsea.npy")
 
     iio.v3.imwrite(tmp_path / "1.jpg", im, plugin="pillow", quality=90)
     iio.v3.imwrite(tmp_path / "2.jpg", im, plugin="pillow", quality=10)
@@ -239,10 +237,10 @@ def test_jpg_compression(image_cache, tmp_path):
     assert size_2 < size_1
 
 
-def test_exif_orientation(image_cache, tmp_path):
+def test_exif_orientation(test_images, tmp_path):
     from PIL.Image import Exif
 
-    im = np.load(image_cache / "test-images" / "chelsea.npy")
+    im = np.load(test_images / "chelsea.npy")
 
     # original image is has landscape format
     assert im.shape[0] < im.shape[1]
@@ -278,15 +276,15 @@ def test_exif_orientation(image_cache, tmp_path):
     assert np.array_equal(im, im_reloaded)
 
 
-def test_gif_rgb_vs_rgba(image_cache):
+def test_gif_rgb_vs_rgba(test_images):
     # Note: I don't understand the point of this test
     im_rgb = iio.v3.imread(
-        image_cache / "test-images" / "newtonscradle.gif",
+        test_images / "newtonscradle.gif",
         plugin="pillow",
         mode="RGB",
     )
     im_rgba = iio.v3.imread(
-        image_cache / "test-images" / "newtonscradle.gif",
+        test_images / "newtonscradle.gif",
         plugin="pillow",
         mode="RGBA",
     )
@@ -294,10 +292,10 @@ def test_gif_rgb_vs_rgba(image_cache):
     assert np.allclose(im_rgb, im_rgba[..., :3])
 
 
-def test_gif_gray(image_cache, tmp_path):
+def test_gif_gray(test_images, tmp_path):
     # Note: There was no assert here; we test that it doesn't crash?
     im = iio.v3.imread(
-        image_cache / "test-images" / "newtonscradle.gif",
+        test_images / "newtonscradle.gif",
         plugin="pillow",
         mode="L",
     )
@@ -311,9 +309,9 @@ def test_gif_gray(image_cache, tmp_path):
     )
 
 
-def test_gif_irregular_duration(image_cache, tmp_path):
+def test_gif_irregular_duration(test_images, tmp_path):
     im = iio.v3.imread(
-        image_cache / "test-images" / "newtonscradle.gif",
+        test_images / "newtonscradle.gif",
         plugin="pillow",
         mode="RGBA",
     )
@@ -326,9 +324,9 @@ def test_gif_irregular_duration(image_cache, tmp_path):
     # how to assert duration here
 
 
-def test_gif_palletsize(image_cache, tmp_path):
+def test_gif_palletsize(test_images, tmp_path):
     im = iio.v3.imread(
-        image_cache / "test-images" / "newtonscradle.gif",
+        test_images / "newtonscradle.gif",
         plugin="pillow",
         mode="RGBA",
     )
@@ -337,12 +335,12 @@ def test_gif_palletsize(image_cache, tmp_path):
     # TODO: assert pallet size is 128
 
 
-def test_gif_loop_and_fps(image_cache, tmp_path):
+def test_gif_loop_and_fps(test_images, tmp_path):
     # Note: I think this test tests pillow kwargs, not imageio functionality
     # maybe we should drop it?
 
     im = iio.v3.imread(
-        image_cache / "test-images" / "newtonscradle.gif",
+        test_images / "newtonscradle.gif",
         plugin="pillow",
         mode="RGBA",
     )
@@ -354,13 +352,11 @@ def test_gif_loop_and_fps(image_cache, tmp_path):
     # This test had no assert; how to assert fps and loop count?
 
 
-def test_gif_indexed_read(image_cache):
+def test_gif_indexed_read(test_images):
     idx = 0
-    numpy_im = np.load(image_cache / "test-images" / "newtonscradle_rgb.npy")[idx, ...]
+    numpy_im = np.load(test_images / "newtonscradle_rgb.npy")[idx, ...]
 
-    with iio.imopen(
-        image_cache / "test-images" / "newtonscradle.gif", "r", plugin="pillow"
-    ) as file:
+    with iio.imopen(test_images / "newtonscradle.gif", "r", plugin="pillow") as file:
         # exists to touch branch, would be better two write an explicit test
         meta = file.get_meta(index=idx)
         assert "version" in meta
@@ -382,10 +378,10 @@ def test_unknown_image(tmp_path):
 # TODO: introduce new plugin for writing compressed GIF
 # This is not what pillow does, and hence unexpected when explicitly calling
 # for pillow
-# def test_gif_subrectangles(image_cache, tmp_path):
+# def test_gif_subrectangles(test_images, tmp_path):
 #     # feature might be made obsolete by upstream (pillow) supporting it natively
 #     # related issues: https://github.com/python-pillow/Pillow/issues/4977
-#     im = iio.v3.imread(image_cache / "test-images" / "newtonscradle.gif", legacy_api=False, plugin="pillow", mode="RGBA")
+#     im = iio.v3.imread(test_images / "newtonscradle.gif", legacy_api=False, plugin="pillow", mode="RGBA")
 #     im = np.stack((*im, im[-1]), axis=0)
 #     print(im.dtype)
 
@@ -400,10 +396,10 @@ def test_unknown_image(tmp_path):
 #     assert size_2 < size_1
 
 
-def test_gif_transparent_pixel(image_cache):
+def test_gif_transparent_pixel(test_images):
     # see issue #245
     im = iio.v3.imread(
-        image_cache / "images" / "imageio_issue245.gif",
+        test_images / "imageio_issue245.gif",
         plugin="pillow",
         mode="RGBA",
     )
@@ -411,21 +407,21 @@ def test_gif_transparent_pixel(image_cache):
 
 
 # TODO: Pillow actually doesn't read zip. This should be a different plugin.
-# def test_inside_zipfile(image_cache):
+# def test_inside_zipfile(test_images):
 
 #     fname = os.path.join(tmp_path, "pillowtest.zip")
 #     with ZipFile(fname, "w") as z:
-#         z.writestr("x.png", open(image_cache / "test-images" / "chelsea.png", "rb").read())
-#         z.writestr("x.jpg", open(image_cache / "images" / "rommel.jpg", "rb").read())
+#         z.writestr("x.png", open(test_images / "chelsea.png", "rb").read())
+#         z.writestr("x.jpg", open(test_images / "rommel.jpg", "rb").read())
 
 #     for name in ("x.png", "x.jpg"):
 #         imageio.imread(fname + "/" + name)
 
 
-def test_legacy_exif_orientation(image_cache, tmp_path):
+def test_legacy_exif_orientation(test_images, tmp_path):
     from PIL.Image import Exif
 
-    im = np.load(image_cache / "test-images" / "chelsea.npy")
+    im = np.load(test_images / "chelsea.npy")
 
     # original image is has landscape format
     assert im.shape[0] < im.shape[1]
@@ -540,7 +536,7 @@ def test_write_jpg_to_bytes_io():
     assert np.allclose(image_from_file, image)
 
 
-def test_initialization_failure(image_cache):
+def test_initialization_failure(test_images):
     test_image = b"this is not an image and will break things."
 
     with pytest.raises(OSError):
@@ -548,7 +544,7 @@ def test_initialization_failure(image_cache):
 
     with pytest.raises(OSError):
         # pillow can not handle npy
-        iio.v3.imread(image_cache / "test-images" / "chelsea_jpg.npy", plugin="pillow")
+        iio.v3.imread(test_images / "chelsea_jpg.npy", plugin="pillow")
 
 
 def test_boolean_reading(tmp_path):
@@ -572,8 +568,8 @@ def test_boolean_writing(tmp_path):
     assert np.allclose(actual, expected)
 
 
-def test_quantized_gif(image_cache, tmp_path):
-    original = iio.v3.imread(image_cache / "test-images" / "newtonscradle.gif")
+def test_quantized_gif(test_images, tmp_path):
+    original = iio.v3.imread(test_images / "newtonscradle.gif")
 
     iio.v3.imwrite(tmp_path / "quantized.gif", original, plugin="pillow", bits=4)
     quantized = iio.v3.imread(tmp_path / "quantized.gif")

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -399,7 +399,7 @@ def test_gif_transparent_pixel(image_files: Path):
 # TODO: Pillow actually doesn't read zip. This should be a different plugin.
 # def test_inside_zipfile():
 
-#     fname = os.path.join(test_dir, "pillowtest.zip")
+#     fname = os.path.join(tmp_path, "pillowtest.zip")
 #     with ZipFile(fname, "w") as z:
 #         z.writestr("x.png", open(get_remote_file(
 #             "images/chelsea.png"), "rb").read())

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -548,9 +548,7 @@ def test_initialization_failure(image_cache):
 
     with pytest.raises(OSError):
         # pillow can not handle npy
-        iio.v3.imread(
-            image_cache / "test-images" / "chelsea_jpg.npy", plugin="pillow"
-        )
+        iio.v3.imread(image_cache / "test-images" / "chelsea_jpg.npy", plugin="pillow")
 
 
 def test_boolean_reading(tmp_path):
@@ -577,9 +575,7 @@ def test_boolean_writing(tmp_path):
 def test_quantized_gif(image_cache, tmp_path):
     original = iio.v3.imread(image_cache / "test-images" / "newtonscradle.gif")
 
-    iio.v3.imwrite(
-        tmp_path / "quantized.gif", original, plugin="pillow", bits=4
-    )
+    iio.v3.imwrite(tmp_path / "quantized.gif", original, plugin="pillow", bits=4)
     quantized = iio.v3.imread(tmp_path / "quantized.gif")
 
     for original_frame, quantized_frame in zip(original, quantized):

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -553,7 +553,7 @@ def test_write_jpg_to_bytes_io():
     assert np.allclose(image_from_file, image)
 
 
-def test_initialization_failure(image_files: Path):
+def test_initialization_failure(image_cache):
     test_image = b"this is not an image and will break things."
 
     with pytest.raises(OSError):
@@ -561,7 +561,9 @@ def test_initialization_failure(image_files: Path):
 
     with pytest.raises(OSError):
         # pillow can not handle npy
-        iio.v3.imread(image_files / "chelsea_jpg.npy", plugin="pillow")
+        iio.v3.imread(
+            image_cache / "test-images" / "chelsea_jpg.npy", plugin="pillow"
+        )
 
 
 def test_boolean_reading(tmp_path):
@@ -585,10 +587,12 @@ def test_boolean_writing(tmp_path):
     assert np.allclose(actual, expected)
 
 
-def test_quantized_gif(image_files: Path, tmp_path):
-    original = iio.v3.imread(image_files / "newtonscradle.gif")
+def test_quantized_gif(image_cache, tmp_path):
+    original = iio.v3.imread(image_cache / "test-images" / "newtonscradle.gif")
 
-    iio.v3.imwrite(tmp_path / "quantized.gif", original, plugin="pillow", bits=4)
+    iio.v3.imwrite(
+        tmp_path / "quantized.gif", original, plugin="pillow", bits=4
+    )
     quantized = iio.v3.imread(tmp_path / "quantized.gif")
 
     for original_frame, quantized_frame in zip(original, quantized):

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -23,7 +23,10 @@ from imageio.core.request import InitializationError
         ("chelsea.npy", "iio.bmp", "pil.bmp"),
     ],
 )
-def test_write_single_frame(image_files: Path, im_npy: str, im_out: str, im_comp: str):
+@pytest.mark.needs_internet
+def test_write_single_frame(
+    image_files: Path, im_npy: str, im_out: str, im_comp: str
+):
     # the base image as numpy array
     im = np.load(image_files / im_npy)
     # written with imageio
@@ -50,7 +53,10 @@ def test_write_single_frame(image_files: Path, im_npy: str, im_out: str, im_comp
         # ("newtonscradle_rgba.npy", "iio.gif", "pil.gif"),
     ],
 )
-def test_write_multiframe(image_files: Path, im_npy: str, im_out: str, im_comp: str):
+@pytest.mark.needs_internet
+def test_write_multiframe(
+    image_files: Path, im_npy: str, im_out: str, im_comp: str
+):
     # the base image as numpy array
     im = np.load(image_files / im_npy)
     # written with imageio
@@ -79,6 +85,7 @@ def test_write_multiframe(image_files: Path, im_npy: str, im_out: str, im_comp: 
         ("newtonscradle.gif", "RGBA"),
     ],
 )
+@pytest.mark.needs_internet
 def test_read(image_files: Path, im_in: str, mode: str):
     im_path = image_files / im_in
     iio_im = iio.v3.imread(im_path, plugin="pillow", mode=mode)
@@ -102,6 +109,7 @@ def test_read(image_files: Path, im_in: str, mode: str):
         ("newtonscradle.gif", "RGBA"),
     ],
 )
+@pytest.mark.needs_internet
 def test_gif_legacy_pillow(image_files: Path, im_in: str, mode: str):
     """
     This test tests backwards compatibility of using the new API
@@ -126,6 +134,7 @@ def test_gif_legacy_pillow(image_files: Path, im_in: str, mode: str):
     assert np.allclose(iio_im, pil_im)
 
 
+@pytest.mark.needs_internet
 def test_png_compression(image_files: Path):
     # Note: Note sure if we should test this or pillow
 
@@ -139,6 +148,7 @@ def test_png_compression(image_files: Path):
     assert size_2 < size_1
 
 
+@pytest.mark.needs_internet
 def test_png_quantization(image_files: Path):
     # Note: Note sure if we should test this or pillow
 
@@ -152,12 +162,16 @@ def test_png_quantization(image_files: Path):
     assert size_2 < size_1
 
 
+@pytest.mark.needs_internet
 def test_png_16bit(image_files: Path):
     # 16b bit images
     im = np.load(image_files / "chelsea.npy")[..., 0]
 
     iio.v3.imwrite(
-        image_files / "1.png", 2 * im.astype(np.uint16), plugin="pillow", mode="I;16"
+        image_files / "1.png",
+        2 * im.astype(np.uint16),
+        plugin="pillow",
+        mode="I;16",
     )
     iio.v3.imwrite(image_files / "2.png", im, plugin="pillow", mode="L")
 
@@ -179,6 +193,7 @@ def test_png_16bit(image_files: Path):
 # their behavior. Consequentially this test was removed.
 
 
+@pytest.mark.needs_internet
 def test_png_remote():
     # issue #202
 
@@ -187,6 +202,7 @@ def test_png_remote():
     assert im.shape == (300, 451, 3)
 
 
+@pytest.mark.needs_internet
 def test_png_transparent_pixel(image_files: Path):
     # see issue #245
     im = iio.v3.imread(
@@ -195,12 +211,15 @@ def test_png_transparent_pixel(image_files: Path):
     assert im.shape == (24, 30, 4)
 
 
+@pytest.mark.needs_internet
 def test_png_gamma_correction(image_files: Path):
     with iio.imopen(image_files / "kodim03.png", "r", plugin="pillow") as f:
         im1 = f.read()
         im1_meta = f.get_meta()
 
-    im2 = iio.v3.imread(image_files / "kodim03.png", plugin="pillow", apply_gamma=True)
+    im2 = iio.v3.imread(
+        image_files / "kodim03.png", plugin="pillow", apply_gamma=True
+    )
 
     # Test result depending of application of gamma
     assert im1_meta["gamma"] < 1
@@ -212,6 +231,7 @@ def test_png_gamma_correction(image_files: Path):
     assert im2.dtype == "uint8"
 
 
+@pytest.mark.needs_internet
 def test_jpg_compression(image_files: Path):
     # Note: Note sure if we should test this or pillow
 
@@ -225,6 +245,7 @@ def test_jpg_compression(image_files: Path):
     assert size_2 < size_1
 
 
+@pytest.mark.needs_internet
 def test_exif_orientation(image_files: Path):
     from PIL.Image import Exif
 
@@ -238,7 +259,10 @@ def test_exif_orientation(image_files: Path):
     exif_tag[274] = 6  # Set Orientation to 6
 
     iio.v3.imwrite(
-        image_files / "chelsea_tagged.png", im_flipped, plugin="pillow", exif=exif_tag
+        image_files / "chelsea_tagged.png",
+        im_flipped,
+        plugin="pillow",
+        exif=exif_tag,
     )
 
     with iio.imopen(
@@ -261,6 +285,7 @@ def test_exif_orientation(image_files: Path):
     assert np.array_equal(im, im_reloaded)
 
 
+@pytest.mark.needs_internet
 def test_gif_rgb_vs_rgba(image_files: Path):
     # Note: I don't understand the point of this test
     im_rgb = iio.v3.imread(
@@ -273,17 +298,27 @@ def test_gif_rgb_vs_rgba(image_files: Path):
     assert np.allclose(im_rgb, im_rgba[..., :3])
 
 
+@pytest.mark.needs_internet
 def test_gif_gray(image_files: Path):
     # Note: There was no assert here; we test that it doesn't crash?
-    im = iio.v3.imread(image_files / "newtonscradle.gif", plugin="pillow", mode="L")
+    im = iio.v3.imread(
+        image_files / "newtonscradle.gif", plugin="pillow", mode="L"
+    )
 
     iio.v3.imwrite(
-        image_files / "test.gif", im[..., 0], plugin="pillow", duration=0.2, mode="L"
+        image_files / "test.gif",
+        im[..., 0],
+        plugin="pillow",
+        duration=0.2,
+        mode="L",
     )
 
 
+@pytest.mark.needs_internet
 def test_gif_irregular_duration(image_files: Path):
-    im = iio.v3.imread(image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA")
+    im = iio.v3.imread(
+        image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA"
+    )
     duration = [0.5 if idx in [2, 5, 7] else 0.1 for idx in range(im.shape[0])]
 
     with iio.imopen(image_files / "test.gif", "w", plugin="pillow") as file:
@@ -293,18 +328,26 @@ def test_gif_irregular_duration(image_files: Path):
     # how to assert duration here
 
 
+@pytest.mark.needs_internet
 def test_gif_palletsize(image_files: Path):
-    im = iio.v3.imread(image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA")
+    im = iio.v3.imread(
+        image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA"
+    )
 
-    iio.v3.imwrite(image_files / "test.gif", im, plugin="pillow", palletsize=100)
+    iio.v3.imwrite(
+        image_files / "test.gif", im, plugin="pillow", palletsize=100
+    )
     # TODO: assert pallet size is 128
 
 
+@pytest.mark.needs_internet
 def test_gif_loop_and_fps(image_files: Path):
     # Note: I think this test tests pillow kwargs, not imageio functionality
     # maybe we should drop it?
 
-    im = iio.v3.imread(image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA")
+    im = iio.v3.imread(
+        image_files / "newtonscradle.gif", plugin="pillow", mode="RGBA"
+    )
 
     with iio.imopen(image_files / "test.gif", "w", plugin="pillow") as file:
         for frame in im:
@@ -313,11 +356,14 @@ def test_gif_loop_and_fps(image_files: Path):
     # This test had no assert; how to assert fps and loop count?
 
 
+@pytest.mark.needs_internet
 def test_gif_indexed_read(image_files: Path):
     idx = 0
     numpy_im = np.load(image_files / "newtonscradle_rgb.npy")[idx, ...]
 
-    with iio.imopen(image_files / "newtonscradle.gif", "r", plugin="pillow") as file:
+    with iio.imopen(
+        image_files / "newtonscradle.gif", "r", plugin="pillow"
+    ) as file:
         # exists to touch branch, would be better two write an explicit test
         meta = file.get_meta(index=idx)
         assert "version" in meta
@@ -327,9 +373,12 @@ def test_gif_indexed_read(image_files: Path):
     assert np.allclose(pillow_im, numpy_im)
 
 
+@pytest.mark.needs_internet
 def test_unknown_image(image_files: Path):
     with open(image_files / "foo.unknown", "w") as file:
-        file.write("This image, which is actually no image, has an unknown image type.")
+        file.write(
+            "This image, which is actually no image, has an unknown image type."
+        )
 
     with pytest.raises(InitializationError):
         r = Request(image_files / "foo.unknown", "r")
@@ -339,6 +388,7 @@ def test_unknown_image(image_files: Path):
 # TODO: introduce new plugin for writing compressed GIF
 # This is not what pillow does, and hence unexpected when explicitly calling
 # for pillow
+# @pytest.mark.needs_internet
 # def test_gif_subrectangles(image_files: Path):
 #     # feature might be made obsolete by upstream (pillow) supporting it natively
 #     # related issues: https://github.com/python-pillow/Pillow/issues/4977
@@ -357,6 +407,7 @@ def test_unknown_image(image_files: Path):
 #     assert size_2 < size_1
 
 
+@pytest.mark.needs_internet
 def test_gif_transparent_pixel(image_files: Path):
     # see issue #245
     im = iio.v3.imread(
@@ -367,7 +418,6 @@ def test_gif_transparent_pixel(image_files: Path):
 
 # TODO: Pillow actually doesn't read zip. This should be a different plugin.
 # def test_inside_zipfile():
-#     need_internet()
 
 #     fname = os.path.join(test_dir, "pillowtest.zip")
 #     with ZipFile(fname, "w") as z:
@@ -380,6 +430,7 @@ def test_gif_transparent_pixel(image_files: Path):
 #         imageio.imread(fname + "/" + name)
 
 
+@pytest.mark.needs_internet
 def test_legacy_exif_orientation(image_files: Path):
     from PIL.Image import Exif
 
@@ -393,7 +444,10 @@ def test_legacy_exif_orientation(image_files: Path):
     exif_tag[274] = 6  # Set Orientation to 6
 
     iio.v3.imwrite(
-        image_files / "chelsea_tagged.png", im_flipped, plugin="pillow", exif=exif_tag
+        image_files / "chelsea_tagged.png",
+        im_flipped,
+        plugin="pillow",
+        exif=exif_tag,
     )
 
     with iio.imopen(
@@ -419,7 +473,9 @@ def test_legacy_exif_orientation(image_files: Path):
 
 def test_incomatible_write_format(tmp_path):
     with pytest.raises(IOError):
-        iio.v3.imopen(tmp_path / "foo.mp3", "w", plugin="pillow", legacy_mode=False)
+        iio.v3.imopen(
+            tmp_path / "foo.mp3", "w", plugin="pillow", legacy_mode=False
+        )
 
 
 def test_write_to_bytes():
@@ -448,7 +504,9 @@ def test_write_to_bytes_rgba():
 
     # writing to bytes with imageIO
     with io.BytesIO() as output:
-        iio.v3.imwrite(output, image, plugin="pillow", format="PNG", mode="RGBA")
+        iio.v3.imwrite(
+            output, image, plugin="pillow", format="PNG", mode="RGBA"
+        )
         iio_contents = output.getvalue()
 
     assert iio_contents == contents
@@ -463,7 +521,9 @@ def test_write_to_bytes_imwrite():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format="PNG")
+    bytes_string = iio.v3.imwrite(
+        "<bytes>", image, plugin="pillow", format="PNG"
+    )
 
     assert contents == bytes_string
 
@@ -477,7 +537,9 @@ def test_write_to_bytes_jpg():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format="JPEG")
+    bytes_string = iio.v3.imwrite(
+        "<bytes>", image, plugin="pillow", format="JPEG"
+    )
 
     assert contents == bytes_string
 

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -404,7 +404,7 @@ def test_inside_zipfile(image_cache, tmp_path):
     with ZipFile(fname, "w") as z:
         z.writestr(
             "x.png",
-            (image_cache / "test-images" / "chelsea.png).read_bytes(),
+            (image_cache / "test-images" / "chelsea.png").read_bytes(),
         )
         z.writestr(
             "x.jpg",

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -74,7 +74,7 @@ def assert_close(im1, im2, tol=0.0):
 @pytest.mark.needs_internet
 def test_pillow_format(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     # Format - Pillow is the default!
     F = imageio.formats["PNG"]
@@ -103,7 +103,7 @@ def test_pillow_format(tmp_path):
 @pytest.mark.needs_internet
 def test_png(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -187,7 +187,7 @@ def test_png_remote():
 
 def test_jpg(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -226,7 +226,7 @@ def test_jpg(tmp_path):
 @pytest.mark.needs_internet
 def test_jpg_more(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     # Test broken JPEG
     fname = fnamebase + "_broken.jpg"
@@ -260,7 +260,7 @@ def test_jpg_more(tmp_path):
 
 
 def test_gif(tmp_path):
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     # The not-animated gif
 
@@ -290,7 +290,7 @@ def test_gif(tmp_path):
 @pytest.mark.needs_internet
 def test_animated_gif(tmp_path):
 
-    fnamebase = tmp_path / "test"
+    fnamebase = str(tmp_path / "test")
 
     # Read newton's cradle
     ims = imageio.mimread("imageio:newtonscradle.gif")
@@ -408,7 +408,7 @@ def test_gamma_correction():
 @pytest.mark.needs_internet
 def test_inside_zipfile(tmp_path):
 
-    fname = tmp_path / "pillowtest.zip"
+    fname = str(tmp_path / "pillowtest.zip")
     with ZipFile(fname, "w") as z:
         z.writestr("x.png", open(get_remote_file("images/chelsea.png"), "rb").read())
         z.writestr("x.jpg", open(get_remote_file("images/rommel.jpg"), "rb").read())

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -72,9 +72,9 @@ def assert_close(im1, im2, tol=0.0):
 
 
 @pytest.mark.needs_internet
-def test_pillow_format(test_dir):
+def test_pillow_format(tmp_path):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     # Format - Pillow is the default!
     F = imageio.formats["PNG"]
@@ -96,9 +96,9 @@ def test_pillow_format(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_png(test_dir):
+def test_png(tmp_path):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -173,9 +173,9 @@ def test_png_remote():
     assert im.shape == (512, 512, 3)
 
 
-def test_jpg(test_dir):
+def test_jpg(tmp_path):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -210,9 +210,9 @@ def test_jpg(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_jpg_more(test_dir):
+def test_jpg_more(tmp_path):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     # Test broken JPEG
     fname = fnamebase + "_broken.jpg"
@@ -243,8 +243,8 @@ def test_jpg_more(test_dir):
     assert im.meta.EXIF_MAIN
 
 
-def test_gif(test_dir):
-    fnamebase = os.path.join(test_dir, "test")
+def test_gif(tmp_path):
+    fnamebase = os.path.join(tmp_path, "test")
 
     # The not-animated gif
 
@@ -269,9 +269,9 @@ def test_gif(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_animated_gif(test_dir):
+def test_animated_gif(tmp_path):
 
-    fnamebase = os.path.join(test_dir, "test")
+    fnamebase = os.path.join(tmp_path, "test")
 
     # Read newton's cradle
     ims = imageio.mimread("imageio:newtonscradle.gif")
@@ -380,9 +380,9 @@ def test_gamma_correction():
 
 
 @pytest.mark.needs_internet
-def test_inside_zipfile(test_dir):
+def test_inside_zipfile(tmp_path):
 
-    fname = os.path.join(test_dir, "pillowtest.zip")
+    fname = os.path.join(tmp_path, "pillowtest.zip")
     with ZipFile(fname, "w") as z:
         z.writestr("x.png", open(get_remote_file("images/chelsea.png"), "rb").read())
         z.writestr("x.jpg", open(get_remote_file("images/rommel.jpg"), "rb").read())
@@ -392,8 +392,8 @@ def test_inside_zipfile(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_bmp(test_dir):
-    fname = get_remote_file("images/scribble_P_RGB.bmp", test_dir)
+def test_bmp(tmp_path):
+    fname = get_remote_file("images/scribble_P_RGB.bmp", tmp_path)
 
     imageio.imread(fname)
     imageio.imread(fname, pilmode="RGB")

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -122,7 +122,7 @@ def test_png(tmp_path):
     # Parameter fail
     with pytest.raises(TypeError):
         imageio.imread("imageio:chelsea.png", notavalidk=True)
-        
+
     with pytest.raises(TypeError):
         imageio.imsave(fnamebase + ".png", im, notavalidk=True)
 

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -70,7 +70,7 @@ def assert_close(im1, im2, tol=0.0):
     # vv.subplot(121); vv.imshow(im1); vv.subplot(122); vv.imshow(im2)
 
 
-def test_pillow_format(image_cache, tmp_path):
+def test_pillow_format(test_images, tmp_path):
 
     fnamebase = str(tmp_path / "test")
 
@@ -79,7 +79,7 @@ def test_pillow_format(image_cache, tmp_path):
     assert F.name == "PNG-PIL"
 
     # Reader
-    R = F.get_reader(core.Request(image_cache / "test-images" / "chelsea.png", "ri"))
+    R = F.get_reader(core.Request(test_images / "chelsea.png", "ri"))
     assert len(R) == 1
     assert isinstance(R.get_meta_data(), dict)
     assert isinstance(R.get_meta_data(0), dict)
@@ -98,7 +98,7 @@ def test_pillow_format(image_cache, tmp_path):
         W.append_data(im0)
 
 
-def test_png(image_cache, tmp_path):
+def test_png(test_images, tmp_path):
 
     fnamebase = str(tmp_path / "test")
 
@@ -113,12 +113,12 @@ def test_png(image_cache, tmp_path):
                 assert_close(rim * mul, im, 0.1)  # lossless
 
     # Parameters
-    im = imageio.imread(image_cache / "test-images" / "chelsea.png", ignoregamma=True)
+    im = imageio.imread(test_images / "chelsea.png", ignoregamma=True)
     imageio.imsave(fnamebase + ".png", im, interlaced=True)
 
     # Parameter fail
     with pytest.raises(TypeError):
-        imageio.imread(image_cache / "test-images" / "chelsea.png", notavalidk=True)
+        imageio.imread(test_images / "chelsea.png", notavalidk=True)
 
     with pytest.raises(TypeError):
         imageio.imsave(fnamebase + ".png", im, notavalidk=True)
@@ -150,7 +150,7 @@ def test_png(image_cache, tmp_path):
         imageio.imsave(fname, im[:, :, 0], quantize=100)
 
     # 16b bit images
-    im = imageio.imread(image_cache / "test-images" / "chelsea.png")[:, :, 0]
+    im = imageio.imread(test_images / "chelsea.png")[:, :, 0]
     imageio.imsave(fnamebase + "1.png", im.astype("uint16") * 2)
     imageio.imsave(fnamebase + "2.png", im)
     s1 = os.stat(fnamebase + "1.png").st_size
@@ -220,7 +220,7 @@ def test_jpg(tmp_path):
         imageio.imsave(fnamebase + ".jpg", im, quality=120)
 
 
-def test_jpg_more(image_cache, tmp_path):
+def test_jpg_more(test_images, tmp_path):
 
     fnamebase = str(tmp_path / "test")
 
@@ -240,7 +240,7 @@ def test_jpg_more(image_cache, tmp_path):
         imageio.imread(fname)
 
     # Test EXIF stuff
-    fname = image_cache / "images" / "rommel.jpg"
+    fname = test_images / "rommel.jpg"
     im = imageio.imread(fname)
     assert im.shape[0] > im.shape[1]
     im = imageio.imread(fname, exifrotate=False)
@@ -283,12 +283,12 @@ def test_gif(tmp_path):
         imageio.imsave(fnamebase + "1.gif", im, notavalidk=True)
 
 
-def test_animated_gif(image_cache, tmp_path):
+def test_animated_gif(test_images, tmp_path):
 
     fnamebase = str(tmp_path / "test")
 
     # Read newton's cradle
-    ims = imageio.mimread(image_cache / "test-images" / "newtonscradle.gif")
+    ims = imageio.mimread(test_images / "newtonscradle.gif")
     assert len(ims) == 36
     for im in ims:
         assert im.shape == (150, 200, 4)
@@ -364,21 +364,21 @@ def test_animated_gif(image_cache, tmp_path):
     assert isinstance(imageio.read(fname).get_meta_data(), dict)
 
 
-def test_images_with_transparency(image_cache):
+def test_images_with_transparency(test_images):
     # Not alpha channel, but transparent pixels, see issue #245 and #246
 
-    fname = image_cache / "test-images" / "imageio_issue245.gif"
+    fname = test_images / "imageio_issue245.gif"
     im = imageio.imread(fname)
     assert im.shape == (24, 30, 4)
 
-    fname = image_cache / "test-images" / "imageio_issue246.png"
+    fname = test_images / "imageio_issue246.png"
     im = imageio.imread(fname)
     assert im.shape == (24, 30, 4)
 
 
-def test_gamma_correction(image_cache):
+def test_gamma_correction(test_images):
 
-    fname = image_cache / "test-images" / "kodim03.png"
+    fname = test_images / "kodim03.png"
 
     # Load image three times
     im1 = imageio.imread(fname)
@@ -398,36 +398,36 @@ def test_gamma_correction(image_cache):
         assert im.shape == (512, 768, 3) and im.dtype == "uint8"
 
 
-def test_inside_zipfile(image_cache, tmp_path):
+def test_inside_zipfile(test_images, tmp_path):
 
     fname = str(tmp_path / "pillowtest.zip")
     with ZipFile(fname, "w") as z:
         z.writestr(
             "x.png",
-            (image_cache / "test-images" / "chelsea.png").read_bytes(),
+            (test_images / "chelsea.png").read_bytes(),
         )
         z.writestr(
             "x.jpg",
-            (image_cache / "images" / "rommel.jpg").read_bytes(),
+            (test_images / "rommel.jpg").read_bytes(),
         )
 
     for name in ("x.png", "x.jpg"):
         imageio.imread(fname + "/" + name)
 
 
-def test_bmp(image_cache):
-    fname = image_cache / "images" / "scribble_P_RGB.bmp"
+def test_bmp(test_images):
+    fname = test_images / "scribble_P_RGB.bmp"
 
     imageio.imread(fname)
     imageio.imread(fname, pilmode="RGB")
     imageio.imread(fname, pilmode="RGBA")
 
 
-def test_scipy_imread_compat(image_cache):
+def test_scipy_imread_compat(test_images):
     # https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imread.html
     # https://github.com/scipy/scipy/blob/41a3e69ca3141d8bf996bccb5eca5fc7bbc21a51/scipy/misc/pilutil.py#L111
 
-    fname = image_cache / "test-images" / "chelsea.png"
+    fname = test_images / "chelsea.png"
 
     im = imageio.imread(fname)
     assert im.shape == (300, 451, 3) and im.dtype == "uint8"

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -404,11 +404,11 @@ def test_inside_zipfile(image_cache, tmp_path):
     with ZipFile(fname, "w") as z:
         z.writestr(
             "x.png",
-            open(image_cache / "test-images" / "chelsea.png", "rb").read(),
+            (image_cache / "test-images" / "chelsea.png).read_bytes(),
         )
         z.writestr(
             "x.jpg",
-            open(image_cache / "images" / "rommel.jpg", "rb").read(),
+            (image_cache / "images" / "rommel.jpg").read_bytes(),
         )
 
     for name in ("x.png", "x.jpg"):

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -79,9 +79,7 @@ def test_pillow_format(image_cache, tmp_path):
     assert F.name == "PNG-PIL"
 
     # Reader
-    R = F.get_reader(
-        core.Request(image_cache / "test-images" / "chelsea.png", "ri")
-    )
+    R = F.get_reader(core.Request(image_cache / "test-images" / "chelsea.png", "ri"))
     assert len(R) == 1
     assert isinstance(R.get_meta_data(), dict)
     assert isinstance(R.get_meta_data(0), dict)
@@ -115,16 +113,12 @@ def test_png(image_cache, tmp_path):
                 assert_close(rim * mul, im, 0.1)  # lossless
 
     # Parameters
-    im = imageio.imread(
-        image_cache / "test-images" / "chelsea.png", ignoregamma=True
-    )
+    im = imageio.imread(image_cache / "test-images" / "chelsea.png", ignoregamma=True)
     imageio.imsave(fnamebase + ".png", im, interlaced=True)
 
     # Parameter fail
     with pytest.raises(TypeError):
-        imageio.imread(
-            image_cache / "test-images" / "chelsea.png", notavalidk=True
-        )
+        imageio.imread(image_cache / "test-images" / "chelsea.png", notavalidk=True)
 
     with pytest.raises(TypeError):
         imageio.imsave(fnamebase + ".png", im, notavalidk=True)
@@ -166,9 +160,7 @@ def test_png(image_cache, tmp_path):
     assert im2.dtype == np.uint16
 
     # issue #352 - prevent low-luma uint16 truncation to uint8
-    arr = np.full(
-        (32, 32), 255, dtype=np.uint16
-    )  # values within range of uint8
+    arr = np.full((32, 32), 255, dtype=np.uint16)  # values within range of uint8
     preferences_dtypes = [
         [{}, np.uint8],
         [{"prefer_uint8": True}, np.uint8],

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -74,7 +74,7 @@ def assert_close(im1, im2, tol=0.0):
 @pytest.mark.needs_internet
 def test_pillow_format(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     # Format - Pillow is the default!
     F = imageio.formats["PNG"]
@@ -85,20 +85,25 @@ def test_pillow_format(tmp_path):
     assert len(R) == 1
     assert isinstance(R.get_meta_data(), dict)
     assert isinstance(R.get_meta_data(0), dict)
-    assert pytest.raises(IndexError, R.get_data, 2)
-    assert pytest.raises(IndexError, R.get_meta_data, 2)
+
+    with pytest.raises(IndexError):
+        R.get_data(2)
+
+    with pytest.raises(IndexError):
+        R.get_meta_data(2)
 
     # Writer
     W = F.get_writer(core.Request(fnamebase + ".png", "wi"))
     W.append_data(im0)
     W.set_meta_data({"foo": 3})
-    assert pytest.raises(RuntimeError, W.append_data, im0)
+    with pytest.raises(RuntimeError):
+        W.append_data(im0)
 
 
 @pytest.mark.needs_internet
 def test_png(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -115,8 +120,11 @@ def test_png(tmp_path):
     imageio.imsave(fnamebase + ".png", im, interlaced=True)
 
     # Parameter fail
-    pytest.raises(TypeError, imageio.imread, "imageio:chelsea.png", notavalidk=True)
-    pytest.raises(TypeError, imageio.imsave, fnamebase + ".png", im, notavalidk=True)
+    with pytest.raises(TypeError):
+        imageio.imread("imageio:chelsea.png", notavalidk=True)
+        
+    with pytest.raises(TypeError):
+        imageio.imsave(fnamebase + ".png", im, notavalidk=True)
 
     # Compression
     imageio.imsave(fnamebase + "1.png", im, compression=0)
@@ -125,7 +133,8 @@ def test_png(tmp_path):
     s2 = os.stat(fnamebase + "2.png").st_size
     assert s2 < s1
     # Fail
-    pytest.raises(ValueError, imageio.imsave, fnamebase + ".png", im, compression=12)
+    with pytest.raises(ValueError):
+        imageio.imsave(fnamebase + ".png", im, compression=12)
 
     # Quantize
     imageio.imsave(fnamebase + "1.png", im, quantize=256)
@@ -137,8 +146,11 @@ def test_png(tmp_path):
     assert s1 > s2
     # Fail
     fname = fnamebase + "1.png"
-    pytest.raises(ValueError, imageio.imsave, fname, im[:, :, :3], quantize=300)
-    pytest.raises(ValueError, imageio.imsave, fname, im[:, :, 0], quantize=100)
+    with pytest.raises(ValueError):
+        imageio.imsave(fname, im[:, :, :3], quantize=300)
+
+    with pytest.raises(ValueError):
+        imageio.imsave(fname, im[:, :, 0], quantize=100)
 
     # 16b bit images
     im = imageio.imread("imageio:chelsea.png")[:, :, 0]
@@ -175,7 +187,7 @@ def test_png_remote():
 
 def test_jpg(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     for isfloat in (False, True):
         for crop in (0, 1, 2):
@@ -189,7 +201,8 @@ def test_jpg(tmp_path):
 
     # No alpha in JPEG
     fname = fnamebase + ".jpg"
-    pytest.raises(Exception, imageio.imsave, fname, im4)
+    with pytest.raises(Exception):
+        imageio.imsave(fname, im4)
 
     # Parameters
     imageio.imsave(
@@ -206,18 +219,20 @@ def test_jpg(tmp_path):
     s1 = os.stat(fnamebase + "1.jpg").st_size
     s2 = os.stat(fnamebase + "2.jpg").st_size
     assert s2 > s1
-    pytest.raises(ValueError, imageio.imsave, fnamebase + ".jpg", im, quality=120)
+    with pytest.raises(ValueError):
+        imageio.imsave(fnamebase + ".jpg", im, quality=120)
 
 
 @pytest.mark.needs_internet
 def test_jpg_more(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     # Test broken JPEG
     fname = fnamebase + "_broken.jpg"
     open(fname, "wb").write(b"this is not an image")
-    pytest.raises(Exception, imageio.imread, fname)
+    with pytest.raises(Exception):
+        imageio.imread(fname)
     #
     img = get_ref_im(3, 0, 0)
     bb = imageio.imsave(imageio.RETURN_BYTES, img, "JPEG-PIL")
@@ -225,7 +240,8 @@ def test_jpg_more(tmp_path):
         f.write(bb[:400])
         f.write(b" ")
         f.write(bb[400:])
-    pytest.raises(Exception, imageio.imread, fname)
+    with pytest.raises(Exception):
+        imageio.imread(fname)
 
     # Test EXIF stuff
     fname = get_remote_file("images/rommel.jpg")
@@ -244,7 +260,7 @@ def test_jpg_more(tmp_path):
 
 
 def test_gif(tmp_path):
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     # The not-animated gif
 
@@ -264,14 +280,17 @@ def test_gif(tmp_path):
                 assert_close(rim * mul, im, 1.1)  # lossless
 
     # Parameter fail
-    pytest.raises(TypeError, imageio.imread, fname, notavalidkwarg=True)
-    pytest.raises(TypeError, imageio.imsave, fnamebase + "1.gif", im, notavalidk=True)
+    with pytest.raises(TypeError):
+        imageio.imread(fname, notavalidkwarg=True)
+
+    with pytest.raises(TypeError):
+        imageio.imsave(fnamebase + "1.gif", im, notavalidk=True)
 
 
 @pytest.mark.needs_internet
 def test_animated_gif(tmp_path):
 
-    fnamebase = os.path.join(tmp_path, "test")
+    fnamebase = tmp_path / "test"
 
     # Read newton's cradle
     ims = imageio.mimread("imageio:newtonscradle.gif")
@@ -323,10 +342,17 @@ def test_animated_gif(tmp_path):
     W = imageio.save(fnamebase + ".animated.palettes100.gif", palettesize=100)
     assert W._writer.opt_palette_size == 128
     # Fail
-    assert pytest.raises(IndexError, R.get_meta_data, -1)
-    assert pytest.raises(ValueError, imageio.mimsave, fname, ims, palettesize=300)
-    assert pytest.raises(ValueError, imageio.mimsave, fname, ims, quantizer="foo")
-    assert pytest.raises(ValueError, imageio.mimsave, fname, ims, duration="foo")
+    with pytest.raises(IndexError):
+        R.get_meta_data(-1)
+
+    with pytest.raises(ValueError):
+        imageio.mimsave(fname, ims, palettesize=300)
+
+    with pytest.raises(ValueError):
+        imageio.mimsave(fname, ims, quantizer="foo")
+
+    with pytest.raises(ValueError):
+        imageio.mimsave(fname, ims, duration="foo")
 
     # Add one duplicate image to ims to touch subractangle with not change
     ims.append(ims[-1])
@@ -382,7 +408,7 @@ def test_gamma_correction():
 @pytest.mark.needs_internet
 def test_inside_zipfile(tmp_path):
 
-    fname = os.path.join(tmp_path, "pillowtest.zip")
+    fname = tmp_path / "pillowtest.zip"
     with ZipFile(fname, "w") as z:
         z.writestr("x.png", open(get_remote_file("images/chelsea.png"), "rb").read())
         z.writestr("x.jpg", open(get_remote_file("images/rommel.jpg"), "rb").read())

--- a/tests/test_simpleitk.py
+++ b/tests/test_simpleitk.py
@@ -7,12 +7,8 @@ import numpy as np
 
 import pytest
 from pytest import raises
-from imageio.testing import run_tests_if_main, get_test_dir
 
 import imageio
-
-test_dir = get_test_dir()
-
 
 itk = None
 try:
@@ -27,7 +23,7 @@ except ImportError:
 
 
 @pytest.mark.skipif("itk is None")
-def test_simpleitk_reading_writing():
+def test_simpleitk_reading_writing(test_dir):
     """Test reading and saveing tiff"""
     im2 = np.ones((10, 10, 3), np.uint8) * 2
 
@@ -58,6 +54,3 @@ def test_simpleitk_reading_writing():
     raises(IndexError, R.get_data, -1)
     raises(IndexError, R.get_data, 3)
     raises(RuntimeError, R.get_meta_data)
-
-
-run_tests_if_main()

--- a/tests/test_simpleitk.py
+++ b/tests/test_simpleitk.py
@@ -23,11 +23,11 @@ except ImportError:
 
 
 @pytest.mark.skipif("itk is None")
-def test_simpleitk_reading_writing(test_dir):
+def test_simpleitk_reading_writing(tmp_path):
     """Test reading and saveing tiff"""
     im2 = np.ones((10, 10, 3), np.uint8) * 2
 
-    filename1 = os.path.join(test_dir, "test_tiff.tiff")
+    filename1 = os.path.join(tmp_path, "test_tiff.tiff")
 
     # One image
     imageio.imsave(filename1, im2, "itk")

--- a/tests/test_simpleitk.py
+++ b/tests/test_simpleitk.py
@@ -27,7 +27,7 @@ def test_simpleitk_reading_writing(tmp_path):
     """Test reading and saveing tiff"""
     im2 = np.ones((10, 10, 3), np.uint8) * 2
 
-    filename1 = os.path.join(tmp_path, "test_tiff.tiff")
+    filename1 = tmp_path / "test_tiff.tiff"
 
     # One image
     imageio.imsave(filename1, im2, "itk")

--- a/tests/test_simpleitk.py
+++ b/tests/test_simpleitk.py
@@ -1,8 +1,6 @@
 """ Test simpleitk plugin functionality.
 """
 
-import os
-
 import numpy as np
 
 import pytest

--- a/tests/test_spe.py
+++ b/tests/test_spe.py
@@ -13,8 +13,8 @@ def test_spe_format():
         assert isinstance(fmt, spe.SpeFormat)
 
 
-def test_spe_reading(image_cache):
-    fname = image_cache / "images" / "test_000_.SPE"
+def test_spe_reading(test_images):
+    fname = test_images / "test_000_.SPE"
 
     fr1 = np.zeros((32, 32), np.uint16)
     fr2 = np.ones_like(fr1)

--- a/tests/test_spe.py
+++ b/tests/test_spe.py
@@ -5,7 +5,6 @@ import pytest
 
 import imageio
 from imageio.plugins import spe
-from imageio.core import get_remote_file
 
 
 def test_spe_format():
@@ -14,9 +13,8 @@ def test_spe_format():
         assert isinstance(fmt, spe.SpeFormat)
 
 
-@pytest.mark.needs_internet
-def test_spe_reading():
-    fname = get_remote_file("images/test_000_.SPE")
+def test_spe_reading(image_cache):
+    fname = image_cache / "images" / "test_000_.SPE"
 
     fr1 = np.zeros((32, 32), np.uint16)
     fr2 = np.ones_like(fr1)

--- a/tests/test_spe.py
+++ b/tests/test_spe.py
@@ -5,11 +5,7 @@ import pytest
 
 import imageio
 from imageio.plugins import spe
-from imageio.testing import run_tests_if_main, get_test_dir, need_internet
 from imageio.core import get_remote_file
-
-
-test_dir = get_test_dir()
 
 
 def test_spe_format():
@@ -18,8 +14,8 @@ def test_spe_format():
         assert isinstance(fmt, spe.SpeFormat)
 
 
+@pytest.mark.needs_internet
 def test_spe_reading():
-    need_internet()
     fname = get_remote_file("images/test_000_.SPE")
 
     fr1 = np.zeros((32, 32), np.uint16)
@@ -80,6 +76,3 @@ def test_spe_reading():
     assert sdt_meta["sdt_minor_version"] == 18
     assert isinstance(sdt_meta["modulation_script"], str)
     assert sdt_meta["sequence_type"] == "standard"
-
-
-run_tests_if_main()

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -5,28 +5,23 @@ import os
 
 import numpy as np
 
-from pytest import raises
-from imageio.testing import run_tests_if_main, get_test_dir, need_internet
+import pytest
 
 import imageio
 from imageio import core
 from imageio.core import get_remote_file, IS_PYPY
 
 
-test_dir = get_test_dir()
-
-
 def mean(x):
     return x.sum() / x.size  # pypy-compat mean
 
 
-# We use need_internet; don't ship the swf image: its rather big and a
+# We use needs_internet marker; don't ship the swf image: its rather big and a
 # rather specific format
 
 
-def test_format_selection():
-
-    need_internet()
+@pytest.mark.needs_internet
+def test_format_selection(test_dir):
 
     fname1 = get_remote_file("images/stent.swf", test_dir)
     fname2 = fname1[:-4] + ".out.swf"
@@ -39,9 +34,8 @@ def test_format_selection():
     assert type(imageio.save(fname2).format) is type(F)
 
 
-def test_reading_saving():
-
-    need_internet()
+@pytest.mark.needs_internet
+def test_reading_saving(test_dir):
 
     fname1 = get_remote_file("images/stent.swf", test_dir)
     fname2 = fname1[:-4] + ".out.swf"
@@ -60,8 +54,8 @@ def test_reading_saving():
     # Seek
     assert (R.get_data(3) == ims1[3]).all()
     # Fails
-    raises(IndexError, R.get_data, -1)  # No negative index
-    raises(IndexError, R.get_data, 10)  # Out of bounds
+    pytest.raises(IndexError, R.get_data, -1)  # No negative index
+    pytest.raises(IndexError, R.get_data, 10)  # Out of bounds
     R.close()
 
     # Test loop
@@ -136,9 +130,8 @@ def test_reading_saving():
             f.write(line.strip().encode("utf-8") + b"\n")
 
 
+@pytest.mark.needs_internet
 def test_read_from_url():
-
-    need_internet()
 
     burl = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/"
     url = burl + "images/stent.swf"
@@ -147,9 +140,8 @@ def test_read_from_url():
     assert len(ims) == 10
 
 
-def test_invalid():
-
-    need_internet()
+@pytest.mark.needs_internet
+def test_invalid(test_dir):
 
     fname1 = get_remote_file("images/stent.swf", test_dir)
     fname2 = fname1[:-4] + ".invalid.swf"
@@ -158,24 +150,23 @@ def test_invalid():
     with open(fname2, "wb"):
         pass
     assert not imageio.formats.search_read_format(core.Request(fname2, "rI"))
-    raises(RuntimeError, imageio.mimread, fname2, "swf")
+    pytest.raises(RuntimeError, imageio.mimread, fname2, "swf")
 
     # File with BS data
     with open(fname2, "wb") as f:
         f.write(b"x" * 100)
     assert not imageio.formats.search_read_format(core.Request(fname2, "rI"))
-    raises(RuntimeError, imageio.mimread, fname2, "swf")
+    pytest.raises(RuntimeError, imageio.mimread, fname2, "swf")
 
 
+@pytest.mark.needs_internet
 def test_lowlevel():
-
-    need_internet()
 
     # Some tests from low level implementation that is not covered
     # by using the plugin itself.
     _swf = imageio.plugins.swf.load_lib()
     tag = _swf.Tag()
-    raises(NotImplementedError, tag.process_tag)
+    pytest.raises(NotImplementedError, tag.process_tag)
     assert tag.make_matrix_record() == "00000000"
     assert tag.make_matrix_record(scale_xy=(1, 1))
     assert tag.make_matrix_record(rot_xy=(1, 1))
@@ -193,9 +184,8 @@ def test_lowlevel():
     )
 
 
-def test_types():
-
-    need_internet()
+@pytest.mark.needs_internet
+def test_types(test_dir):
 
     fname1 = get_remote_file("images/stent.swf", test_dir)
     fname2 = fname1[:-4] + ".out3.swf"
@@ -222,6 +212,3 @@ def test_types():
             assert im2.dtype == np.uint8
             if len(shape) == 3 and dtype == np.uint8:
                 assert (im1[:, :, 0] == im2[:, :, 0]).all()
-
-
-run_tests_if_main()

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -7,22 +7,17 @@ import pytest
 
 import imageio
 from imageio import core
-from imageio.core import get_remote_file, IS_PYPY
+from imageio.core import IS_PYPY
 
 
 def mean(x):
     return x.sum() / x.size  # pypy-compat mean
 
 
-# We use needs_internet marker; don't ship the swf image: its rather big and a
-# rather specific format
+def test_format_selection(image_cache):
 
-
-@pytest.mark.needs_internet
-def test_format_selection(tmp_path):
-
-    fname1 = get_remote_file("images/stent.swf", tmp_path)
-    fname2 = fname1[:-4] + ".out.swf"
+    fname1 = image_cache / "images" / "stent.swf"
+    fname2 = fname1.with_suffix(".out.swf")
 
     F = imageio.formats["swf"]
     assert F.name == "SWF"
@@ -32,13 +27,12 @@ def test_format_selection(tmp_path):
     assert type(imageio.save(fname2).format) is type(F)
 
 
-@pytest.mark.needs_internet
-def test_reading_saving(tmp_path):
+def test_reading_saving(image_cache, tmp_path):
 
-    fname1 = get_remote_file("images/stent.swf", tmp_path)
-    fname2 = fname1[:-4] + ".out.swf"
-    fname3 = fname1[:-4] + ".compressed.swf"
-    fname4 = fname1[:-4] + ".out2.swf"
+    fname1 = image_cache / "images" / "stent.swf"
+    fname2 = fname1.with_suffix(".out.swf")
+    fname3 = fname1.with_suffix(".compressed.swf")
+    fname4 = fname1.with_suffix(".out2.swf")
 
     # Read
     R = imageio.read(fname1)
@@ -141,11 +135,10 @@ def test_read_from_url():
     assert len(ims) == 10
 
 
-@pytest.mark.needs_internet
-def test_invalid(tmp_path):
+def test_invalid(image_cache):
 
-    fname1 = get_remote_file("images/stent.swf", tmp_path)
-    fname2 = fname1[:-4] + ".invalid.swf"
+    fname1 = image_cache / "images" / "stent.swf"
+    fname2 = fname1.with_suffix(".invalid.swf")
 
     # Empty file
     with open(fname2, "wb"):
@@ -188,11 +181,10 @@ def test_lowlevel():
     )
 
 
-@pytest.mark.needs_internet
-def test_types(tmp_path):
+def test_types(image_cache):
 
-    fname1 = get_remote_file("images/stent.swf", tmp_path)
-    fname2 = fname1[:-4] + ".out3.swf"
+    fname1 = image_cache / "images" / "stent.swf"
+    fname2 = fname1.with_suffix(".out3.swf")
 
     for dtype in [
         np.uint8,

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -21,9 +21,9 @@ def mean(x):
 
 
 @pytest.mark.needs_internet
-def test_format_selection(test_dir):
+def test_format_selection(tmp_path):
 
-    fname1 = get_remote_file("images/stent.swf", test_dir)
+    fname1 = get_remote_file("images/stent.swf", tmp_path)
     fname2 = fname1[:-4] + ".out.swf"
 
     F = imageio.formats["swf"]
@@ -35,9 +35,9 @@ def test_format_selection(test_dir):
 
 
 @pytest.mark.needs_internet
-def test_reading_saving(test_dir):
+def test_reading_saving(tmp_path):
 
-    fname1 = get_remote_file("images/stent.swf", test_dir)
+    fname1 = get_remote_file("images/stent.swf", tmp_path)
     fname2 = fname1[:-4] + ".out.swf"
     fname3 = fname1[:-4] + ".compressed.swf"
     fname4 = fname1[:-4] + ".out2.swf"
@@ -125,7 +125,7 @@ def test_reading_saving(test_dir):
         fname4,
     )
 
-    with open(os.path.join(test_dir, "test_swf.html"), "wb") as f:
+    with open(os.path.join(tmp_path, "test_swf.html"), "wb") as f:
         for line in html.splitlines():
             f.write(line.strip().encode("utf-8") + b"\n")
 
@@ -141,9 +141,9 @@ def test_read_from_url():
 
 
 @pytest.mark.needs_internet
-def test_invalid(test_dir):
+def test_invalid(tmp_path):
 
-    fname1 = get_remote_file("images/stent.swf", test_dir)
+    fname1 = get_remote_file("images/stent.swf", tmp_path)
     fname2 = fname1[:-4] + ".invalid.swf"
 
     # Empty file
@@ -185,9 +185,9 @@ def test_lowlevel():
 
 
 @pytest.mark.needs_internet
-def test_types(test_dir):
+def test_types(tmp_path):
 
-    fname1 = get_remote_file("images/stent.swf", test_dir)
+    fname1 = get_remote_file("images/stent.swf", tmp_path)
     fname2 = fname1[:-4] + ".out3.swf"
 
     for dtype in [

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -54,8 +54,11 @@ def test_reading_saving(tmp_path):
     # Seek
     assert (R.get_data(3) == ims1[3]).all()
     # Fails
-    pytest.raises(IndexError, R.get_data, -1)  # No negative index
-    pytest.raises(IndexError, R.get_data, 10)  # Out of bounds
+    with pytest.raises(IndexError):
+        R.get_data(-1)  # No negative index
+
+    with pytest.raises(IndexError):
+        R.get_data(10)  # Out of bounds
     R.close()
 
     # Test loop
@@ -125,7 +128,7 @@ def test_reading_saving(tmp_path):
         fname4,
     )
 
-    with open(os.path.join(tmp_path, "test_swf.html"), "wb") as f:
+    with open(tmp_path / "test_swf.html", "wb") as f:
         for line in html.splitlines():
             f.write(line.strip().encode("utf-8") + b"\n")
 
@@ -150,13 +153,15 @@ def test_invalid(tmp_path):
     with open(fname2, "wb"):
         pass
     assert not imageio.formats.search_read_format(core.Request(fname2, "rI"))
-    pytest.raises(RuntimeError, imageio.mimread, fname2, "swf")
+    with pytest.raises(RuntimeError):
+        imageio.mimread(fname2, "swf")
 
     # File with BS data
     with open(fname2, "wb") as f:
         f.write(b"x" * 100)
     assert not imageio.formats.search_read_format(core.Request(fname2, "rI"))
-    pytest.raises(RuntimeError, imageio.mimread, fname2, "swf")
+    with pytest.raises(RuntimeError):
+        imageio.mimread(fname2, "swf")
 
 
 @pytest.mark.needs_internet
@@ -166,7 +171,8 @@ def test_lowlevel():
     # by using the plugin itself.
     _swf = imageio.plugins.swf.load_lib()
     tag = _swf.Tag()
-    pytest.raises(NotImplementedError, tag.process_tag)
+    with pytest.raises(NotImplementedError):
+        tag.process_tag()
     assert tag.make_matrix_record() == "00000000"
     assert tag.make_matrix_record(scale_xy=(1, 1))
     assert tag.make_matrix_record(rot_xy=(1, 1))

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -14,9 +14,9 @@ def mean(x):
     return x.sum() / x.size  # pypy-compat mean
 
 
-def test_format_selection(image_cache):
+def test_format_selection(test_images):
 
-    fname1 = image_cache / "images" / "stent.swf"
+    fname1 = test_images / "stent.swf"
     fname2 = fname1.with_suffix(".out.swf")
 
     F = imageio.formats["swf"]
@@ -27,9 +27,9 @@ def test_format_selection(image_cache):
     assert type(imageio.save(fname2).format) is type(F)
 
 
-def test_reading_saving(image_cache, tmp_path):
+def test_reading_saving(test_images, tmp_path):
 
-    fname1 = image_cache / "images" / "stent.swf"
+    fname1 = test_images / "stent.swf"
     fname2 = fname1.with_suffix(".out.swf")
     fname3 = fname1.with_suffix(".compressed.swf")
     fname4 = fname1.with_suffix(".out2.swf")
@@ -135,9 +135,9 @@ def test_read_from_url():
     assert len(ims) == 10
 
 
-def test_invalid(image_cache):
+def test_invalid(test_images):
 
-    fname1 = image_cache / "images" / "stent.swf"
+    fname1 = test_images / "stent.swf"
     fname2 = fname1.with_suffix(".invalid.swf")
 
     # Empty file
@@ -181,9 +181,9 @@ def test_lowlevel():
     )
 
 
-def test_types(image_cache):
+def test_types(test_images):
 
-    fname1 = image_cache / "images" / "stent.swf"
+    fname1 = test_images / "stent.swf"
     fname2 = fname1.with_suffix(".out3.swf")
 
     for dtype in [

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -1,8 +1,6 @@
 """ Tests for the shockwave flash plugin
 """
 
-import os
-
 import numpy as np
 
 import pytest

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -22,12 +22,12 @@ def test_tifffile_format():
 
 
 @pytest.mark.needs_internet
-def test_tifffile_reading_writing(test_dir):
+def test_tifffile_reading_writing(tmp_path):
     """Test reading and saving tiff"""
 
     im2 = np.ones((10, 10, 3), np.uint8) * 2
 
-    filename1 = os.path.join(test_dir, "test_tiff.tiff")
+    filename1 = os.path.join(tmp_path, "test_tiff.tiff")
 
     # One image
     imageio.imsave(filename1, im2)
@@ -82,7 +82,7 @@ def test_tifffile_reading_writing(test_dir):
     pytest.raises(IndexError, R.get_data, 3)
 
     # Ensure imread + imwrite works round trip
-    filename3 = os.path.join(test_dir, "test_tiff2.tiff")
+    filename3 = os.path.join(tmp_path, "test_tiff2.tiff")
     im1 = imageio.imread(filename1)
     imageio.imwrite(filename3, im1)
     im3 = imageio.imread(filename3)
@@ -91,7 +91,7 @@ def test_tifffile_reading_writing(test_dir):
     assert (im1 == im3).all()
 
     # Ensure imread + imwrite works round trip - volume like
-    filename3 = os.path.join(test_dir, "test_tiff2.tiff")
+    filename3 = os.path.join(tmp_path, "test_tiff2.tiff")
     im1 = np.stack(imageio.mimread(filename1))
     imageio.volwrite(filename3, im1)
     im3 = imageio.volread(filename3)

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 import pytest
-from imageio.core import get_remote_file
 import imageio
 import imageio as iio
 
@@ -20,8 +19,7 @@ def test_tifffile_format():
         assert format.name == "TIFF"
 
 
-@pytest.mark.needs_internet
-def test_tifffile_reading_writing(tmp_path):
+def test_tifffile_reading_writing(image_cache, tmp_path):
     """Test reading and saving tiff"""
 
     im2 = np.ones((10, 10, 3), np.uint8) * 2
@@ -57,7 +55,7 @@ def test_tifffile_reading_writing(tmp_path):
         assert (vol[i] == im2).all()
 
     # remote channel-first volume rgb (2, 3, 10, 10)
-    filename2 = get_remote_file("images/multipage_rgb.tif")
+    filename2 = image_cache / "images" / "multipage_rgb.tif"
     img = imageio.mimread(filename2)
     assert len(img) == 2
     assert img[0].shape == (3, 10, 10)

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -1,7 +1,6 @@
 """ Test tifffile plugin functionality.
 """
 
-import os
 import datetime
 import numpy as np
 import pytest

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -6,15 +6,12 @@ import datetime
 import numpy as np
 import pytest
 
-from pytest import raises
-from imageio.testing import run_tests_if_main, get_test_dir, need_internet
+import pytest
 from imageio.core import get_remote_file
 import imageio
 import imageio as iio
-import tifffile
 
-
-test_dir = get_test_dir()
+pytest.importorskip("tifffile", reason="tifffile is not installed")
 
 
 def test_tifffile_format():
@@ -24,10 +21,9 @@ def test_tifffile_format():
         assert format.name == "TIFF"
 
 
-def test_tifffile_reading_writing():
+@pytest.mark.needs_internet
+def test_tifffile_reading_writing(test_dir):
     """Test reading and saving tiff"""
-
-    need_internet()  # We keep a test image in the imageio-binary repo
 
     im2 = np.ones((10, 10, 3), np.uint8) * 2
 
@@ -82,8 +78,8 @@ def test_tifffile_reading_writing():
     # meta = R.get_meta_data()
     # assert meta['orientation'] == 'top_left'  # not there in later version
     # Fail
-    raises(IndexError, R.get_data, -1)
-    raises(IndexError, R.get_data, 3)
+    pytest.raises(IndexError, R.get_data, -1)
+    pytest.raises(IndexError, R.get_data, 3)
 
     # Ensure imread + imwrite works round trip
     filename3 = os.path.join(test_dir, "test_tiff2.tiff")
@@ -134,6 +130,8 @@ def test_tifffile_reading_writing():
 
 def test_imagej_hyperstack(tmp_path):
     # create artifical hyperstack
+    import tifffile
+
     tifffile.imwrite(
         tmp_path / "hyperstack.tiff",
         np.zeros((15, 2, 180, 183), dtype=np.uint8),
@@ -171,6 +169,3 @@ def test_read_bytes(tmp_path):
 
     some_bytes = iio.imwrite("<bytes>", [[0]], format="tiff")
     assert some_bytes is not None
-
-
-run_tests_if_main()

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -78,7 +78,7 @@ def test_tifffile_reading_writing(tmp_path):
     # meta = R.get_meta_data()
     # assert meta['orientation'] == 'top_left'  # not there in later version
     # Fail
-    with pytest.raises(IndexError)
+    with pytest.raises(IndexError):
         R.get_data(-1)
 
     with pytest.raises(IndexError):

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -27,7 +27,7 @@ def test_tifffile_reading_writing(tmp_path):
 
     im2 = np.ones((10, 10, 3), np.uint8) * 2
 
-    filename1 = os.path.join(tmp_path, "test_tiff.tiff")
+    filename1 = tmp_path / "test_tiff.tiff"
 
     # One image
     imageio.imsave(filename1, im2)
@@ -78,11 +78,14 @@ def test_tifffile_reading_writing(tmp_path):
     # meta = R.get_meta_data()
     # assert meta['orientation'] == 'top_left'  # not there in later version
     # Fail
-    pytest.raises(IndexError, R.get_data, -1)
-    pytest.raises(IndexError, R.get_data, 3)
+    with pytest.raises(IndexError)
+        R.get_data(-1)
+
+    with pytest.raises(IndexError):
+        R.get_data(3)
 
     # Ensure imread + imwrite works round trip
-    filename3 = os.path.join(tmp_path, "test_tiff2.tiff")
+    filename3 = tmp_path / "test_tiff2.tiff"
     im1 = imageio.imread(filename1)
     imageio.imwrite(filename3, im1)
     im3 = imageio.imread(filename3)
@@ -91,7 +94,7 @@ def test_tifffile_reading_writing(tmp_path):
     assert (im1 == im3).all()
 
     # Ensure imread + imwrite works round trip - volume like
-    filename3 = os.path.join(tmp_path, "test_tiff2.tiff")
+    filename3 = tmp_path / "test_tiff2.tiff"
     im1 = np.stack(imageio.mimread(filename1))
     imageio.volwrite(filename3, im1)
     im3 = imageio.volread(filename3)

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -9,7 +9,7 @@ import pytest
 import imageio
 import imageio as iio
 
-pytest.importorskip("tifffile", reason="tifffile is not installed")
+tifffile = pytest.importorskip("tifffile", reason="tifffile is not installed")
 
 
 def test_tifffile_format():
@@ -130,7 +130,6 @@ def test_tifffile_reading_writing(image_cache, tmp_path):
 
 def test_imagej_hyperstack(tmp_path):
     # create artifical hyperstack
-    import tifffile
 
     tifffile.imwrite(
         tmp_path / "hyperstack.tiff",

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -5,7 +5,6 @@ import datetime
 import numpy as np
 import pytest
 
-import pytest
 import imageio
 import imageio as iio
 
@@ -19,7 +18,7 @@ def test_tifffile_format():
         assert format.name == "TIFF"
 
 
-def test_tifffile_reading_writing(image_cache, tmp_path):
+def test_tifffile_reading_writing(test_images, tmp_path):
     """Test reading and saving tiff"""
 
     im2 = np.ones((10, 10, 3), np.uint8) * 2
@@ -55,7 +54,7 @@ def test_tifffile_reading_writing(image_cache, tmp_path):
         assert (vol[i] == im2).all()
 
     # remote channel-first volume rgb (2, 3, 10, 10)
-    filename2 = image_cache / "images" / "multipage_rgb.tif"
+    filename2 = test_images / "multipage_rgb.tif"
     img = imageio.mimread(filename2)
     assert len(img) == 2
     assert img[0].shape == (3, 10, 10)


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/700

This PR includes the following changes:

* replace the use of `need_internet()` by a marker, called `needs_internet`.  All tests that require internet access can now be easily skipped with `pytest -m 'not needs_internet'`.  Please note that, during testing, the environment variable `IMAGEIO_NO_INTERNET` is not required anymore, but that is still used by `imageio.core.fetching`.  I'm not sure it is still relevant.
* make `get_test_dir()/clean_test_dir()` into a proper fixture, and add it to `tests/conftest.py`, ensure that all test units that require that to be setup explicitly invoke that fixture
* remove `run_tests_if_main()` from `imageio.testing`.  You may call `pytest` by hand to achieve the same effect.  Default options may go into a `pyproject.toml` if they wish to be preserved (however I did not do this in this PR)
* cleanup unused modules in some tests
* use `pytest.importorskip` to skip modules that require specific python libraries to be installed.  This is the case for osgeo/gdal, astropy, tifffile and imageio-ffmpeg.
* only execute `tests/test_ffmpeg.py` if psutil is also installed.
* replace global setup functions by equivalent test fixtures (e.g. `tests/test_dicom.py`)
* pass Black through out all touched files
* no tests require `imageio.testing` anymore, however, I left the file there since some of the CD/CI pipelines use this via invoke?  (I'm not sure of this, however, I think it would be cleaner if the `pytest` command-line appeared directly on these YAML files, so it serves as an example of how the package should be tested.

To run tests, you can simply do:

```sh
$ pytest -sv tests/
```

Tests that need running should be automatically detected, except the internet access.

To see what is skipped (and the reason) in a more explicit way, do:

```sh
$ pytest -sv -rs tests/
```

To suppress all tests that require internet access, just do:

```sh
$ pytest -sv -m 'not needs_internet' tests/
```