### PR TITLE
DOC: v3 API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ imageio/lib
 docs/_build
 docs/reference/_backends
 docs/reference/_core_29
+docs/reference/_core_v3
 tests/zipped
 tests/freezing/frozen
 imageio/resources/images

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -325,15 +325,18 @@ To develop a new plugin, you can start off with a simple def install::
 To write a new plugin, you have to create a new class that follows our plugin
 API, which is documented below:
 
+**v2 plugin docs**
 .. autosummary::
 
     imageio.plugins
 
+**v3 plugin docs**
 .. autosummary::
     :template: better_class.rst
     :toctree: ../_autosummary
 
     imageio.core.v3_plugin_api.PluginV3
+    imageio.core.v3_plugin_api.ImageProperties
 
 The file itself should be placed into our plugins folder at
 ``imageio\plugins\your_plugin.py``.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -326,11 +326,13 @@ To write a new plugin, you have to create a new class that follows our plugin
 API, which is documented below:
 
 **v2 plugin docs**
+
 .. autosummary::
 
     imageio.plugins
 
 **v3 plugin docs**
+
 .. autosummary::
     :template: better_class.rst
     :toctree: ../_autosummary

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -17,18 +17,18 @@ Probably the most important thing you'll ever need.
 
 .. code-block:: python
 
-    import imageio as iio
+    import imageio.v3 as iio
 
-    im = iio.v3.imread('imageio:chelsea.png')
+    im = iio.imread('imageio:chelsea.png')
     print(im.shape)  # (300, 451, 3)
     
 If the image is a GIF:
 
 .. code-block:: python
 
-    import imageio as iio
+    import imageio.v3 as iio
     
-    frames = iio.v3.imread("newtonscradle.gif", index=None)
+    frames = iio.imread("imageio:newtonscradle.gif", index=None)
     # ndarray with (num_frames, height, width, channel)
     print(frames.shape)  # (36, 150, 200, 3)
     
@@ -36,14 +36,13 @@ If the GIF is stored in memory:
 
 .. code-block:: python
 
-    import imageio as iio
-    from pathlib import Path
+    import imageio.v3 as iio
 
-    # setup
-    image_path = iio.core.get_remote_file("images/newtonscradle.gif") 
-    bytes_image = Path(image_path).read_bytes()
+    # create bytes containing an encoded GIF
+    frames = iio.imread("imageio:newtonscradle.gif", index=None)
+    bytes_image = iio.imwrite("<bytes>", frames, format_hint=".gif")
     
-    # the actual reading
+    # read GIF from bytes
     frames = iio.v3.imread(bytes_image, index=None)
     
 
@@ -54,38 +53,30 @@ Imageio can read from filenames, file objects, http, zipfiles and bytes.
 
 .. code-block:: python
 
-    import imageio as iio
+    import imageio.v3 as iio
     import matplotlib.pyplot as plt
 
-    im = iio.v3.imread('http://upload.wikimedia.org/wikipedia/commons/d/de/Wikipedia_Logo_1.0.png')
+    im = iio.imread('http://upload.wikimedia.org/wikipedia/commons/d/de/Wikipedia_Logo_1.0.png')
     plt.imshow(im, cmap="gray")
     plt.show()
-
-Note: reading from HTTP and zipfiles works for many formats including png and
-jpeg, but may not work for all formats (some plugins "seek" the file object,
-which HTTP/zip streams do not support). In such a case one can download/extract
-the file first. For HTTP one can use something like
-``imageio.imread(imageio.core.urlopen(url).read(), '.gif')``.
 
 Read all Images in a Folder
 ---------------------------
 
-One common scenario is that you want to read all images in a folder, e.g. for a
-scientific analysis, or because these are all your training examples. Assuming
-the folder only contains image files, you can read it using a snippet like
-
 .. code-block:: python
 
-    import imageio as iio
+    import imageio.v3 as iio
     from pathlib import Path
 
     images = list()
     for file in Path("path/to/folder").iterdir():
-        im = iio.v3.imread(file)
-        images.append(im)
+        if not file.is_file():
+            continue
 
-Note, however, that ``Path().iterdir()`` does not make any guarantees about the
-order in which files are read.
+        images.append(iio.v3.imread(file))
+
+Note, however, that ``Path().iterdir()`` does not guarantees the order in which
+files are read.
 
 
 Iterate over frames in a movie
@@ -93,9 +84,9 @@ Iterate over frames in a movie
 
 .. code-block:: python
 
-    import imageio as iio
+    import imageio.v3 as iio
 
-    for i, frame in enumerate(iio.v3.imiter("imageio:cockatoo.mp4")):
+    for i, frame in enumerate(iio.imiter("imageio:cockatoo.mp4")):
         print("Mean of frame %i is %1.1f" % (i, frame.mean()))
 
 

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -8,13 +8,15 @@ Core API v3
     For migration instructions from the v2 API check :ref:`our migration guide
     <migration_from_v2>`.
 
-These functions represent imageio's main interface for the user. They
-provide a common API to read and write image data for a large
-variety of formats. All read and write functions accept keyword
-arguments, which are passed on to the backend that does the actual work.
+This API provides a functional interface to all of ImageIOs backends. It is
+split into two parts: :ref:`Everyday Usage <v3_basic_usage>` and :ref:`Advanced
+Usage <v3_advanced_usage>`. The first part (everyday usage) focusses on sensible
+defaults and automation to cover everyday tasks such as plain reading or writing
+of images. The second part (advanced usage) focusses on providing fully-featured
+and performant access to all the a particular backend.
 
-API at a Glance
----------------
+API Overview
+------------
 
 .. autosummary::
     :toctree: _core_v3/
@@ -23,15 +25,94 @@ API at a Glance
     imageio.core.v3_api.imwrite
     imageio.core.v3_api.imiter
 
