### PR TITLE
FEAT: add format_hint to v3 API

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,8 +70,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"imageio"
-copyright = u"2014-2021, imageio contributors"
+project = "imageio"
+copyright = "2014-2021, imageio contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -233,8 +233,8 @@ latex_documents = [
     (
         "index",
         "imageio.tex",
-        u"imageio Documentation",
-        u"imageio contributors",
+        "imageio Documentation",
+        "imageio contributors",
         "manual",
     )
 ]
@@ -264,9 +264,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    ("index", "imageio", u"imageio Documentation", [u"imageio contributors"], 1)
-]
+man_pages = [("index", "imageio", "imageio Documentation", ["imageio contributors"], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -281,8 +279,8 @@ texinfo_documents = [
     (
         "index",
         "imageio",
-        u"imageio Documentation",
-        u"imageio contributors",
+        "imageio Documentation",
+        "imageio contributors",
         "imageio",
         "One line description of project.",
         "Miscellaneous",

--- a/imageio/core/fetching.py
+++ b/imageio/core/fetching.py
@@ -239,7 +239,7 @@ def _sizeof_fmt(num):
     """Human friendly file size"""
     if num > 1:
         exponent = min(int(log(num, 1024)), len(units) - 1)
-        quotient = float(num) / 1024 ** exponent
+        quotient = float(num) / 1024**exponent
         unit = units[exponent]
         num_decimals = decimals[exponent]
         format_string = "{0:.%sf} {1}" % num_decimals

--- a/imageio/core/functions.py
+++ b/imageio/core/functions.py
@@ -17,9 +17,9 @@ MEMTEST_DEFAULT_MVOL = "1GB"
 mem_re = re.compile(r"^(\d+\.?\d*)\s*([kKMGTPEZY]?i?)B?$")
 sizes = {"": 1, None: 1}
 for i, si in enumerate([""] + list("kMGTPEZY")):
-    sizes[si] = 1000 ** i
+    sizes[si] = 1000**i
     if si:
-        sizes[si.upper() + "i"] = 1024 ** i
+        sizes[si.upper() + "i"] = 1024**i
 
 
 def to_nbytes(arg, default=None) -> Number:

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -204,7 +204,7 @@ def imopen(
         raise err_type(err_msg) from err_from
 
     # fast-path based on format_hint
-    if format_hint is not None:
+    if request.format_hint is not None:
         for candidate_format in known_extensions[format_hint]:
             for plugin_name in candidate_format.priority:
                 config = known_plugins[plugin_name]

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -227,7 +227,9 @@ def imopen(
 
                 return plugin_instance
         else:
-            raise IOError(f"The ImageResource can not be opened as a `{format_hint}` file.")
+            raise IOError(
+                f"The ImageResource can not be opened as a `{format_hint}` file."
+            )
 
     # fast-path based on file extension
     if request.extension in known_extensions:

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -66,6 +66,7 @@ def imopen(
     io_mode: str,
     *,
     plugin: Union[str, Any] = None,
+    format_hint: str = None,
     legacy_mode: bool = True,
     **kwargs,
 ) -> Any:
@@ -100,7 +101,15 @@ def imopen(
 
     plugin : str, Plugin, or None
         The plugin to use. If set to None (default) imopen will perform a
-        search for a matching plugin.
+        search for a matching plugin. If not None, this takes priority over
+        the provided format hint.
+    format_hint : str
+        A format hint to help optimize plugin selection given as the format's
+        extension, e.g. ".png". This can speed up the selection process for
+        ImageResources that don't have an explicit extension, e.g. streams, or
+        for ImageResources where the extension does not match the resource's
+        content. If the ImageResource lacks an explicit extension, it will be
+        set to this format.
     legacy_mode : bool
         If true (default) use the v2 behavior when searching for a suitable
         plugin. This will ignore v3 plugins and will check ``plugin``
@@ -117,6 +126,13 @@ def imopen(
     Passing a ``Request`` as the uri is only supported if ``legacy_mode``
     is ``True``. In this case ``io_mode`` is ignored.
 
+    Using the kwarg ``format_hint`` does not enforce the given format. It merely
+    provides a `hint` to the selection process and plugin. The selection
+    processes uses this hint for optimization; however, a plugin's decision how
+    to read a ImageResource will - typically - still be based on the content of
+    the resource.
+
+
     Examples
     --------
 
@@ -129,16 +145,23 @@ def imopen(
 
     """
 
+    if format_hint is not None and format_hint[0] != ".":
+        raise ValueError(
+            "`format_hint` should be a file extension starting with a `.`,"
+            f" but is `{format_hint}`."
+        )
+
     if isinstance(uri, Request) and legacy_mode:
         request = uri
         uri = request.raw_uri
         io_mode = request.mode.io_mode
+        request.format_hint = format_hint
     else:
-        request = Request(uri, io_mode)
+        request = Request(uri, io_mode, format_hint=format_hint)
 
     source = "<bytes>" if isinstance(uri, bytes) else uri
 
-    # plugin specified, no search needed
+    # fast-path based on plugin
     # (except in legacy mode)
     if plugin is not None:
         if isinstance(plugin, str):
@@ -180,6 +203,32 @@ def imopen(
         request.finish()
         raise err_type(err_msg) from err_from
 
+    # fast-path based on format_hint
+    if format_hint is not None:
+        for candidate_format in known_extensions[format_hint]:
+            for plugin_name in candidate_format.priority:
+                config = known_plugins[plugin_name]
+
+                # v2 compatibility; delete in v3
+                if legacy_mode and not config.is_legacy:
+                    continue
+
+                try:
+                    candidate_plugin = config.plugin_class
+                except ImportError:
+                    # not installed
+                    continue
+
+                try:
+                    plugin_instance = candidate_plugin(request, **kwargs)
+                except InitializationError:
+                    # file extension doesn't match file type
+                    continue
+
+                return plugin_instance
+        else:
+            raise IOError(f"The ImageResource can not be opened as a `{format_hint}` file.")
+
     # fast-path based on file extension
     if request.extension in known_extensions:
         for candidate_format in known_extensions[request.extension]:
@@ -205,7 +254,7 @@ def imopen(
                 return plugin_instance
 
     # error out for read-only special targets
-    # this is again hacky; can we come up with a better solution for this?
+    # this is hacky; can we come up with a better solution for this?
     if request.mode.io_mode == IOMode.write:
         if isinstance(uri, str) and uri.startswith(SPECIAL_READ_URIS):
             err_type = ValueError if legacy_mode else IOError

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -11,6 +11,7 @@ from .request import (
 from ..config.plugins import PluginConfig
 from ..config import known_plugins
 from ..config.extensions import known_extensions
+import warnings
 
 
 def _get_config(plugin: str, legacy_mode: bool) -> PluginConfig:
@@ -227,9 +228,10 @@ def imopen(
 
                 return plugin_instance
         else:
-            raise IOError(
-                f"The ImageResource can not be opened as a `{format_hint}` file."
+            resource = (
+                "<bytes>" if isinstance(request.raw_uri, bytes) else request.raw_uri
             )
+            warnings.warn(f"`{resource}` can not be opened as a `{format_hint}` file.")
 
     # fast-path based on file extension
     if request.extension in known_extensions:

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -18,6 +18,7 @@ from ..core import urlopen, get_remote_file
 
 from pathlib import Path
 from urllib.parse import urlparse
+from typing import Optional
 
 # URI types
 URI_BYTES = 1
@@ -212,13 +213,14 @@ class Request(object):
 
     """
 
-    def __init__(self, uri, mode, **kwargs):
+    def __init__(self, uri, mode, *, format_hint:str=None, **kwargs):
 
         # General
         self.raw_uri = uri
         self._uri_type = None
         self._filename = None
         self._extension = None
+        self._format_hint = None
         self._kwargs = kwargs
         self._result = None  # Some write actions may have a result
 
@@ -253,6 +255,8 @@ class Request(object):
                 path = urlparse(self._filename).path
             ext = Path(path).suffix.lower()
             self._extension = ext if ext != "" else None
+
+        self.format_hint = format_hint
 
     def _parse_uri(self, uri):
         """Try to figure our what we were given"""
@@ -407,6 +411,17 @@ class Request(object):
         not based on a filename.
         """
         return self._extension
+
+    @property
+    def format_hint(self) -> Optional[str]:
+        return self._format_hint
+
+    @format_hint.setter
+    def format_hint(self, format:str) -> None:
+        self._format_hint = format
+        if self._extension is None:
+            self._extension = format
+
 
     @property
     def mode(self):

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -213,7 +213,7 @@ class Request(object):
 
     """
 
-    def __init__(self, uri, mode, *, format_hint:str=None, **kwargs):
+    def __init__(self, uri, mode, *, format_hint: str = None, **kwargs):
 
         # General
         self.raw_uri = uri
@@ -417,11 +417,10 @@ class Request(object):
         return self._format_hint
 
     @format_hint.setter
-    def format_hint(self, format:str) -> None:
+    def format_hint(self, format: str) -> None:
         self._format_hint = format
         if self._extension is None:
             self._extension = format
-
 
     @property
     def mode(self):

--- a/imageio/core/v3_api.py
+++ b/imageio/core/v3_api.py
@@ -7,7 +7,9 @@ from typing import Optional, Iterator
 imopen = imopen
 
 
-def imread(uri, *, index: int = None, plugin: str = None, **kwargs) -> np.ndarray:
+def imread(
+    uri, *, index: int = None, plugin: str = None, format_hint: str = None, **kwargs
+) -> np.ndarray:
     """Read an ndimage from a URI.
 
     Opens the given URI and reads an ndimage from it. The exact behavior
@@ -24,7 +26,16 @@ def imread(uri, *, index: int = None, plugin: str = None, **kwargs) -> np.ndarra
         If the URI contains multiple ndimages, select the index-th ndimage
         from among them and return it. The exact behavior is plugin dependent.
     plugin : {str, None}
-        The plugin to be used. If None, performs a search for a matching plugin.
+        The plugin to use. If set to None (default) imopen will perform a
+        search for a matching plugin. If not None, this takes priority over
+        the provided format hint.
+    format_hint : str
+        A format hint to help optimize plugin selection given as the format's
+        extension, e.g. ".png". This can speed up the selection process for
+        ImageResources that don't have an explicit extension, e.g. streams, or
+        for ImageResources where the extension does not match the resource's
+        content. If the ImageResource lacks an explicit extension, it will be
+        set to this format.
     **kwargs :
         Additional keyword arguments will be passed to the plugin's read call.
 
@@ -34,13 +45,15 @@ def imread(uri, *, index: int = None, plugin: str = None, **kwargs) -> np.ndarra
         The ndimage located at the given URI.
     """
 
-    plugin_kwargs = {"legacy_mode": False, "plugin": plugin}
+    plugin_kwargs = {"legacy_mode": False, "plugin": plugin, "format_hint": format_hint}
 
     with imopen(uri, "r", **plugin_kwargs) as img_file:
         return np.asarray(img_file.read(index=index, **kwargs))
 
 
-def imiter(uri, *, plugin: str = None, **kwargs) -> Iterator[np.ndarray]:
+def imiter(
+    uri, *, plugin: str = None, format_hint: str = None, **kwargs
+) -> Iterator[np.ndarray]:
     """Read a sequence of ndimages from a URI.
 
     Returns an iterable that yields ndimages from the given URI. The exact
@@ -54,8 +67,16 @@ def imiter(uri, *, plugin: str = None, **kwargs) -> Iterator[np.ndarray]:
         The resource to load the image from, e.g. a filename, pathlib.Path,
         http address or file object, see the docs for more info.
     plugin : {str, None}
-        The plugin to be used. If None, performs a search for a matching
-        plugin.
+        The plugin to use. If set to None (default) imopen will perform a
+        search for a matching plugin. If not None, this takes priority over
+        the provided format hint.
+    format_hint : str
+        A format hint to help optimize plugin selection given as the format's
+        extension, e.g. ".png". This can speed up the selection process for
+        ImageResources that don't have an explicit extension, e.g. streams, or
+        for ImageResources where the extension does not match the resource's
+        content. If the ImageResource lacks an explicit extension, it will be
+        set to this format.
     **kwargs :
         Additional keyword arguments will be passed to the plugin's ``iter``
         call.
@@ -67,7 +88,7 @@ def imiter(uri, *, plugin: str = None, **kwargs) -> Iterator[np.ndarray]:
 
     """
 
-    plugin_kwargs = {"legacy_mode": False, "plugin": plugin}
+    plugin_kwargs = {"legacy_mode": False, "plugin": plugin, "format_hint": format_hint}
 
     with imopen(uri, "r", **plugin_kwargs) as img_file:
         for image in img_file.iter(**kwargs):
@@ -76,7 +97,9 @@ def imiter(uri, *, plugin: str = None, **kwargs) -> Iterator[np.ndarray]:
             yield np.asarray(image)
 
 
-def imwrite(uri, image: np.ndarray, *, plugin: str = None, **kwargs) -> Optional[bytes]:
+def imwrite(
+    uri, image: np.ndarray, *, plugin: str = None, format_hint: str = None, **kwargs
+) -> Optional[bytes]:
     """Write an ndimage to the given URI.
 
     The exact behavior depends on the file type and plugin used. To learn about
@@ -90,8 +113,16 @@ def imwrite(uri, image: np.ndarray, *, plugin: str = None, **kwargs) -> Optional
     image : np.ndarray
         The image to write to disk.
     plugin : {str, None}
-        The plugin to be used. If None, performs a search for a matching
-        plugin.
+        The plugin to use. If set to None (default) imopen will perform a
+        search for a matching plugin. If not None, this takes priority over
+        the provided format hint.
+    format_hint : str
+        A format hint to help optimize plugin selection given as the format's
+        extension, e.g. ".png". This can speed up the selection process for
+        ImageResources that don't have an explicit extension, e.g. streams, or
+        for ImageResources where the extension does not match the resource's
+        content. If the ImageResource lacks an explicit extension, it will be
+        set to this format.
     **kwargs :
         Additional keyword arguments will be passed to the plugin's ``write``
         call.
@@ -104,7 +135,7 @@ def imwrite(uri, image: np.ndarray, *, plugin: str = None, **kwargs) -> Optional
 
     """
 
-    plugin_kwargs = {"legacy_mode": False, "plugin": plugin}
+    plugin_kwargs = {"legacy_mode": False, "plugin": plugin, "format_hint": format_hint}
 
     with imopen(uri, "w", **plugin_kwargs) as img_file:
         encoded = img_file.write(image, **kwargs)

--- a/imageio/core/v3_api.py
+++ b/imageio/core/v3_api.py
@@ -26,16 +26,15 @@ def imread(
         If the URI contains multiple ndimages, select the index-th ndimage
         from among them and return it. The exact behavior is plugin dependent.
     plugin : {str, None}
-        The plugin to use. If set to None (default) imopen will perform a
+        The plugin to use. If set to None (default) imread will perform a
         search for a matching plugin. If not None, this takes priority over
-        the provided format hint.
+        the provided format hint  (if present).
     format_hint : str
         A format hint to help optimize plugin selection given as the format's
         extension, e.g. ".png". This can speed up the selection process for
         ImageResources that don't have an explicit extension, e.g. streams, or
         for ImageResources where the extension does not match the resource's
-        content. If the ImageResource lacks an explicit extension, it will be
-        set to this format.
+        content.
     **kwargs :
         Additional keyword arguments will be passed to the plugin's read call.
 
@@ -67,9 +66,9 @@ def imiter(
         The resource to load the image from, e.g. a filename, pathlib.Path,
         http address or file object, see the docs for more info.
     plugin : {str, None}
-        The plugin to use. If set to None (default) imopen will perform a
+        The plugin to use. If set to None (default) imiter will perform a
         search for a matching plugin. If not None, this takes priority over
-        the provided format hint.
+        the provided format hint (if present).
     format_hint : str
         A format hint to help optimize plugin selection given as the format's
         extension, e.g. ".png". This can speed up the selection process for
@@ -113,9 +112,9 @@ def imwrite(
     image : np.ndarray
         The image to write to disk.
     plugin : {str, None}
-        The plugin to use. If set to None (default) imopen will perform a
+        The plugin to use. If set to None (default) imwrite will perform a
         search for a matching plugin. If not None, this takes priority over
-        the provided format hint.
+        the provided format hint (if present).
     format_hint : str
         A format hint to help optimize plugin selection given as the format's
         extension, e.g. ".png". This can speed up the selection process for

--- a/imageio/plugins/_dicom.py
+++ b/imageio/plugins/_dicom.py
@@ -540,21 +540,21 @@ class SimpleDicomReader(object):
                 if minReq < 0:
                     # Signed integer type
                     maxReq = max([-minReq, maxReq])
-                    if maxReq < 2 ** 7:
+                    if maxReq < 2**7:
                         dtype = np.int8
-                    elif maxReq < 2 ** 15:
+                    elif maxReq < 2**15:
                         dtype = np.int16
-                    elif maxReq < 2 ** 31:
+                    elif maxReq < 2**31:
                         dtype = np.int32
                     else:
                         dtype = np.float32
                 else:
                     # Unsigned integer type
-                    if maxReq < 2 ** 8:
+                    if maxReq < 2**8:
                         dtype = np.int8
-                    elif maxReq < 2 ** 16:
+                    elif maxReq < 2**16:
                         dtype = np.int16
-                    elif maxReq < 2 ** 32:
+                    elif maxReq < 2**32:
                         dtype = np.int32
                     else:
                         dtype = np.float32

--- a/imageio/plugins/_swf.py
+++ b/imageio/plugins/_swf.py
@@ -279,7 +279,7 @@ def floats2bits(arr):
         i1 = int(i)
         i2 = i - i1
         bits += int2bits(i1, 15)
-        bits += int2bits(i2 * 2 ** 16, 16)
+        bits += int2bits(i2 * 2**16, 16)
     return bits
 
 

--- a/imageio/plugins/_tifffile.py
+++ b/imageio/plugins/_tifffile.py
@@ -461,7 +461,7 @@ def imread(files, **kwargs):
 
 
 def imsave(
-    file, data=None, shape=None, dtype=None, bigsize=2 ** 32 - 2 ** 25, **kwargs
+    file, data=None, shape=None, dtype=None, bigsize=2**32 - 2**25, **kwargs
 ):
     """Write numpy array to TIFF file.
 
@@ -1446,7 +1446,7 @@ class TiffWriter(object):
         # the entries in an IFD must be sorted in ascending order by tag code
         tags = sorted(tags, key=lambda x: x[0])
 
-        if not (self._bigtiff or self._imagej) and (fh.tell() + datasize > 2 ** 31 - 1):
+        if not (self._bigtiff or self._imagej) and (fh.tell() + datasize > 2**31 - 1):
             raise ValueError("data too large for standard TIFF file")
 
         # if not compressed or multi-tiled, write the first IFD and then
@@ -1645,7 +1645,7 @@ class TiffWriter(object):
 
         # check if all IFDs fit in file
         pos = fh.tell()
-        if not self._bigtiff and pos + ifd.tell() * pageno > 2 ** 32 - 256:
+        if not self._bigtiff and pos + ifd.tell() * pageno > 2**32 - 256:
             if self._imagej:
                 warnings.warn("truncating ImageJ file")
                 self._truncate = True
@@ -1864,7 +1864,7 @@ class TiffFile(object):
             self.pages = TiffPages(self)
 
             if self.is_lsm and (
-                self.filehandle.size >= 2 ** 32
+                self.filehandle.size >= 2**32
                 or self.pages[0].compression != 1
                 or self.pages[1].compression != 1
             ):
@@ -2552,7 +2552,7 @@ class TiffFile(object):
         Each series and position require separate unwrapping (undocumented).
 
         """
-        if self.filehandle.size < 2 ** 32:
+        if self.filehandle.size < 2**32:
             return
 
         pages = self.pages
@@ -2594,7 +2594,7 @@ class TiffFile(object):
             dataoffsets = []
             for currentoffset in page.dataoffsets:
                 if currentoffset < previousoffset:
-                    wrap += 2 ** 32
+                    wrap += 2**32
                 dataoffsets.append(currentoffset + wrap)
                 previousoffset = currentoffset
             page.dataoffsets = tuple(dataoffsets)
@@ -3073,7 +3073,7 @@ class TiffPages(object):
                 if isinstance(page, TiffFrame):
                     pages[i] = page.offset
 
-    def _seek(self, index, maxpages=2 ** 22):
+    def _seek(self, index, maxpages=2**22):
         """Seek file to offset of specified page."""
         pages = self.pages
         if not pages:
@@ -3154,7 +3154,7 @@ class TiffPages(object):
             return pages[key]
 
         if isinstance(key, slice):
-            start, stop, _ = key.indices(2 ** 31 - 1)
+            start, stop, _ = key.indices(2**31 - 1)
             if not self.complete and max(stop, start) > len(pages):
                 self._seek(-1)
             return [self[i] for i in range(*key.indices(len(pages)))]
@@ -3233,7 +3233,7 @@ class TiffPage(object):
     bitspersample = 1
     samplesperpixel = 1
     sampleformat = 1
-    rowsperstrip = 2 ** 32 - 1
+    rowsperstrip = 2**32 - 1
     compression = 1
     planarconfig = 1
     fillorder = 1
@@ -3482,7 +3482,7 @@ class TiffPage(object):
         squeeze=True,
         lock=None,
         reopen=True,
-        maxsize=2 ** 44,
+        maxsize=2**44,
         validate=True,
     ):
         """Read image data from file and return as numpy array.
@@ -3766,7 +3766,7 @@ class TiffPage(object):
         if photometric == PHOTOMETRIC.PALETTE:
             colormap = self.colormap
             if (
-                colormap.shape[1] < 2 ** self.bitspersample
+                colormap.shape[1] < 2**self.bitspersample
                 or self.dtype.char not in "BH"
             ):
                 raise ValueError("cannot apply colormap")
@@ -5057,7 +5057,7 @@ class FileHandle(object):
         )
 
     def read_array(
-        self, dtype, count=-1, sep="", chunksize=2 ** 25, out=None, native=False
+        self, dtype, count=-1, sep="", chunksize=2**25, out=None, native=False
     ):
         """Return numpy array from file.
 
@@ -7401,7 +7401,7 @@ def read_tags(fh, byteorder, offsetsize, tagnames, customtags=None, maxifds=None
     if customtags is None:
         customtags = {}
     if maxifds is None:
-        maxifds = 2 ** 32
+        maxifds = 2**32
 
     result = []
     unpack = struct.unpack
@@ -7679,7 +7679,7 @@ def read_uic_tag(fh, tagid, planecount, offset):
     elif dtype is str:
         # pascal string
         size = read_int()
-        if 0 <= size < 2 ** 10:
+        if 0 <= size < 2**10:
             value = struct.unpack("%is" % size, fh.read(size))[0][:-1]
             value = bytes2str(stripnull(value))
         elif offset:
@@ -7692,7 +7692,7 @@ def read_uic_tag(fh, tagid, planecount, offset):
         value = []
         for _ in range(planecount):
             size = read_int()
-            if 0 <= size < 2 ** 10:
+            if 0 <= size < 2**10:
                 string = struct.unpack("%is" % size, fh.read(size))[0][:-1]
                 string = bytes2str(stripnull(string))
                 value.append(string)
@@ -8906,7 +8906,7 @@ def unpack_rgb(data, dtype="<B", bitspersample=(5, 6, 5), rescale=True):
             o = ((dtype.itemsize * 8) // bps + 1) * bps
             if o > data.dtype.itemsize * 8:
                 t = t.astype("I")
-            t *= (2 ** o - 1) // (2 ** bps - 1)
+            t *= (2**o - 1) // (2**bps - 1)
             t //= 2 ** (o - (dtype.itemsize * 8))
         result[:, i] = t
     return result.reshape(-1)
@@ -9226,7 +9226,7 @@ def clean_offsets_counts(offsets, counts):
     return offsets[:j], counts[:j]
 
 
-def buffered_read(fh, lock, offsets, bytecounts, buffersize=2 ** 26):
+def buffered_read(fh, lock, offsets, bytecounts, buffersize=2**26):
     """Return iterator over blocks read from file."""
     length = len(offsets)
     i = 0
@@ -9473,7 +9473,7 @@ def stripascii(string):
     return string[: i + 1]
 
 
-def asbool(value, true=(b"true", u"true"), false=(b"false", u"false")):
+def asbool(value, true=(b"true", "true"), false=(b"false", "false")):
     """Return string as bool if possible, else raise TypeError.
 
     >>> asbool(b' False ')
@@ -9783,7 +9783,7 @@ def hexdump(bytestr, width=75, height=24, snipat=-2, modulo=2, ellipsis="..."):
             result.append(ellipsis)  # 'skip %i bytes' % start)
             continue
         hexstr = binascii.hexlify(bytestr)
-        strstr = re.sub(br"[^\x20-\x7f]", b".", bytestr)
+        strstr = re.sub(rb"[^\x20-\x7f]", b".", bytestr)
         for i in range(0, len(bytestr), bytesperline):
             h = hexstr[2 * i : 2 * i + bytesperline * 2]
             r = (addr % (i + start)) if height > 1 else addr
@@ -9922,7 +9922,7 @@ def snipstr(string, width=79, snipat=0.5, ellipsis="..."):
         if isinstance(string, bytes):
             ellipsis = b"..."
         else:
-            ellipsis = u"\u2026"  # does not print on win-py3.5
+            ellipsis = "\u2026"  # does not print on win-py3.5
     esize = len(ellipsis)
 
     splitlines = string.splitlines()
@@ -10216,7 +10216,7 @@ def imshow(
         elif not isinstance(bitspersample, inttypes):
             # bitspersample can be tuple, e.g. (5, 6, 5)
             bitspersample = data.dtype.itemsize * 8
-        datamax = 2 ** bitspersample
+        datamax = 2**bitspersample
         if isrgb:
             if bitspersample < 8:
                 data = data << (8 - bitspersample)

--- a/imageio/plugins/pillow_info.py
+++ b/imageio/plugins/pillow_info.py
@@ -149,7 +149,7 @@ pillow_formats = [
 
 
 pillow_docs = {
-    "BMP": u"""*From the Pillow docs:*
+    "BMP": """*From the Pillow docs:*
 
 
     PIL reads and writes Windows and OS/2 BMP files containing ``1``, ``L``, ``P``,
@@ -162,7 +162,7 @@ pillow_docs = {
     **compression**
         Set to ``bmp_rle`` if the file is run-length encoded.
     """,
-    "BUFR": u"""*From the Pillow docs:*
+    "BUFR": """*From the Pillow docs:*
 
 
     .. versionadded:: Pillow  1.1.3
@@ -172,13 +172,13 @@ pillow_docs = {
     To add read or write support to your application, use
     :py:func:`PIL.BufrStubImagePlugin.register_handler`.
     """,
-    "CUR": u"""*From the Pillow docs:*
+    "CUR": """*From the Pillow docs:*
 
 
     CUR is used to store cursors on Windows. The CUR decoder reads the largest
     available cursor. Animated cursors are not supported.
     """,
-    "DCX": u"""*From the Pillow docs:*
+    "DCX": """*From the Pillow docs:*
 
 
     DCX is a container file format for PCX files, defined by Intel. The DCX format
@@ -189,7 +189,7 @@ pillow_docs = {
     :py:meth:`~file.seek` or :py:mod:`~PIL.ImageSequence` to read other images.
 
     """,
-    "DDS": u"""*From the Pillow docs:*
+    "DDS": """*From the Pillow docs:*
 
 
     DDS is a popular container texture format used in video games and natively
@@ -199,8 +199,8 @@ pillow_docs = {
 
     .. versionadded:: Pillow  3.4.0 DXT3
     """,
-    "DIB": u"""No docs for DIB.""",
-    "EPS": u"""*From the Pillow docs:*
+    "DIB": """No docs for DIB.""",
+    "EPS": """*From the Pillow docs:*
 
 
     PIL identifies EPS files containing image data, and can read files that contain
@@ -225,7 +225,7 @@ pillow_docs = {
             im.load(scale=2)
             im.size #(200,200)
     """,
-    "FITS": u"""*From the Pillow docs:*
+    "FITS": """*From the Pillow docs:*
 
 
     .. versionadded:: Pillow  1.1.5
@@ -235,8 +235,8 @@ pillow_docs = {
     To add read or write support to your application, use
     :py:func:`PIL.FitsStubImagePlugin.register_handler`.
     """,
-    "FLI": u"""No docs for FLI.""",
-    "FPX": u"""*From the Pillow docs:*
+    "FLI": """No docs for FLI.""",
+    "FPX": """*From the Pillow docs:*
 
 
     PIL reads Kodak FlashPix files. In the current version, only the highest
@@ -249,7 +249,7 @@ pillow_docs = {
         library before building the Python Imaging Library. See the distribution
         README for details.
     """,
-    "FTEX": u"""*From the Pillow docs:*
+    "FTEX": """*From the Pillow docs:*
 
 
     .. versionadded:: Pillow  3.2.0
@@ -258,7 +258,7 @@ pillow_docs = {
     Independence War 2: Edge Of Chaos. The plugin reads a single texture
     per file, in the compressed and uncompressed formats.
     """,
-    "GBR": u"""*From the Pillow docs:*
+    "GBR": """*From the Pillow docs:*
 
 
     The GBR decoder reads GIMP brush files, version 1 and 2.
@@ -286,7 +286,7 @@ pillow_docs = {
         Transparency color index. This key is omitted if the image is not
         transparent.
     """,
-    "GIF": u"""*From the Pillow docs:*
+    "GIF": """*From the Pillow docs:*
 
 
     PIL reads GIF87a and GIF89a versions of the GIF file format. The library writes
@@ -390,7 +390,7 @@ pillow_docs = {
             im.size = (x1 - x0, y1 - y0)
             im.tile = [(tag, (0, 0) + im.size, offset, extra)]
     """,
-    "GRIB": u"""*From the Pillow docs:*
+    "GRIB": """*From the Pillow docs:*
 
 
     .. versionadded:: Pillow  1.1.5
@@ -404,7 +404,7 @@ pillow_docs = {
     To add read or write support to your application, use
     :py:func:`PIL.GribStubImagePlugin.register_handler`.
     """,
-    "HDF5": u"""*From the Pillow docs:*
+    "HDF5": """*From the Pillow docs:*
 
 
     .. versionadded:: Pillow  1.1.5
@@ -414,7 +414,7 @@ pillow_docs = {
     To add read or write support to your application, use
     :py:func:`PIL.Hdf5StubImagePlugin.register_handler`.
     """,
-    "ICNS": u"""*From the Pillow docs:*
+    "ICNS": """*From the Pillow docs:*
 
 
     PIL reads and (macOS only) writes macOS ``.icns`` files.  By default, the
@@ -433,7 +433,7 @@ pillow_docs = {
         ask for ``(512, 512, 2)``, the final value of
         :py:attr:`~PIL.Image.Image.size` will be ``(1024, 1024)``).
     """,
-    "ICO": u"""*From the Pillow docs:*
+    "ICO": """*From the Pillow docs:*
 
 
     ICO is used to store icons on Windows. The largest available icon is read.
@@ -455,14 +455,14 @@ pillow_docs = {
 
     IM is the only format that can store all internal PIL formats.
     """,
-    "IM": u"""No docs for IM.""",
-    "IMT": u"""*From the Pillow docs:*
+    "IM": """No docs for IM.""",
+    "IMT": """*From the Pillow docs:*
 
 
     PIL reads Image Tools images containing ``L`` data.
     """,
-    "IPTC": u"""No docs for IPTC.""",
-    "JPEG": u"""*From the Pillow docs:*
+    "IPTC": """No docs for IPTC.""",
+    "JPEG": """*From the Pillow docs:*
 
 
     PIL reads JPEG, JFIF, and Adobe JPEG files containing ``L``, ``RGB``, or
@@ -572,7 +572,7 @@ pillow_docs = {
         before building the Python Imaging Library. See the distribution README for
         details.
     """,
-    "JPEG2000": u"""*From the Pillow docs:*
+    "JPEG2000": """*From the Pillow docs:*
 
 
     .. versionadded:: Pillow  2.4.0
@@ -660,12 +660,12 @@ pillow_docs = {
        you fail to do this, you will get errors about not being able to load the
        ``_imaging`` DLL).
     """,
-    "MCIDAS": u"""*From the Pillow docs:*
+    "MCIDAS": """*From the Pillow docs:*
 
 
     PIL identifies and reads 8-bit McIdas area files.
     """,
-    "MIC": u"""*From the Pillow docs:*
+    "MIC": """*From the Pillow docs:*
 
 
     PIL identifies and reads Microsoft Image Composer (MIC) files. When opened, the
@@ -674,12 +674,12 @@ pillow_docs = {
 
     Note that there may be an embedded gamma of 2.2 in MIC files.
     """,
-    "MPEG": u"""*From the Pillow docs:*
+    "MPEG": """*From the Pillow docs:*
 
 
     PIL identifies MPEG files.
     """,
-    "MPO": u"""*From the Pillow docs:*
+    "MPO": """*From the Pillow docs:*
 
 
     Pillow identifies and reads Multi Picture Object (MPO) files, loading the primary
@@ -687,25 +687,25 @@ pillow_docs = {
     methods may be used to read other pictures from the file. The pictures are
     zero-indexed and random access is supported.
     """,
-    "MSP": u"""*From the Pillow docs:*
+    "MSP": """*From the Pillow docs:*
 
 
     PIL identifies and reads MSP files from Windows 1 and 2. The library writes
     uncompressed (Windows 1) versions of this format.
     """,
-    "PCD": u"""*From the Pillow docs:*
+    "PCD": """*From the Pillow docs:*
 
 
     PIL reads PhotoCD files containing ``RGB`` data. This only reads the 768x512
     resolution image from the file. Higher resolutions are encoded in a proprietary
     encoding.
     """,
-    "PCX": u"""*From the Pillow docs:*
+    "PCX": """*From the Pillow docs:*
 
 
     PIL reads and writes PCX files containing ``1``, ``L``, ``P``, or ``RGB`` data.
     """,
-    "PIXAR": u"""*From the Pillow docs:*
+    "PIXAR": """*From the Pillow docs:*
 
 
     PIL provides limited support for PIXAR raster files. The library can identify
@@ -713,7 +713,7 @@ pillow_docs = {
 
     The format code is ``PIXAR``.
     """,
-    "PNG": u"""*From the Pillow docs:*
+    "PNG": """*From the Pillow docs:*
 
 
     PIL identifies, reads, and writes PNG files containing ``1``, ``L``, ``P``,
@@ -797,25 +797,25 @@ pillow_docs = {
         library before building the Python Imaging Library. See the installation
         documentation for details.
     """,
-    "PPM": u"""*From the Pillow docs:*
+    "PPM": """*From the Pillow docs:*
 
 
     PIL reads and writes PBM, PGM and PPM files containing ``1``, ``L`` or ``RGB``
     data.
     """,
-    "PSD": u"""*From the Pillow docs:*
+    "PSD": """*From the Pillow docs:*
 
 
     PIL identifies and reads PSD files written by Adobe Photoshop 2.5 and 3.0.
 
     """,
-    "SGI": u"""*From the Pillow docs:*
+    "SGI": """*From the Pillow docs:*
 
 
     Pillow reads and writes uncompressed ``L``, ``RGB``, and ``RGBA`` files.
 
     """,
-    "SPIDER": u"""*From the Pillow docs:*
+    "SPIDER": """*From the Pillow docs:*
 
 
     PIL reads and writes SPIDER image files of 32-bit floating point data
@@ -855,13 +855,13 @@ pillow_docs = {
     .. _SPIDER homepage: https://spider.wadsworth.org/spider_doc/spider/docs/spider.html
     .. _Wadsworth Center: https://www.wadsworth.org/
     """,
-    "SUN": u"""No docs for SUN.""",
-    "TGA": u"""*From the Pillow docs:*
+    "SUN": """No docs for SUN.""",
+    "TGA": """*From the Pillow docs:*
 
 
     PIL reads 24- and 32-bit uncompressed and run-length encoded TGA files.
     """,
-    "TIFF": u"""*From the Pillow docs:*
+    "TIFF": """*From the Pillow docs:*
 
 
     Pillow reads and writes TIFF files. It can read both striped and tiled
@@ -993,7 +993,7 @@ pillow_docs = {
         an equal x and y resolution, dpi also implies a unit of inches.
 
     """,
-    "WMF": u"""*From the Pillow docs:*
+    "WMF": """*From the Pillow docs:*
 
 
     PIL can identify playable WMF files.
@@ -1024,12 +1024,12 @@ pillow_docs = {
         WmfImagePlugin.register_handler(wmf_handler)
 
         im = Image.open("sample.wmf")""",
-    "XBM": u"""*From the Pillow docs:*
+    "XBM": """*From the Pillow docs:*
 
 
     PIL reads and writes X bitmap files (mode ``1``).
     """,
-    "XPM": u"""*From the Pillow docs:*
+    "XPM": """*From the Pillow docs:*
 
 
     PIL reads X pixmap files (mode ``P``) with 256 colors or less.
@@ -1041,5 +1041,5 @@ pillow_docs = {
         Transparency color index. This key is omitted if the image is not
         transparent.
     """,
-    "XVThumb": u"""No docs for XVThumb.""",
+    "XVThumb": """No docs for XVThumb.""",
 }

--- a/imageio/plugins/pillow_legacy.py
+++ b/imageio/plugins/pillow_legacy.py
@@ -424,7 +424,7 @@ class PNGFormat(PillowFormat):
                 kwargs["compress_level"] = compression
             if quantize is not None:
                 for bits in range(1, 9):
-                    if 2 ** bits == quantize:
+                    if 2**bits == quantize:
                         break
                 else:
                     raise ValueError(

--- a/imageio/plugins/pillowmulti.py
+++ b/imageio/plugins/pillowmulti.py
@@ -236,7 +236,7 @@ class GifWriter:
         if loop == 1:
             return b""
         if loop == 0:
-            loop = 2 ** 16 - 1
+            loop = 2**16 - 1
         bb = b""
         if loop != 0:  # omit the extension if we would like a nonlooping gif
             bb = b"\x21\xFF\x0B"  # application extension

--- a/imageio/plugins/spe.py
+++ b/imageio/plugins/spe.py
@@ -403,7 +403,7 @@ class SDTControlSpec:
         "sdt_major_version": CommentDesc(4, slice(66, 68), int),
         "sdt_minor_version": CommentDesc(4, slice(68, 70), int),
         "sdt_controller_name": CommentDesc(4, slice(0, 6), str),
-        "exposure_time": CommentDesc(1, slice(64, 73), float, 10 ** -6),
+        "exposure_time": CommentDesc(1, slice(64, 73), float, 10**-6),
         "color_code": CommentDesc(4, slice(10, 14), str),
         "detection_channels": CommentDesc(4, slice(15, 16), int),
         "background_subtraction": CommentDesc(4, 14, lambda x: x == "B"),
@@ -414,18 +414,18 @@ class SDTControlSpec:
         "sequence_type": CommentDesc(
             4, slice(6, 10), lambda x: __class__.sequence_types[x]
         ),
-        "grid": CommentDesc(4, slice(16, 25), float, 10 ** -6),
+        "grid": CommentDesc(4, slice(16, 25), float, 10**-6),
         "n_macro": CommentDesc(1, slice(0, 4), int),
-        "delay_macro": CommentDesc(1, slice(10, 19), float, 10 ** -3),
+        "delay_macro": CommentDesc(1, slice(10, 19), float, 10**-3),
         "n_mini": CommentDesc(1, slice(4, 7), int),
-        "delay_mini": CommentDesc(1, slice(19, 28), float, 10 ** -6),
+        "delay_mini": CommentDesc(1, slice(19, 28), float, 10**-6),
         "n_micro": CommentDesc(1, slice(7, 10), int),
-        "delay_micro": CommentDesc(1, slice(28, 37), float, 10 ** -6),
+        "delay_micro": CommentDesc(1, slice(28, 37), float, 10**-6),
         "n_subpics": CommentDesc(1, slice(7, 10), int),
-        "delay_shutter": CommentDesc(1, slice(73, 79), float, 10 ** -6),
-        "delay_prebleach": CommentDesc(1, slice(37, 46), float, 10 ** -6),
-        "bleach_time": CommentDesc(1, slice(46, 55), float, 10 ** -6),
-        "recovery_time": CommentDesc(1, slice(55, 64), float, 10 ** -6),
+        "delay_shutter": CommentDesc(1, slice(73, 79), float, 10**-6),
+        "delay_prebleach": CommentDesc(1, slice(37, 46), float, 10**-6),
+        "bleach_time": CommentDesc(1, slice(46, 55), float, 10**-6),
+        "recovery_time": CommentDesc(1, slice(55, 64), float, 10**-6),
     }
 
     @staticmethod

--- a/semantic_release_conf.py
+++ b/semantic_release_conf.py
@@ -102,7 +102,7 @@ COMMIT_TYPES = [
 
 _commit_filter = "|".join(c.tag for c in COMMIT_TYPES)
 re_parser = re.compile(
-    fr"(?P<tag>{_commit_filter})?"
+    rf"(?P<tag>{_commit_filter})?"
     r"(?:\((?P<scope>[^\n]+)\))?"
     r":? "
     r"(?P<subject>[^\n]+):?"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,7 +150,7 @@ def clear_plugins():
 def invalid_file(tmp_path, request):
     ext = request.param
     with open(tmp_path / ("foo" + ext), "w") as file:
-        file.write("Actually not a file.")
+        file.write("This is not an image.")
 
     return tmp_path / ("foo" + ext)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -984,3 +984,25 @@ def test_sort_order_restore():
     new_order = iio.config.known_extensions[".png"][0].priority.copy()
 
     assert old_order == new_order
+
+
+def test_imopen_format_hint(image_files):
+    image_bytes = Path(image_files / "chelsea.png").read_bytes()
+
+    with iio.v3.imopen(image_bytes, "r", format_hint=".png") as resource:
+        result = resource.read()
+
+    expected = iio.v3.imread(image_files / "chelsea.png")
+
+    assert np.allclose(result, expected)
+
+
+@pytest.mark.parametrize("invalid_file", [".jpg"], indirect=["invalid_file"])
+def test_imopen_format_hint_malformatted(invalid_file):
+    with pytest.raises(ValueError):
+        # format_hint should be ".png"
+        iio.v3.imopen(invalid_file, "r", format_hint="PNG")
+
+    with pytest.raises(IOError):
+        # format_hint is invalid and opening should fail
+        iio.v3.imopen(invalid_file, "r", format_hint=".cap")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -518,10 +518,10 @@ def test_util_image_as_uint():
 
     test_arrays = (  # (input, output bitdepth, expected output)
         # No bitdepth specified, assumed to be 8-bit
-        (np.array([0, 2 ** 8 - 1], "uint8"), None, np.uint8([0, 255])),
-        (np.array([0, 2 ** 16 - 1], "uint16"), None, np.uint8([0, 255])),
-        (np.array([0, 2 ** 32 - 1], "uint32"), None, np.uint8([0, 255])),
-        (np.array([0, 2 ** 64 - 1], "uint64"), None, np.uint8([0, 255])),
+        (np.array([0, 2**8 - 1], "uint8"), None, np.uint8([0, 255])),
+        (np.array([0, 2**16 - 1], "uint16"), None, np.uint8([0, 255])),
+        (np.array([0, 2**32 - 1], "uint32"), None, np.uint8([0, 255])),
+        (np.array([0, 2**64 - 1], "uint64"), None, np.uint8([0, 255])),
         (np.array([-2, 2], "int8"), None, np.uint8([0, 255])),
         (np.array([-2, 2], "int16"), None, np.uint8([0, 255])),
         (np.array([-2, 2], "int32"), None, np.uint8([0, 255])),
@@ -533,10 +533,10 @@ def test_util_image_as_uint():
         (np.array([-1.0, 1.0], "float32"), None, np.uint8([0, 255])),
         (np.array([-1.0, 1.0], "float64"), None, np.uint8([0, 255])),
         # 8-bit output
-        (np.array([0, 2 ** 8 - 1], "uint8"), 8, np.uint8([0, 255])),
-        (np.array([0, 2 ** 16 - 1], "uint16"), 8, np.uint8([0, 255])),
-        (np.array([0, 2 ** 32 - 1], "uint32"), 8, np.uint8([0, 255])),
-        (np.array([0, 2 ** 64 - 1], "uint64"), 8, np.uint8([0, 255])),
+        (np.array([0, 2**8 - 1], "uint8"), 8, np.uint8([0, 255])),
+        (np.array([0, 2**16 - 1], "uint16"), 8, np.uint8([0, 255])),
+        (np.array([0, 2**32 - 1], "uint32"), 8, np.uint8([0, 255])),
+        (np.array([0, 2**64 - 1], "uint64"), 8, np.uint8([0, 255])),
         (np.array([-2, 2], "int8"), 8, np.uint8([0, 255])),
         (np.array([-2, 2], "int16"), 8, np.uint8([0, 255])),
         (np.array([-2, 2], "int32"), 8, np.uint8([0, 255])),
@@ -548,10 +548,10 @@ def test_util_image_as_uint():
         (np.array([-1.0, 1.0], "float32"), 8, np.uint8([0, 255])),
         (np.array([-1.0, 1.0], "float64"), 8, np.uint8([0, 255])),
         # 16-bit output
-        (np.array([0, 2 ** 8 - 1], "uint8"), 16, np.uint16([0, 65535])),
-        (np.array([0, 2 ** 16 - 1], "uint16"), 16, np.uint16([0, 65535])),
-        (np.array([0, 2 ** 32 - 1], "uint32"), 16, np.uint16([0, 65535])),
-        (np.array([0, 2 ** 64 - 1], "uint64"), 16, np.uint16([0, 65535])),
+        (np.array([0, 2**8 - 1], "uint8"), 16, np.uint16([0, 65535])),
+        (np.array([0, 2**16 - 1], "uint16"), 16, np.uint16([0, 65535])),
+        (np.array([0, 2**32 - 1], "uint32"), 16, np.uint16([0, 65535])),
+        (np.array([0, 2**64 - 1], "uint64"), 16, np.uint16([0, 65535])),
         (np.array([-2, 2], "int8"), 16, np.uint16([0, 65535])),
         (np.array([-2, 2], "int16"), 16, np.uint16([0, 65535])),
         (np.array([-2, 2], "int32"), 16, np.uint16([0, 65535])),
@@ -716,10 +716,10 @@ def test_functions(test_images, tmp_path):
         (1, 1),
         ("1", 1),
         ("8B", 8),
-        ("1MB", 1000 ** 2),
-        ("1M", 1000 ** 2),
-        ("1GiB", 1024 ** 3),
-        ("1.5TB", 1.5 * 1000 ** 4),
+        ("1MB", 1000**2),
+        ("1M", 1000**2),
+        ("1GiB", 1024**3),
+        ("1.5TB", 1.5 * 1000**4),
     ],
 )
 def test_to_nbytes_correct(arg, expected):
@@ -736,7 +736,7 @@ def test_to_nbytes_incorrect(arg):
 def test_memtest(test_images, tmp_path):
     fname3 = test_images / "newtonscradle.gif"
     imageio.mimread(fname3)  # trivial case
-    imageio.mimread(fname3, memtest=1000 ** 2 * 256)
+    imageio.mimread(fname3, memtest=1000**2 * 256)
     imageio.mimread(fname3, memtest="256MB")
     imageio.mimread(fname3, memtest="256M")
     imageio.mimread(fname3, memtest="256MiB")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -998,12 +998,11 @@ def test_imopen_format_hint(image_files):
 
 
 @pytest.mark.parametrize("invalid_file", [".jpg"], indirect=["invalid_file"])
-def test_imopen_format_hint_malformatted(invalid_file):
+def test_imopen_format_hint_malformatted(invalid_file, test_images):
     with pytest.raises(ValueError):
         # format_hint should be ".png"
         iio.v3.imopen(invalid_file, "r", format_hint="PNG")
 
     with pytest.warns(UserWarning):
         # format_hint is invalid and should emit a warning
-        with iio.v3.imopen(invalid_file, "r", format_hint=".cap"):
-            pass
+        iio.v3.imread(test_images / "chelsea.png", format_hint=".cap")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1003,6 +1003,7 @@ def test_imopen_format_hint_malformatted(invalid_file):
         # format_hint should be ".png"
         iio.v3.imopen(invalid_file, "r", format_hint="PNG")
 
-    with pytest.raises(IOError):
-        # format_hint is invalid and opening should fail
-        iio.v3.imopen(invalid_file, "r", format_hint=".cap")
+    with pytest.warns(UserWarning):
+        # format_hint is invalid and should emit a warning
+        with iio.v3.imopen(invalid_file, "r", format_hint=".cap"):
+            pass

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -640,7 +640,7 @@ def test_reverse_read(tmpdir):
 
 def test_read_stream(test_images):
     """Test stream reading workaround"""
-    
+
     video_blob = Path(test_images / "cockatoo.mp4").read_bytes()
 
     result = imageio.v3.imread(video_blob, index=5, format_hint=".mp4")

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -9,6 +9,7 @@ import gc
 import time
 import threading
 import platform
+from pathlib import Path
 
 import numpy as np
 
@@ -635,3 +636,14 @@ def test_reverse_read(tmpdir):
         print("reading", i)
         W.get_data(i)
     W.close()
+
+
+def test_read_stream(test_images):
+    """Test stream reading workaround"""
+    
+    video_blob = Path(test_images / "cockatoo.mp4").read_bytes()
+
+    result = imageio.v3.imread(video_blob, format_hint=".mp4")
+    expected = imageio.v3.imread("imageio:cockatoo.mp4")
+
+    assert np.allclose(result, expected)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -643,7 +643,7 @@ def test_read_stream(test_images):
     
     video_blob = Path(test_images / "cockatoo.mp4").read_bytes()
 
-    result = imageio.v3.imread(video_blob, format_hint=".mp4")
-    expected = imageio.v3.imread("imageio:cockatoo.mp4")
+    result = imageio.v3.imread(video_blob, index=5, format_hint=".mp4")
+    expected = imageio.v3.imread("imageio:cockatoo.mp4", index=5)
 
     assert np.allclose(result, expected)

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -84,8 +84,8 @@ def test_fits_get_reader(normal_plugin_order, tmp_path):
 
     sigma = 10
     xx, yy = np.meshgrid(np.arange(512), np.arange(512))
-    z = (1 / (2 * np.pi * (sigma ** 2))) * np.exp(
-        -((xx ** 2) + (yy ** 2)) / (2 * (sigma ** 2))
+    z = (1 / (2 * np.pi * (sigma**2))) * np.exp(
+        -((xx**2) + (yy**2)) / (2 * (sigma**2))
     )
     img = np.log(z)
     phdu = fits.PrimaryHDU()


### PR DESCRIPTION
I didn't create an explicit issue for this PR, because I thought demonstrating it is easier than describing it.

The PR adds a new keyword argument (called `format_hint`) to `imopen` (and subsequentially to `imread`, `imwrite`, and `imiter` in the v3 API. It allows a new fast path for ImageResources without an explicit extension (e.g., streams, bytes and FileLike Objects) or for files for which the extension doesn't match the actual content of the file. It works pretty much like the fast path we have for file extensions, i.e., try plugins that are associated with that extension first. Hints are provided using the format's file extension, e.g. `imread(something, format_hint=".jpg")`.

In addition, it will overwrite/set the extension of a Request if the extension for that request was previously `None`. This is useful to elevate some of the pains tracked in #686. With this, ffmpeg streams can now be read via

```python
# this is a video as bytes
video_blob = Path("path/to/video.mp4).read_bytes()

# raises IOError, because FFMPEG's can_read is too naive
# ndimage = imageio.v3.imread(video_blob)

# with the hint, FFMPEG can read blobs directly again
ndimage = imageio.v3.imread(video_blob, format_hint=".mp4")
```

This is, ofc, only a workaround, but I think its already much better than not being able to read them anymore.