### PR TITLE
Fix issue 697: close standard streams properly, using sp.run

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -231,8 +231,12 @@ class FfmpegFormat(Format):
                 # using `-list_devices` (or `-list_options`), even if the
                 # command is successful, so we set `check=False` explicitly.
                 completed_process = sp.run(
-                    cmd, stdout=sp.PIPE, stderr=sp.PIPE, encoding="utf-8",
-                    shell=True, check=False
+                    cmd,
+                    stdout=sp.PIPE,
+                    stderr=sp.PIPE,
+                    encoding="utf-8",
+                    shell=True,
+                    check=False,
                 )
 
                 # Return device name at index

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -231,8 +231,8 @@ class FfmpegFormat(Format):
                 # using `-list_devices` (or `-list_options`), even if the
                 # command is successful, so we set `check=False` explicitly.
                 completed_process = sp.run(
-                    cmd, capture_output=True, encoding="utf-8", shell=True,
-                    check=False)
+                    cmd, capture_output=True, encoding="utf-8", shell=True, check=False
+                )
 
                 # Return device name at index
                 try:

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -231,7 +231,8 @@ class FfmpegFormat(Format):
                 # using `-list_devices` (or `-list_options`), even if the
                 # command is successful, so we set `check=False` explicitly.
                 completed_process = sp.run(
-                    cmd, capture_output=True, encoding="utf-8", shell=True, check=False
+                    cmd, stdout=sp.PIPE, stderr=sp.PIPE, encoding="utf-8",
+                    shell=True, check=False
                 )
 
                 # Return device name at index

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -576,15 +576,16 @@ def test_webcam_resource_warnings():
     except IndexError:
         skip("no webcam")
 
-    # todo: remove this part when imageio_ffmpeg issue #61 has been fixed
     import imageio_ffmpeg
 
     if imageio_ffmpeg.__version__ == "0.4.5":
-        assert len(warnings) == 1
-        assert "unclosed file" in str(warnings[0].message)
+        # We still expect imagio_ffmpeg 0.4.5 to generate (at most) one warning.
+        # todo: remove this assertion when a fix for imageio_ffmpeg issue #61
+        #  has been released
+        assert len(warnings) < 2
         return
 
-    # there should not be any warnings, but show warning messages if there are
+    # There should not be any warnings, but show warning messages if there are.
     assert not [w.message for w in warnings]
 
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -572,6 +572,14 @@ def test_webcam_resource_warnings():
     with warns(None) as warnings:
         with imageio.get_reader("<video0>"):
             pass
+
+    # todo: remove this part when imageio_ffmpeg issue #61 has been fixed
+    import imageio_ffmpeg
+    if imageio_ffmpeg.__version__ == "0.4.5":
+        assert len(warnings) == 1
+        assert 'unclosed file' in str(warnings[0].message)
+        return
+
     # there should not be any warnings, but show warning messages if there are
     assert not [w.message for w in warnings]
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -565,12 +565,15 @@ def test_webcam_resource_warnings():
     """
     Test for issue #697. Ensures that ffmpeg Reader standard streams are
     properly closed by checking for ResourceWarning "unclosed file".
+
+    todo: use pytest.does_not_warn() as soon as it becomes available
+     (see https://github.com/pytest-dev/pytest/issues/9404)
     """
-    with warns(ResourceWarning, match="unclosed file") as resource_warnings:
+    with warns(None) as warnings:
         with imageio.get_reader("<video0>"):
             pass
     # there should not be any warnings, but show warning messages if there are
-    assert not [w.message for w in resource_warnings]
+    assert not [w.message for w in warnings]
 
 
 def show_in_console():

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -13,7 +13,7 @@ import psutil
 
 import numpy as np
 
-from pytest import raises, skip
+from pytest import raises, skip, warns
 from imageio.testing import run_tests_if_main, get_test_dir
 
 import imageio
@@ -559,6 +559,18 @@ def test_webcam_process_termination():
         assert not get_ffmpeg_pids().difference(pids0)
     except IndexError:
         skip("no webcam")
+
+
+def test_webcam_resource_warnings():
+    """
+    Test for issue #697. Ensures that ffmpeg Reader standard streams are
+    properly closed by checking for ResourceWarning "unclosed file".
+    """
+    with warns(ResourceWarning, match="unclosed file") as resource_warnings:
+        with imageio.get_reader("<video0>"):
+            pass
+    # there should not be any warnings, but show warning messages if there are
+    assert not [w.message for w in resource_warnings]
 
 
 def show_in_console():

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -575,9 +575,10 @@ def test_webcam_resource_warnings():
 
     # todo: remove this part when imageio_ffmpeg issue #61 has been fixed
     import imageio_ffmpeg
+
     if imageio_ffmpeg.__version__ == "0.4.5":
         assert len(warnings) == 1
-        assert 'unclosed file' in str(warnings[0].message)
+        assert "unclosed file" in str(warnings[0].message)
         return
 
     # there should not be any warnings, but show warning messages if there are

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -569,9 +569,12 @@ def test_webcam_resource_warnings():
     todo: use pytest.does_not_warn() as soon as it becomes available
      (see https://github.com/pytest-dev/pytest/issues/9404)
     """
-    with warns(None) as warnings:
-        with imageio.get_reader("<video0>"):
-            pass
+    try:
+        with warns(None) as warnings:
+            with imageio.get_reader("<video0>"):
+                pass
+    except IndexError:
+        skip("no webcam")
 
     # todo: remove this part when imageio_ffmpeg issue #61 has been fixed
     import imageio_ffmpeg


### PR DESCRIPTION
This should fix issue #697.

The test has a temporary workaround, which could be removed after the acceptance of https://github.com/imageio/imageio-ffmpeg/pull/62 and subsequent release. Not sure how you would like to handle that.