+.. _v3_basic_usage:
 
-Reading
--------
+Everyday Usage
+--------------
 
-Writing
--------
+Most of the time, the image-related IO we wish to perform can be described as "I
+want to load X as a numpy array.", or "I want to save my array as a XYZ file".
+This should not be complicated, and it is, in fact, as simple as calling the
+corresponding function::
 
-Metadata
---------
+    import imageio as iio
+
+    # reading:
+    img = iio.v3.imread("imageio:chelsea.png")
+    
+    # writing:
+    iio.v3.imwrite("out_image.jpg", img)
+
+Both functions accept any :doc:`ImageResource <../getting_started/requests>` as
+their first argument, which means we can read/write almost anything image
+related; from simple JPGs through ImageJ hyperstacks to MP4 video or various
+niche RAW formats.
+
+If we do need to customize or tweak this process we can pass additional keyword
+arguments (`kwargs`) to overwrite any defaults ImageIO uses when reading or writing.
+The two `kwargs` that are always available are:
+
+- ``plugin``: The name of the plugin to use for reading/writing.
+- ``index`` (reading only): The index of the ndimage to read, if the format
+  supports storing more than one (GIF, multi-page TIFF, video, etc.).
+
+Additional `kwargs` are specific to the plugin being used and we can find a list
+of available ones in the documentation of the specific plugin (where they
+are called parameters). A list of all available plugins can be found :ref:`here
+<supported_backends>`.
+
+.. _v3_advanced_usage:
 
 Advanced Usage
 --------------
+
+Iterating Video and Multi-Page Formats
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some formats (GIF, MP4, TIFF, among others) allow storage of more than one
+ndimage in the same file, and often we wish to do processing on all ndimages in
+such a file instead of just a single one. While :func:`iio.v3.imread(...,
+index=None) <imageio.core.v3_api.imread>` allows us to read all ndimages and
+stack them into a ndarray, this comes with two problems:
+
+- Some formats (e.g., SPE or TIFF) allow multiple ndimages with different shapes
+  in the same file, which prevents stacking.
+- Some files (especially video) are
+  too big to fit into memory when loaded all at once.
+
+To address this problem, the v3 API introduces :func:`iio.v3.imiter
+<imageio.core.v3_api.imiter>`, a generator yielding ndimages in the order in
+which they appear in the file::
+
+    import imageio as iio
+
+    for frame in iio.v3.imiter("imageio:cockatoo.mp4"):
+        pass # do something with the current frame
+
+Just like imread, imiter accepts additional `kwargs` to overwrite any defaults used by ImageIO.
+
+Low-Level Access
+^^^^^^^^^^^^^^^^
+
+Sometimes we may wish for low-level access to a plugin or file, for example, because
+
+- we wish to have fine-grained control over when it is opened/closed.
+- we need to perform multiple IO operations and don't want to open the file multiple times.
+- a plugin/backend offers unique features not otherwise exposed by the v3 API.
+
+For these cases, the v3 API offers :func:`iio.v3.imopen
+<imageio.core.imopen.imopen>`. It provides a context managed that initializes
+the plugin and openes the file for reading (``"r"``) or writing (``"w"``),
+similar to the built-in ``open``::
+
+    import imageio as iio
+
+    with iio.v3.imopen("imageio:chelsea.png", "r") as iio_plugin:
+        img = iio_plugin.read()
+        metadata = iio_plugin.get_meta()
+        # iio_plugin.plugin_specific_function()
+
+Similar to above, you can pass the ``plugin`` `kwarg` to imopen to control the
+plugin that is being used. The returned plugin instance (`iio_plugin`) exposes
+the v3 plugin API (TODO: link to documentation), and can be used for low-level
+access.

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -31,25 +31,25 @@ API Overview
 Everyday Usage
 --------------
 
-Most of the time, the image-related IO we wish to perform can be described as "I
+Frequently, the image-related IO you wish to perform can be summarized as "I
 want to load X as a numpy array.", or "I want to save my array as a XYZ file".
 This should not be complicated, and it is, in fact, as simple as calling the
 corresponding function::
 
-    import imageio as iio
+    import imageio.v3 as iio
 
     # reading:
-    img = iio.v3.imread("imageio:chelsea.png")
+    img = iio.imread("imageio:chelsea.png")
     
     # writing:
-    iio.v3.imwrite("out_image.jpg", img)
+    iio.imwrite("out_image.jpg", img)
 
 Both functions accept any :doc:`ImageResource <../getting_started/requests>` as
-their first argument, which means we can read/write almost anything image
+their first argument, which means you can read/write almost anything image
 related; from simple JPGs through ImageJ hyperstacks to MP4 video or various
 niche RAW formats.
 
-If we do need to customize or tweak this process we can pass additional keyword
+If you do need to customize or tweak this process you can pass additional keyword
 arguments (`kwargs`) to overwrite any defaults ImageIO uses when reading or
 writing. The two `kwargs` that are always available are:
 
@@ -57,10 +57,11 @@ writing. The two `kwargs` that are always available are:
 - ``index`` (reading only): The index of the ndimage to read, if the format
   supports storing more than one (GIF, multi-page TIFF, video, etc.).
 
