### PR TITLE
fix: add TiffFileError to the internal tifffile package

### DIFF
--- a/imageio/plugins/_tifffile.py
+++ b/imageio/plugins/_tifffile.py
@@ -4561,6 +4561,9 @@ class TiffTag(object):
         return line
 
 
+# Added to produce cleaner exceptions if tifffile unexpectedly fails to open the
+# file. See this comment (and the following) for details:
+# https://github.com/imageio/imageio/commit/bdbe699bbcda4223b0b6bd4d7474f84bbe34af09#r64068747
 class TiffFileError(ValueError):
     pass
 

--- a/imageio/plugins/_tifffile.py
+++ b/imageio/plugins/_tifffile.py
@@ -4561,6 +4561,10 @@ class TiffTag(object):
         return line
 
 
+class TiffFileError(ValueError):
+    pass
+
+
 class TiffPageSeries(object):
     """Series of TIFF pages with compatible shape and data type.
 


### PR DESCRIPTION
This barely cause any issues in general usage, but since `TiffFileError` is required [here](https://github.com/imageio/imageio/blob/master/imageio/plugins/tifffile.py#L367), it's better to include it in.