### PR TITLE
BUG: handle pillow9 GIFs correctly in v2 pillow plugin

### DIFF
--- a/imageio/plugins/pillow_legacy.py
+++ b/imageio/plugins/pillow_legacy.py
@@ -746,6 +746,13 @@ def pil_get_frame(im, is_gray=None, as_gray=None, mode=None, dtype=None):
         frame = im.convert("RGBA")
     elif im.mode == "CMYK":
         frame = im.convert("RGB")
+    elif im.format == "GIF" and im.mode == "RGB":
+        # pillow9 returns RGBA images for subsequent frames so that it can deal
+        # with multi-frame GIF that use frame-level palettes and don't dispose
+        # all areas.
+
+        # For backwards compatibility, we promote everything to RGBA.
+        frame = im.convert("RGBA")
 
     # Apply a post-convert if necessary
     if as_gray:


### PR DESCRIPTION
Closes: #719 

I figured out a fix that doesn't involve a huge amount of changes, nor involves skipping pillow9. Not sure why I didn't come up with this one sooner.

I think https://github.com/imageio/imageio/pull/722 is actually affected by the pillow9 changes, too, but somehow we don't have a breaking test here. I will investigate and add a test as necessary.