### PR TITLE
BUG: Avoid raw bytes in exception message

### DIFF
--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -136,6 +136,8 @@ def imopen(
     else:
         request = Request(uri, io_mode)
 
+    source = "<bytes>" if isinstance(uri, bytes) else uri
+
     # plugin specified, no search needed
     # (except in legacy mode)
     if plugin is not None:
@@ -207,7 +209,7 @@ def imopen(
     if request.mode.io_mode == IOMode.write:
         if isinstance(uri, str) and uri.startswith(SPECIAL_READ_URIS):
             err_type = ValueError if legacy_mode else IOError
-            err_msg = f"`{uri}` is read-only."
+            err_msg = f"`{source}` is read-only."
             raise err_type(err_msg)
 
     # error out for directories
@@ -239,7 +241,7 @@ def imopen(
             return plugin_instance
 
     err_type = ValueError if legacy_mode else IOError
-    err_msg = f"Could not find a backend to open `{uri}`` with iomode `{io_mode}`."
+    err_msg = f"Could not find a backend to open `{source}`` with iomode `{io_mode}`."
 
     # check if a missing plugin could help
     if request.extension in known_extensions:

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -58,16 +58,20 @@ class LegacyPlugin:
         self._request = request
         self._format = legacy_plugin
 
+        source = (
+            "<bytes>"
+            if isinstance(self._request.raw_uri, bytes)
+            else self._request.raw_uri
+        )
         if self._request.mode.io_mode == IOMode.read:
             if not self._format.can_read(request):
                 raise InitializationError(
-                    f"`{self._format.name}`" f" can not read `{self._request.raw_uri}`."
+                    f"`{self._format.name}`" f" can not read `{source}`."
                 )
         else:
             if not self._format.can_write(request):
                 raise InitializationError(
-                    f"`{self._format.name}`"
-                    f" can not write to `{self._request.raw_uri}`."
+                    f"`{self._format.name}`" f" can not write to `{source}`."
                 )
 
     def legacy_get_reader(self, **kwargs):

--- a/tests/test_legacy_plugin_wrapper.py
+++ b/tests/test_legacy_plugin_wrapper.py
@@ -1,6 +1,5 @@
 import imageio as iio
 import pytest
-from pathlib import Path
 
 
 def test_exception_message_bytes():

--- a/tests/test_legacy_plugin_wrapper.py
+++ b/tests/test_legacy_plugin_wrapper.py
@@ -5,16 +5,20 @@ import pytest
 def test_exception_message_bytes():
     # regression test for: https://github.com/imageio/imageio/issues/694
     # test via `python -bb -m pytest .\tests\test_legacy_plugin_wrapper.py::test_exception_message_bytes`
-    try:
-        iio.v3.imread(b"")
-    except BytesWarning:
-        pytest.fail("raw bytes used in string.")
-    except IOError:
-        pass  # expected in v3
+    # if run normally, whill check that bytes are not reported
 
     try:
-        iio.imread(b"")
+        iio.v3.imread(b"This will not be reported.")
     except BytesWarning:
         pytest.fail("raw bytes used in string.")
-    except ValueError:
-        pass  # expected in v3
+    except IOError as e:
+        assert "This will not be reported." not in str(e)
+        assert "<bytes>" in str(e)
+
+    try:
+        iio.imread(b"This will not be reported.")
+    except BytesWarning:
+        pytest.fail("raw bytes used in string.")
+    except ValueError as e:
+        assert "This will not be reported." not in str(e)
+        assert "<bytes>" in str(e)

--- a/tests/test_legacy_plugin_wrapper.py
+++ b/tests/test_legacy_plugin_wrapper.py
@@ -1,0 +1,21 @@
+import imageio as iio
+import pytest
+from pathlib import Path
+
+
+def test_exception_message_bytes():
+    # regression test for: https://github.com/imageio/imageio/issues/694
+    # test via `python -bb -m pytest .\tests\test_legacy_plugin_wrapper.py::test_exception_message_bytes`
+    try:
+        iio.v3.imread(b"")
+    except BytesWarning:
+        pytest.fail("raw bytes used in string.")
+    except IOError:
+        pass  # expected in v3
+
+    try:
+        iio.imread(b"")
+    except BytesWarning:
+        pytest.fail("raw bytes used in string.")
+    except ValueError:
+        pass  # expected in v3


### PR DESCRIPTION
Closes https://github.com/imageio/imageio/issues/694

This PR refactors the exception message printed when an ImageResource can't be read. If the ImageResource is a bytes string, it will be reported as `<bytes>` instead of printing the raw string (which could be _long_).

It also adds a regression test for this; however, it hinges on python being run with BytesWarning enables. I've added a comment to the test.