### PR TITLE
FEAT: Allow mode=None when writing with pillow

### DIFF
--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -504,3 +504,22 @@ def test_initialization_failure(image_files: Path):
     with pytest.raises(OSError):
         # pillow can not handle npy
         iio.v3.imread(image_files / "chelsea_jpg.npy", plugin="pillow")
+
+
+def test_boolean_reading(tmp_path):
+    expected = np.arange(256 * 256).reshape((256, 256)) % 2 == 0
+
+    Image.fromarray(expected).save(tmp_path / "iio.png")
+
+    actual = iio.v3.imread(tmp_path / "iio.png")
+    assert np.allclose(actual, expected)
+
+
+def test_boolean_writing(tmp_path):
+    expected = np.arange(256 * 256).reshape((256, 256)) % 2 == 0
+
+    iio.v3.imwrite(tmp_path / "iio.png", expected)
+
+    actual = np.asarray(Image.open(tmp_path / "iio.png"))
+    # actual = iio.v3.imread(tmp_path / "iio.png")
+    assert np.allclose(actual, expected)


### PR DESCRIPTION
Closes: #721 

This PR refactors the v3 pillow plugin to rely on pillow's exposed modes (`PIL.ImageMode`) instead of maintaining our own list that needs updating whenever pillow changes something. After this refactor, we should automatically stay in sync.

It also adds the ability (new feature) to use `mode=None` when writing an ndimage with pillow. This will use pillow's logic to lookup an appropriate mode based on the ndimage's shape and dtype. It also changes the default mode to `None` to match
pillows `Image.save()`. (Although this is a tad experimental because I don't know if our current unit tests cover all the important scenarios)

As a side-effect this will address the problem reported in #721 which comes from some pillow weirdness:

```python
expected = np.arange(256 * 256).reshape((256, 256)) % 2 == 0

# saves the image correctly because the rawmode is determined by pillow
Image.fromarray(expected).save(tmp_path / "iio.png")

# saves a corrupt image, because mode="1" means 1-bit boolean (bit-packed) 
# whereas numpy uses 1-byte boolean (byte-packed).
# It appears to be impossible to specify mode=?? explicitly in this case.
Image.fromarray(expected, mode="1").save(tmp_path / "iio.png")
```

The PR also adds two tests to cover against regression for the fix of #721.