### PR TITLE
MAINT: reduce release frequency to weekly

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ name: CD
 
 on:
   schedule:
-    - cron: '42 1 * * *' # daily at 1:42am (UTC)
+    - cron: '42 1 * * 1' # weekly on Monday at 1:42am (UTC)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Related to: https://github.com/imageio/imageio/issues/715

This is the first step to closing the above-mentioned issue. It reduces the frequency with which we check for release-worthy changes in the repo from once a day to once a week.