-Additional `kwargs` are specific to the plugin being used and we can find a list
-of available ones in the documentation of the specific plugin (where they
+Additional `kwargs` are specific to the plugin being used and you can find a
+list of available ones in the documentation of the specific plugin (where they
 are called parameters). A list of all available plugins can be found :ref:`here
-<supported_backends>`.
+<supported_backends>` and you can read more about ``plugin`` and ``index`` in
+the documentation of the respective function.
 
 .. _v3_advanced_usage:
 
@@ -71,47 +72,51 @@ Iterating Video and Multi-Page Formats
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Some formats (GIF, MP4, TIFF, among others) allow storage of more than one
-ndimage in the same file, and often we wish to do processing on all ndimages in
-such a file instead of just a single one. While :func:`iio.v3.imread(...,
-index=None) <imageio.core.v3_api.imread>` allows us to read all ndimages and
-stack them into a ndarray, this comes with two problems:
+ndimage in the same file, and you may wish to process all ndimages in such a
+file instead of just a single one. While :func:`iio.imread(..., index=None)
+<imageio.core.v3_api.imread>` allows you to read all ndimages and stack them
+into a ndarray (using `index=None`; check the docs), this comes with two
+problems:
 
 - Some formats (e.g., SPE or TIFF) allow multiple ndimages with different shapes
   in the same file, which prevents stacking.
-- Some files (especially video) are
-  too big to fit into memory when loaded all at once.
+- Some files (especially video) are too big to fit into memory when loaded all
+  at once.
 
-To address this problem, the v3 API introduces :func:`iio.v3.imiter
-<imageio.core.v3_api.imiter>`, a generator yielding ndimages in the order in
+To address these problems, the v3 API introduces :func:`iio.imiter
+<imageio.core.v3_api.imiter>`; a generator yielding ndimages in the order in
 which they appear in the file::
 
-    import imageio as iio
+    import imageio.v3 as iio
 
-    for frame in iio.v3.imiter("imageio:cockatoo.mp4"):
-        pass # do something with the current frame
+    for frame in iio.imiter("imageio:cockatoo.mp4"):
+        pass # do something with each frame
 
 Just like imread, imiter accepts additional `kwargs` to overwrite any defaults
-used by ImageIO.
+used by ImageIO. Like before, the :func:`function-specific documentation
+<imageio.core.v3_api.imiter>` details the `kwargs` that are always present, and
+additional kwargs are plugin specific and documented by the respective plugin.
 
 Low-Level Access
 ^^^^^^^^^^^^^^^^
 
-Sometimes we may wish for low-level access to a plugin or file, for example,
+Sometimes you may wish for low-level access to a plugin or file, for example,
 because:
 
-- we wish to have fine-grained control over when it is opened/closed.
-- we need to perform multiple IO operations and don't want to open the file
+- you wish to have fine-grained control over when it is opened/closed.
+- you need to perform multiple IO operations and don't want to open the file
   multiple times.
-- a plugin/backend offers unique features not otherwise exposed by the v3 API.
+- a plugin/backend offers unique features not otherwise exposed by the
+  high-level API.
 
-For these cases, the v3 API offers :func:`iio.v3.imopen
+For these cases the v3 API offers :func:`iio.v3.imopen
 <imageio.core.imopen.imopen>`. It provides a context manager that initializes
-the plugin and opens the file for reading (``"r"``) or writing (``"w"``),
+the plugin and openes the file for reading (``"r"``) or writing (``"w"``),
 similar to the Python built-in function ``open``::
 
-    import imageio as iio
+    import imageio.v3 as iio
 
-    with iio.v3.imopen("imageio:chelsea.png", "r") as iio_plugin:
+    with iio.imopen("imageio:chelsea.png", "r") as iio_plugin:
         img = iio_plugin.read()
         metadata = iio_plugin.get_meta()
         # iio_plugin.plugin_specific_function()

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -19,7 +19,7 @@ API Overview
 ------------
 
 .. autosummary::
-    :toctree: _core_v3/
+    :toctree: ../_autosummary/
 
     imageio.v3.imread
     imageio.v3.imwrite
@@ -51,7 +51,7 @@ corresponding function::
 
     # (Check the examples section for many more examples.)
 
-Both functions accept any :doc:`ImageResource <../getting_started/requests>` as
+Both functions accept any :doc:`ImageResource <../user_guide/requests>` as
 their first argument, which means you can read/write almost anything image
 related; from simple JPGs through ImageJ hyperstacks to MP4 video or RAW formats.
 Check the :doc:`Supported Formats <../formats/index>` docs for a list of all formats

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -13,7 +13,7 @@ split into two parts: :ref:`Everyday Usage <v3_basic_usage>` and :ref:`Advanced
 Usage <v3_advanced_usage>`. The first part (everyday usage) focusses on sensible
 defaults and automation to cover everyday tasks such as plain reading or writing
 of images. The second part (advanced usage) focusses on providing fully-featured
-and performant access to all the a particular backend.
+and performant access to all the features of a particular backend.
 
 API Overview
 ------------
@@ -97,7 +97,7 @@ Low-Level Access
 ^^^^^^^^^^^^^^^^
 
 Sometimes we may wish for low-level access to a plugin or file, for example,
-because
+because:
 
 - we wish to have fine-grained control over when it is opened/closed.
 - we need to perform multiple IO operations and don't want to open the file
@@ -105,9 +105,9 @@ because
 - a plugin/backend offers unique features not otherwise exposed by the v3 API.
 
 For these cases, the v3 API offers :func:`iio.v3.imopen
-<imageio.core.imopen.imopen>`. It provides a context managed that initializes
-the plugin and openes the file for reading (``"r"``) or writing (``"w"``),
-similar to the built-in ``open``::
+<imageio.core.imopen.imopen>`. It provides a context manager that initializes
+the plugin and opens the file for reading (``"r"``) or writing (``"w"``),
+similar to the Python built-in function ``open``::
 
     import imageio as iio
 

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -24,6 +24,7 @@ API Overview
     imageio.core.v3_api.imread
     imageio.core.v3_api.imwrite
     imageio.core.v3_api.imiter
+    imageio.core.v3_api.imopen
 
 .. _v3_basic_usage:
 

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -76,6 +76,53 @@ the documentation of the respective function (imread/imwrite/etc.).
 Handling Metadata
 ^^^^^^^^^^^^^^^^^
 
+ImageIO serves two types of metadata: ImageProperties and format-specific metadata.
+
+:class:`ImageProperties <imageio.core.v3_plugin_api.ImageProperties>` are a
+collection of standardized metadata fields and are supported by all plugins and
+for all supported formats. If a file doesn't carray the relevat field or if a
+format doesn't support it, its value is set to a sensible default. You can
+access the properties of an image by calling :func:`improps
+<imageio.v3.improps>`::
+
+    import imageio.v3 as iio
+
+    props = iio.improps("imageio:newtonscradle.gif")
+    props.shape
+    props.dtype
+    # ...
+
+As with the other functions of the API, you can pass generally available kwargs
+(`plugin`, `index`, ...) to `improps` to modify the behavior. Plugins may
+specify additional plugin-specific keyword arguments, and those are documented
+in the plugin-specific docs. Further, accessing this metadata is efficient in 
+the sense that it doesn't load (decode) pixel data.
+
+Format-specific metadata is handled by :func:`immeta <imageio.v3.immeta>`::
+
+    import imageio.v3 as iio
+
+    meta = iio.immeta("imageio:newtonscradle.gif")
+
+It returns a dictionary of non-standardized metadata fields. It, too, supports
+general kwargs (`plugin`, `index`, ...) which may be extended by a specific
+plugin. Further, it accepts a kwarg called ``exclude_applied``. If set to True,
+this will remove any items from the dictionary that would be consumed by a read
+call to the plugin. For example, if the metadata sets a rotation flag (the raw
+pixel data should be rotated before displaying it) and the plugin's read call
+will rotate the image because if it, then setting ``expluce_applied=True`` will
+remove the rotation field from the returned metadata. This can be useful to keep
+an image and it's metadata in sync.
+
+Further, this type of metadata is much more specific than ImageProperties
+because different plugins (and formats) may return and support different fields.
+This means that you can get much more specific metadata for a format, e.g., a
+frame's side data in a video format, but you need to be mindful of the plugin
+and format used because these fields may not exist all the time, e.g., jpeg and
+most other image formats have no side data. In general we try to match a fields
+name to the name it has in a format; however, we may adjust this if the name is
+not a valid python string. The best way to know which fields exist for your
+specific ImageResource is to call ``immeta`` on it and inspect the result.
 
 .. _v3_advanced_usage:
 

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -50,8 +50,8 @@ related; from simple JPGs through ImageJ hyperstacks to MP4 video or various
 niche RAW formats.
 
 If we do need to customize or tweak this process we can pass additional keyword
-arguments (`kwargs`) to overwrite any defaults ImageIO uses when reading or writing.
-The two `kwargs` that are always available are:
+arguments (`kwargs`) to overwrite any defaults ImageIO uses when reading or
+writing. The two `kwargs` that are always available are:
 
 - ``plugin``: The name of the plugin to use for reading/writing.
 - ``index`` (reading only): The index of the ndimage to read, if the format
@@ -90,15 +90,18 @@ which they appear in the file::
     for frame in iio.v3.imiter("imageio:cockatoo.mp4"):
         pass # do something with the current frame
 
-Just like imread, imiter accepts additional `kwargs` to overwrite any defaults used by ImageIO.
+Just like imread, imiter accepts additional `kwargs` to overwrite any defaults
+used by ImageIO.
 
 Low-Level Access
 ^^^^^^^^^^^^^^^^
 
-Sometimes we may wish for low-level access to a plugin or file, for example, because
+Sometimes we may wish for low-level access to a plugin or file, for example,
+because
 
 - we wish to have fine-grained control over when it is opened/closed.
-- we need to perform multiple IO operations and don't want to open the file multiple times.
+- we need to perform multiple IO operations and don't want to open the file
+  multiple times.
 - a plugin/backend offers unique features not otherwise exposed by the v3 API.
 
 For these cases, the v3 API offers :func:`iio.v3.imopen

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -13,5 +13,25 @@ provide a common API to read and write image data for a large
 variety of formats. All read and write functions accept keyword
 arguments, which are passed on to the backend that does the actual work.
 
-Migrating from v2
------------------
+API at a Glance
+---------------
+
+.. autosummary::
+    :toctree: _core_v3/
+
+    imageio.core.v3_api.imread
+    imageio.core.v3_api.imwrite
+    imageio.core.v3_api.imiter
+
+
+Reading
+-------
+
+Writing
+-------
+
+Metadata
+--------
+
+Advanced Usage
+--------------

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -1,0 +1,17 @@
+-----------
+Core API v3
+-----------
+
+.. py:currentmodule:: imageio.core.v3_api
+
+.. note::
+    For migration instructions from the v2 API check :ref:`our migration guide
+    <migration_from_v2>`.
+
+These functions represent imageio's main interface for the user. They
+provide a common API to read and write image data for a large
+variety of formats. All read and write functions accept keyword
+arguments, which are passed on to the backend that does the actual work.
+
+Migrating from v2
+-----------------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -10,7 +10,9 @@ advantage of a backend and its unique features.
 Core API
 ^^^^^^^^
 
-The API documented in this section builds on top of the individual plugins.
+The core API is ImageIOs public frontend. It provides convenient (and powerful)
+access to the growing number of individual plugins on top of which ImageIO is
+built.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -7,18 +7,64 @@ such the API is split into two parts: The Core API, which covers standard
 use-cases, and a plugin/backend specific API, which allows you to take full
 advantage of a backend and its unique features.
 
-Core API
-^^^^^^^^
+Core APIs
+^^^^^^^^^
 
 The core API is ImageIOs public frontend. It provides convenient (and powerful)
 access to the growing number of individual plugins on top of which ImageIO is
-built.
+built. Currently the following APIs exist:
 
 .. toctree::
     :maxdepth: 1
 
-    Core API v2 <userapi>
-    Core API v3 <core_v3>
+    Core API v3 (narrative docs) <core_v3>
+    Core API v2 (narrative docs) <userapi>
+
+.. rubric:: Core API v3
+.. note::
+    To use this API import it using::
+
+        import imageio.v3 as iio
+.. note::
+    Check the narrative documentation to build intuition for how to use this API.
+    You can find them here: :doc:`narrative v3 API docs <core_v3>`.
+
+.. autosummary::
+
+    imageio.v3.imread
+    imageio.v3.imiter
+    imageio.v3.improps
+    imageio.v3.immeta
+    imageio.v3.imwrite
+    imageio.v3.imopen
+
+.. rubric:: Core API v2
+.. warning::
+    This API exists for backwards compatibility. It is a wrapper around calls to
+    the v3 API and new code should use the v3 API directly.
+
+.. note::
+    To use this API import it using::
+
+        import imageio.v2 as iio
+
+.. note::
+    Check the narrative documentation to build intuition for how to use this API.
+    You can find them here: :doc:`narrative v2 API docs <userapi>`.
+
+.. autosummary::
+
+    imageio.v2.imread
+    imageio.v2.mimread
+    imageio.v2.volread
+    imageio.v2.mvolread
+    imageio.v2.imwrite
+    imageio.v2.mimwrite
+    imageio.v2.volwrite
+    imageio.v2.mvolwrite
+    imageio.v2.get_reader
+    imageio.v2.get_writer
+
 
 .. _supported_backends:
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,28 +1,33 @@
 API Reference
 =============
 
-ImageIO's API follows the usual idea of choosing sensible defaults for the average use, but giving
-you fine grained control 
+ImageIO's API follows the usual idea of choosing sensible defaults for the
+average user, but giving you fine grained control where you need it. As
+such the API is split into two parts: The Core API, which covers standard
+use-cases, and a plugin/backend specific API, which allows you to take full
+advantage of a backend and its unique features.
 
 Core API (Basic Usage)
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The API documented in this section is shared by all plugins
+The API documented in this section builds on top of the individual plugins.
 
 .. toctree::
     :maxdepth: 1
 
-    Core API v2.9 <userapi>
+    Core API v2 <userapi>
+    Core API v3 <core_v3>
 
 
 Plugins & Backend Libraries (Advanced Usage)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sometimes, you need to do more than just "load an image, done". Sometimes you
-need to use a very specific feature of a very specific backend. ImageIOs allows
+need to use a very specific feature of a very specific backend. ImageIO allows
 you to do so by allowing its plugins to extend the core API. Typically this is
-done in the form of additional keyword arguments (``kwarg``). Below you can find
-a list of available plugins and which arguments they support.
+done in the form of additional keyword arguments (``kwarg``) or plugin-specific
+methods. Below you can find a list of available plugins and which arguments they
+support.
 
 .. autosummary::
     :toctree: ../_autosummary/

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -7,8 +7,8 @@ such the API is split into two parts: The Core API, which covers standard
 use-cases, and a plugin/backend specific API, which allows you to take full
 advantage of a backend and its unique features.
 
-Core API (Basic Usage)
-^^^^^^^^^^^^^^^^^^^^^^
+Core API
+^^^^^^^^
 
 The API documented in this section builds on top of the individual plugins.
 
@@ -18,9 +18,10 @@ The API documented in this section builds on top of the individual plugins.
     Core API v2 <userapi>
     Core API v3 <core_v3>
 
+.. _supported_backends:
 
-Plugins & Backend Libraries (Advanced Usage)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Plugins & Backend Libraries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sometimes, you need to do more than just "load an image, done". Sometimes you
 need to use a very specific feature of a very specific backend. ImageIO allows

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -5,7 +5,7 @@ Core API v2
 .. py:currentmodule:: imageio.v2
 
 .. warning::
-    This API is deprecated and will be superseeded by `the v3 API <core_v3>`
+    This API is deprecated and will be superseeded by :doc:`the v3 API <core_v3>`
     starting with ImageIO v3. Check the migration instructions below for
     detailed information on how to migrate.
 
@@ -79,7 +79,7 @@ that best suits that file-format.
 .. _migration_from_v2:
 
 Migrating to ImageIO v3
------------------------
+^^^^^^^^^^^^^^^^^^^^^^^
 
 The primary novelty of the v3 API compared to the v2 API is that images are now
 treated as ndimages, a generalization of (flat) 2D images to N dimensions. This
@@ -87,7 +87,7 @@ change allows us to design a much simpler API; however, comes with a few
 backwards incompatible changes.
 
 Avoiding API Migration for Legacy Scripts
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------------
 
 If you have an old script where you do not wish to migrate the API, you can
 explicitly import the old v2 API and avoid migration. Note that, while this will
@@ -101,7 +101,7 @@ the v2 API, depending on your script/code, use::
   
 
 Reading Images 
-^^^^^^^^^^^^^^
+--------------
 
 `iio.imread` can now return a ndimage instead of being limited to flat images.
 As such, `iio.volread` has merged into `iio.imread` and is now gone. Similarily,
@@ -128,7 +128,7 @@ snippets::
     img = [im for im in iio.v3.imiter(image_resource)]
 
 Writing Images
-^^^^^^^^^^^^^^
+--------------
 
 Similar to reading images, the new `iio.imwrite` can handle ndimages.
 ``iio.mimwrite``, ``iio.volwrite``, and ``iio.mvolwrite`` have all dissapeared.
@@ -152,7 +152,7 @@ snippets::
     img = iio.v3.imwrite(image_resource, list_of_ndimages)
 
 Reader and Writer
-^^^^^^^^^^^^^^^^^
+-----------------
 
 Plugins now longer have nested ``Reader`` and ``Writer`` classes and they are no
 longer global singletons. Instead, a new plugin object is instantiated in mode ``r``
@@ -181,7 +181,7 @@ manager, and uses `iio.imopen`::
         pass
 
 Metadata
-^^^^^^^^
+--------
 
 The v3 API makes handling of metadata much more consistent and explicit.
 Previously in v2, metadata was provided as a ``dict`` that was attached to the

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -155,13 +155,12 @@ snippets::
 Reader and Writer
 -----------------
 
-Plugins now longer have nested ``Reader`` and ``Writer`` classes and they are no
-longer global singletons. Instead, a new plugin object is instantiated in mode ``r``
-(reading) or  ``w`` (writing) for each `ImageResource` being opened.
-As such, the functions ``iio.get_reader``, ``iio.get_writer``, ``iio.read``, and
-``iio.save`` have become obsolete and the plugin object is used directly
-instead. Using these is considered advanced usage, happens inside a context
-manager, and uses `iio.imopen`::
+Previously, the `reader` and `writer` objects provided an advanced way to
+read/write data with more control. These are no longer needed. Likewise, the
+functions ``iio.get_reader``, ``iio.get_writer``, ``iio.read``, and ``iio.save``
+have become obsolete. Instead, the plugin object is used directly, which is
+instantiated in mode ``r`` (reading) or  ``w`` (writing). To create a plugin
+object, call `iio.imopen` and use it as a context manager::
 
     # reader = iio.get_reader(image_resource)
     # reader = iio.read(image_resource)

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -1,8 +1,13 @@
--------------
-Core API v2.9
--------------
+-----------
+Core API v2
+-----------
 
 .. py:currentmodule:: imageio.v2
+
+.. warning::
+    This API is deprecated and will be superseeded by `the v3 API <core_v3>`
+    starting with ImageIO v3. Check the migration instructions below for
+    detailed information on how to migrate.
 
 These functions represent imageio's main interface for the user. They
 provide a common API to read and write image data for a large
@@ -70,3 +75,129 @@ that best suits that file-format.
 .. autoclass:: imageio.core.format.Writer
     :inherited-members:
     :members: 
+
+.. _migration_from_v2:
+
+Migrating to ImageIO v3
+-----------------------
+
+The primary novelty of the v3 API compared to the v2 API is that images are now
+treated as ndimages, a generalization of (flat) 2D images to N dimensions. This
+change allows us to design a much simpler API; however, comes with a few
+backwards incompatible changes.
+
+Avoiding API Migration for Legacy Scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have an old script where you do not wish to migrate the API, you can
+explicitly import the old v2 API and avoid migration. Note that, while this will
+keep the old (v2) API, it will use on the new (v3) plugins and backends, which
+may contain other backwards incompatible changes. As such, you should prefer a
+full migration to v3, and should avoid using the v2 API in new code. To import
+the v2 API, depending on your script/code, use::
+
+    import imageio... as iio
+    import imageio... as imageio
+  
+
+Reading Images 
+^^^^^^^^^^^^^^
+
+`iio.imread` can now return a ndimage instead of being limited to flat images.
+As such, `iio.volread` has merged into `iio.imread` and is now gone. Similarily,
+`iio.mimread` and `iio.mvolread` have merged into a new function called
+`iio.imiter`, which returns a generator that yields ndimages from a file in the
+order they appear. Further, the default behavior of `iio.imread` has changed,
+and it now returns the first ndimage (instead of the first flat image) if the
+image contains multiple images.
+
+To reproduce similar behavior to the v2 API behavior use one of the following
+snippets::
+
+    # img = iio.v2.imread(image_resource)
+    try:
+        img = iio.v3.imread(image_resource, index=None)[0]
+    except ValueError:
+        img = iio.v3.imread(image_resource, index=0)
+
+    # img = iio.v2.volread(image_resource)
+    img = iio.v3.imread(image_resource)
+    
+    # img = iio.v2.mimread(image_resource)
+    # img = iio.v2.mvolread(image_resource)
+    img = [im for im in iio.v3.imiter(image_resource)]
+
+Writing Images
+^^^^^^^^^^^^^^
+
+Similar to reading images, the new `iio.imwrite` can handle ndimages.
+``iio.mimwrite``, ``iio.volwrite``, and ``iio.mvolwrite`` have all dissapeared.
+The same goes for their aliases ``iio.mimsave``, ``iio.volsave``,
+``iio.mvolsave``, and ``iio.imsave``. They are now all covered by
+``iio.imwrite``.
+
+To reproduce similar behavior to the v2 API behavior use one of the following
+snippets::
+
+    # img = iio.v2.imwrite(image_resource, ndimage)
+    # img = iio.v2.imsave(image_resource, ndimage)
+    # img = iio.v2.volwrite(image_resource, ndimage)
+    # img = iio.v2.volsave(image_resource, ndimage)
+    img = iio.v3.imwrite(image_resource, ndimage)
+
+    # img = iio.v2.mimwrite(image_resource, list_of_ndimages)
+    # img = iio.v2.mimsave(image_resource, list_of_ndimages)
+    # img = iio.v2.mvolwrite(image_resource, list_of_ndimages)
+    # img = iio.v2.mvolsave(image_resource, list_of_ndimages)
+    img = iio.v3.imwrite(image_resource, list_of_ndimages)
+
+Reader and Writer
+^^^^^^^^^^^^^^^^^
+
+Plugins now longer have nested ``Reader`` and ``Writer`` classes and they are no
+longer global singletons. Instead, a new plugin object is instantiated in mode ``r``
+(reading) or  ``w`` (writing) for each `ImageResource` being opened.
+As such, the functions ``iio.get_reader``, ``iio.get_writer``, ``iio.read``, and
+``iio.save`` have become obsolete and the plugin object is used directly
+instead. Using these is considered advanced usage, happens inside a context
+manager, and uses `iio.imopen`::
+
+    # reader = iio.get_reader(image_resource)
+    # reader = iio.read(image_resource)
+    with iio.imopen(image_resource, "r") as reader:
+        # file is only open/accessible here
+        # img = reader.read(index=0)
+        # meta = reader.metadata(index=0)
+        # ...
+        pass
+
+
+    # writer = iio.get_writer(image_resource)
+    # writer = iio.save(image_resource)
+    with iio.imopen(image_resource, "w") as writer:
+        # file is only open/accessible here
+        # writer.write(ndimage)
+        # ...
+        pass
+
+Metadata
+^^^^^^^^
+
+The v3 API makes handling of metadata much more consistent and explicit.
+Previously in v2, metadata was provided as a ``dict`` that was attached to the
+image by returning a custom subclass of ``np.ndarray``. Now metadata is
+provided separately from pixel data::
+
+    # metadata = iio.imread(image_resource)._meta
+    metadata = iio.immeta(image_resource)
+
+Further, ImageIO now provides a curated set of standardized metadata which is
+called ImageProperties in addition to above metadata. The difference between the
+two is as follows: The metadata dict contains metadata using format-specific
+keys to the extent the reading plugin supports them. The ImageProperties
+dataclass contains metadata using standardized attribute names. They are the
+same name for all plugins, and - if the plugin or format doesn't provide a field
+- they are set to a (sensible) default value; usually ``None``. To access
+ImageProperties use::
+
+    props = iio.improps(image_resource)

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -79,26 +79,30 @@ that best suits that file-format.
 
 .. _migration_from_v2:
 
-Migrating to ImageIO v3
+Migrating to the v3 API
 ^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+    Make sure to have a look at the :doc:`narrative docs for the v3 API <core_v3>`
+    to build some intuition on how to use the new API.
 
 The primary novelty of the v3 API compared to the v2 API is that images are now
 treated as ndimages, a generalization of (flat) 2D images to N dimensions. This
 change allows us to design a much simpler API; however, comes with a few
 backwards incompatible changes.
 
-Avoiding API Migration for Legacy Scripts
------------------------------------------
+.. rubric:: Avoiding Migration for Legacy Scripts
 
-If you have an old script where you do not wish to migrate the API, you can
-explicitly import the old v2 API and avoid migration. While this will keep the
-old (v2) API, it will rely on the new (v3) plugins and backends, which may
-contain other backwards incompatible changes. As such, you should prefer a full
-migration to v3 and should avoid using the v2 API in new code. To import the v2
-API, depending on your script/code, use::
+If you have an old script that you do not wish to migrate, you can avoid most of 
+the migration by explicitly importing the v2 API::
 
-    import imageio.v2 as iio
     import imageio.v2 as imageio
+
+This will give you access to most of the old API. However, calls will still rely
+on the new (v3) plugins and backends, which may cause behavioral changes. As
+such, you should prefer a full migration to v3 and should avoid using the v2 API
+in new code. This is primarily as a quick way for you to postpone a full
+migration until it is convenient for you to do so.
   
 
 Reading Images 
@@ -188,13 +192,13 @@ served independently from pixel data::
     # metadata = iio.imread(image_resource).meta
     metadata = iio.immeta(image_resource)
 
-Further, ImageIO now provides a curated set of standardized metadata which is
-called ImageProperties in addition to above metadata. The difference between the
-two is as follows: The metadata dict contains metadata using format-specific
-keys to the extent the reading plugin supports them. The ImageProperties
-dataclass contains metadata using standardized attribute names. Each plugin
-provides the same set of properties, and if the plugin or format doesn't provide a field
-it is set to a (sensible) default value. To access
-ImageProperties use::
+Further, ImageIO now provides a curated set of standardized metadata, which is
+called :class:`ImageProperties <imageio.core.v3_plugin_api.ImageProperties>`, in
+addition to above metadata. The difference between the two is as follows: The
+metadata dict contains metadata using format-specific keys to the extent the
+reading plugin supports them. The ImageProperties dataclass contains generally
+available metadata using standardized attribute names. Each plugin provides the
+same set of properties, and if the plugin or format doesn't provide a field it
+is set to a (sensible) default value. To access ImageProperties use::
 
     props = iio.improps(image_resource)

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -188,16 +188,16 @@ Previously in v2, metadata was provided as a ``dict`` that was attached to the
 image by returning a custom subclass of ``np.ndarray``. Now metadata is
 provided separately from pixel data::
 
-    # metadata = iio.imread(image_resource)._meta
+    # metadata = iio.imread(image_resource).meta
     metadata = iio.immeta(image_resource)
 
 Further, ImageIO now provides a curated set of standardized metadata which is
 called ImageProperties in addition to above metadata. The difference between the
 two is as follows: The metadata dict contains metadata using format-specific
 keys to the extent the reading plugin supports them. The ImageProperties
-dataclass contains metadata using standardized attribute names. They are the
-same name for all plugins, and - if the plugin or format doesn't provide a field
-- they are set to a (sensible) default value; usually ``None``. To access
+dataclass contains metadata using standardized attribute names. Each plugin
+provides the same set of properties, and if the plugin or format doesn't provide a field
+it is set to a (sensible) default value. To access
 ImageProperties use::
 
     props = iio.improps(image_resource)

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -5,9 +5,10 @@ Core API v2
 .. py:currentmodule:: imageio.v2
 
 .. warning::
-    This API is deprecated and will be superseeded by :doc:`the v3 API <core_v3>`
-    starting with ImageIO v3. Check the migration instructions below for
-    detailed information on how to migrate.
+
+    This API exists for backwards compatibility. It is a wrapper around calls to
+    the v3 API and new code should use the v3 API directly. Check the migration
+    instructions below for detailed information on how to migrate.
 
 These functions represent imageio's main interface for the user. They
 provide a common API to read and write image data for a large
@@ -34,10 +35,10 @@ Functions for reading
 .. autosummary::
     :toctree: ../_autosummary/
 
-    imageio.imread
-    imageio.mimread
-    imageio.volread
-    imageio.mvolread
+    imageio.v2.imread
+    imageio.v2.mimread
+    imageio.v2.volread
+    imageio.v2.mvolread
 
 
 Functions for writing
@@ -46,10 +47,10 @@ Functions for writing
 .. autosummary::
     :toctree: ../_autosummary/
 
-    imageio.imwrite
-    imageio.mimwrite
-    imageio.volwrite
-    imageio.mvolwrite
+    imageio.v2.imwrite
+    imageio.v2.mimwrite
+    imageio.v2.volwrite
+    imageio.v2.mvolwrite
 
 More control
 ^^^^^^^^^^^^
@@ -62,9 +63,9 @@ This also allows specific scientific formats to be exposed in a way
 that best suits that file-format.
 
 
-.. autofunction:: imageio.get_reader
+.. autofunction:: imageio.v2.get_reader
 
-.. autofunction:: imageio.get_writer
+.. autofunction:: imageio.v2.get_writer
 
 ----
 

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -198,6 +198,6 @@ metadata dict contains metadata using format-specific keys to the extent the
 reading plugin supports them. The ImageProperties dataclass contains generally
 available metadata using standardized attribute names. Each plugin provides the
 same set of properties, and if the plugin or format doesn't provide a field it
-is set to a (sensible) default value. To access ImageProperties use::
+is set to a default value; usually ``None``. To access ImageProperties use::
 
     props = iio.improps(image_resource)

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -90,14 +90,14 @@ Avoiding API Migration for Legacy Scripts
 -----------------------------------------
 
 If you have an old script where you do not wish to migrate the API, you can
-explicitly import the old v2 API and avoid migration. Note that, while this will
-keep the old (v2) API, it will use on the new (v3) plugins and backends, which
-may contain other backwards incompatible changes. As such, you should prefer a
-full migration to v3, and should avoid using the v2 API in new code. To import
-the v2 API, depending on your script/code, use::
+explicitly import the old v2 API and avoid migration. While this will keep the
+old (v2) API, it will rely on the new (v3) plugins and backends, which may
+contain other backwards incompatible changes. As such, you should prefer a full
+migration to v3 and should avoid using the v2 API in new code. To import the v2
+API, depending on your script/code, use::
 
-    import imageio... as iio
-    import imageio... as imageio
+    import imageio.v2 as iio
+    import imageio.v2 as imageio
   
 
 Reading Images 
@@ -107,9 +107,9 @@ Reading Images
 As such, `iio.volread` has merged into `iio.imread` and is now gone. Similarily,
 `iio.mimread` and `iio.mvolread` have merged into a new function called
 `iio.imiter`, which returns a generator that yields ndimages from a file in the
-order they appear. Further, the default behavior of `iio.imread` has changed,
-and it now returns the first ndimage (instead of the first flat image) if the
-image contains multiple images.
+order in which they appear. Further, the default behavior of `iio.imread` has
+changed, and it now returns the first ndimage (instead of the first flat image)
+if the image contains multiple images.
 
 To reproduce similar behavior to the v2 API behavior use one of the following
 snippets::
@@ -140,15 +140,11 @@ To reproduce similar behavior to the v2 API behavior use one of the following
 snippets::
 
     # img = iio.v2.imwrite(image_resource, ndimage)
-    # img = iio.v2.imsave(image_resource, ndimage)
     # img = iio.v2.volwrite(image_resource, ndimage)
-    # img = iio.v2.volsave(image_resource, ndimage)
     img = iio.v3.imwrite(image_resource, ndimage)
 
     # img = iio.v2.mimwrite(image_resource, list_of_ndimages)
-    # img = iio.v2.mimsave(image_resource, list_of_ndimages)
     # img = iio.v2.mvolwrite(image_resource, list_of_ndimages)
-    # img = iio.v2.mvolsave(image_resource, list_of_ndimages)
     img = iio.v3.imwrite(image_resource, list_of_ndimages)
 
 Reader and Writer
@@ -186,7 +182,7 @@ Metadata
 The v3 API makes handling of metadata much more consistent and explicit.
 Previously in v2, metadata was provided as a ``dict`` that was attached to the
 image by returning a custom subclass of ``np.ndarray``. Now metadata is
-provided separately from pixel data::
+served independently from pixel data::
 
     # metadata = iio.imread(image_resource).meta
     metadata = iio.immeta(image_resource)

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -82,7 +82,7 @@ def imopen(
     Parameters
     ----------
     uri : str or pathlib.Path or bytes or file or Request
-        The :doc:`ImageResource <../../getting_started/requests>` to load the
+        The :doc:`ImageResource <../../user_guide/requests>` to load the
         image from.
     io_mode : str
         The mode in which the file is opened. Possible values are::

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -82,8 +82,8 @@ def imopen(
     Parameters
     ----------
     uri : str or pathlib.Path or bytes or file or Request
-        The :doc:`ImageResources <getting_started.request>` to load the image
-        from.
+        The :doc:`ImageResource <../../getting_started/requests>` to load the
+        image from.
     io_mode : str
         The mode in which the file is opened. Possible values are::
 

--- a/imageio/v3.py
+++ b/imageio/v3.py
@@ -86,7 +86,7 @@ def imiter(
         call.
 
     Yields
-    -------
+    ------
     image : ndimage
         The next ndimage located at the given URI.
 


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/640

Long overdue, but let's get this started.

This PR adds documentation of the ImageIO v3 API and migration instructions to navigate the breaking changes when moving from v2 to v3. I will put the documentation for writing plugins into a separate PR to try and not make this one too big.