### PR TITLE
MAINT: update tested pypy versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.6", "pypy-3.7"]
+        pyversion: ["pypy-3.7", "pypy-3.8"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up pypy

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Set up pypy
         uses: actions/setup-python@v2
         with:
-          python-version: "pypy3"
+          python-version: "${{ matrix.pyversion }}"
       - name: MacOS Numpy Fix
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.6", "pypy-3.7"]
+        pyversion: ["pypy-3.7", "pypy-3.8"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up pypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Set up pypy
         uses: actions/setup-python@v2
         with:
-          python-version: "pypy3"
+          python-version: "${{ matrix.pyversion }}"
       - name: MacOS Numpy Fix
         if: runner.os == 'macOS'
         run: |


### PR DESCRIPTION
I first encountered this in #705 ; however, it is unrelated to that PR.

Turns out pypy-3.6 is depreciated and can no longer be downloaded from the official pypy website. Further, the macos target of GH Actions doesn't come with it preinstalled, and will break if `setup-python` tries to configure it.

This PR addresses that by rotating the pypy versions we test/target to pypy-3.7 and pypy-3.8 respectively.