### PR TITLE
DOC: update download tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/imageio.svg)](https://pypi.python.org/pypi/imageio/)
 [![PyPI Version](https://img.shields.io/pypi/v/imageio.svg)](https://pypi.python.org/pypi/imageio/)
-[![PyPi Download stats](http://pepy.tech/badge/imageio)](http://pepy.tech/project/imageio)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/imageio?color=blue)](https://pypistats.org/packages/imageio)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4972048.svg)](https://doi.org/10.5281/zenodo.4972048)
 
 


### PR DESCRIPTION
Looks like the pepy download tracker doesn't count downloads anymore :( This PR switches it to pypistats. It only supports monthly downloads, but I think that >10M/month a decent enough alternative to show as well :D