### PR TITLE
BUG: clean up PillowPlugin destructor

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -125,7 +125,14 @@ class PillowPlugin(object):
                     # compatible pillow plugin (ref: the pillow docs).
                     pass
             except UnidentifiedImageError:
-                raise InitializationError(f"Pillow can not read {request}.") from None
+                if request._uri_type == URI_BYTES:
+                    raise InitializationError(
+                        f"Pillow can not read the provided bytes."
+                    ) from None
+                else:
+                    raise InitializationError(
+                        f"Pillow can not read {request.raw_uri}."
+                    ) from None
         else:
             # it would be nice if pillow would expose a
             # function to check if an extension can be written

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -130,7 +130,7 @@ class PillowPlugin(object):
             except UnidentifiedImageError:
                 if request._uri_type == URI_BYTES:
                     raise InitializationError(
-                        f"Pillow can not read the provided bytes."
+                        "Pillow can not read the provided bytes."
                     ) from None
                 else:
                     raise InitializationError(

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -117,6 +117,9 @@ class PillowPlugin(object):
 
         """
 
+        self._request = request
+        self._image = None
+
         if request.mode.io_mode == IOMode.read:
             try:
                 with Image.open(request.get_file()):
@@ -153,11 +156,8 @@ class PillowPlugin(object):
                     f"Pillow can not write `{request.extension}` files"
                 ) from None
 
-        self._request = request
         if self._request.mode.io_mode == IOMode.read:
             self._image = Image.open(self._request.get_file())
-        else:
-            self._image = None
 
     def close(self):
         if self._image:

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -493,3 +493,14 @@ def test_write_jpg_to_bytes_io():
 
     image_from_file = iio.v3.imread(bytes_io, plugin="pillow")
     assert np.allclose(image_from_file, image)
+
+
+def test_initialization_failure(image_files: Path):
+    test_image = b"this is not an image and will break things."
+
+    with pytest.raises(OSError):
+        iio.v3.imread(test_image, plugin="pillow")
+
+    with pytest.raises(OSError):
+        # pillow can not handle npy
+        iio.v3.imread(test_image / "chelsea_jpg.npy", plugin="pillow")

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -503,4 +503,4 @@ def test_initialization_failure(image_files: Path):
 
     with pytest.raises(OSError):
         # pillow can not handle npy
-        iio.v3.imread(test_image / "chelsea_jpg.npy", plugin="pillow")
+        iio.v3.imread(image_files / "chelsea_jpg.npy", plugin="pillow")


### PR DESCRIPTION
I was looking through the files in https://github.com/imageio/imageio/issues/708 and noticed that the v3 PillowPlugin can produce a warning/exception in the deconstructor. For me, this happened when the plugin was called with invalid arguments (and hence wasn't constructed properly). This PR addresses this and also streamlines one error message.