### PR TITLE
FEAT: improps and immeta

### DIFF
--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -328,6 +328,7 @@ API, which is documented below:
 .. autosummary::
 
     imageio.plugins
+    imageio.core.v3_plugin.api.PluginV3
 
 The file itself should be placed into our plugins folder at
 ``imageio\plugins\your_plugin.py``.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -330,6 +330,7 @@ API, which is documented below:
     imageio.plugins
 
 .. autosummary::
+    :template: better_class.rst
     :toctree: ../_autosummary
 
     imageio.core.v3_plugin_api.PluginV3

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -328,7 +328,11 @@ API, which is documented below:
 .. autosummary::
 
     imageio.plugins
-    imageio.core.v3_plugin.api.PluginV3
+
+.. autosummary::
+    :toctree: ../_autosummary
+
+    imageio.core.v3_plugin_api.PluginV3
 
 The file itself should be placed into our plugins folder at
 ``imageio\plugins\your_plugin.py``.

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -12,6 +12,7 @@ from .request import (
     IOMode,
     Request,
 )
+from .v3_plugin_api import PluginV3
 
 
 def _get_config(plugin: str, legacy_mode: bool) -> PluginConfig:
@@ -70,7 +71,7 @@ def imopen(
     format_hint: str = None,
     legacy_mode: bool = True,
     **kwargs,
-) -> Any:
+) -> PluginV3:
     """Open an ImageResource.
 
     .. warning::

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -239,7 +239,7 @@ class LegacyPlugin(PluginV3):
 
         """
 
-        # for backwards compatibility ... actually reads the image :(
+        # for backwards compatibility ... actually reads pixel data :(
         image = self.read(index=index)
 
         return ImageProperties(shape=image.shape, dtype=image.dtype)

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -127,8 +127,6 @@ class LegacyPlugin(PluginV3):
 
         if index is None:
             img = np.stack([im for im in self.iter(**kwargs)])
-            if len(img) == 1:
-                img = np.squeeze(img, axis=0)
             return img
 
         reader = self.legacy_get_reader(**kwargs)

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -3,9 +3,10 @@ from typing import Optional, Dict, Any
 from pathlib import Path
 
 from .request import IOMode, Request, InitializationError
+from .v3_plugin_api import PluginV3, ImageProperties
 
 
-class LegacyPlugin:
+class LegacyPlugin(PluginV3):
     """A plugin to  make old (v2.9) plugins compatible with v3.0
 
     .. depreciated:: 2.9
@@ -219,6 +220,29 @@ class LegacyPlugin:
         reader = self.legacy_get_reader(**kwargs)
         for image in reader:
             yield image
+
+    def properties(self, index: int = None) -> ImageProperties:
+        """Standardized ndimage metadata.
+
+        Parameters
+        ----------
+        index : int
+            The index of the ndimage for which to return properties. If the
+            index is out of bounds a ``ValueError`` is raised. If ``None``,
+            return the properties for the ndimage stack. If this is impossible,
+            e.g., due to shape missmatch, an exception will be raised.
+
+        Returns
+        -------
+        properties : ImageProperties
+            A dataclass filled with standardized image metadata.
+
+        """
+
+        # for backwards compatibility ... actually reads the image :(
+        image = self.read(index=index)
+
+        return ImageProperties(shape=image.shape, dtype=image.dtype)
 
     def get_meta(self, *, index=None) -> Dict[str, Any]:
         """Read ndimage metadata from the URI

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -103,7 +103,7 @@ class LegacyPlugin(PluginV3):
         self._request.get_file().seek(0)
         return self._format.get_reader(self._request)
 
-    def read(self, *, index=None, **kwargs) -> np.ndarray:
+    def read(self, *, index: Optional[int] = 0, **kwargs) -> np.ndarray:
         """
         Parses the given URI and creates a ndarray from it.
 
@@ -221,7 +221,7 @@ class LegacyPlugin(PluginV3):
         for image in reader:
             yield image
 
-    def properties(self, index: int = None) -> ImageProperties:
+    def properties(self, index: Optional[int] = 0) -> ImageProperties:
         """Standardized ndimage metadata.
 
         Parameters
@@ -244,7 +244,7 @@ class LegacyPlugin(PluginV3):
 
         return ImageProperties(shape=image.shape, dtype=image.dtype)
 
-    def get_meta(self, *, index=None) -> Dict[str, Any]:
+    def get_meta(self, *, index: Optional[int] = 0) -> Dict[str, Any]:
         """Read ndimage metadata from the URI
 
         Parameters
@@ -267,7 +267,7 @@ class LegacyPlugin(PluginV3):
         return self.metadata(index=index, exclude_applied=False)
 
     def metadata(
-        self, index: int = None, exclude_applied: bool = True
+        self, index: Optional[int] = 0, exclude_applied: bool = True
     ) -> Dict[str, Any]:
         """Format-Specific ndimage metadata.
 

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -295,12 +295,6 @@ class LegacyPlugin(PluginV3):
 
         return self.legacy_get_reader().get_meta_data(index=index)
 
-    def __enter__(self) -> "LegacyPlugin":
-        return self
-
-    def __exit__(self, type, value, traceback) -> None:
-        self._request.finish()
-
     def __del__(self) -> None:
         pass
         # turns out we can't close the file here for LegacyPlugin

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -240,6 +240,35 @@ class LegacyPlugin:
 
         """
 
+        return self.metadata(index=index, exclude_applied=False)
+
+    def metadata(
+        self, index: int = None, exclude_applied: bool = True
+    ) -> Dict[str, Any]:
+        """Format-Specific ndimage metadata.
+
+        Parameters
+        ----------
+        index : int
+            The index of the ndimage to read. If the index is out of bounds a
+            ``ValueError`` is raised. If ``None``, global metadata is returned.
+        exclude_applied : bool
+            If True (default), do not report metadata fields that the plugin
+            would apply/consume while reading the image.
+
+        Returns
+        -------
+        metadata : dict
+            A dictionary filled with format-specific metadata fields and their
+            values.
+
+        """
+
+        if exclude_applied:
+            raise ValueError(
+                "Legacy plugins don't support excluding applied metadata fields."
+            )
+
         return self.legacy_get_reader().get_meta_data(index=index)
 
     def __enter__(self) -> "LegacyPlugin":

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -240,7 +240,11 @@ class LegacyPlugin(PluginV3):
         # for backwards compatibility ... actually reads pixel data :(
         image = self.read(index=index)
 
-        return ImageProperties(shape=image.shape, dtype=image.dtype)
+        return ImageProperties(
+            shape=image.shape,
+            dtype=image.dtype,
+            is_batch=True if index is None else False,
+        )
 
     def get_meta(self, *, index: Optional[int] = 0) -> Dict[str, Any]:
         """Read ndimage metadata from the URI

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -1,0 +1,343 @@
+from . import Request
+from numpy.typing import ArrayLike
+import numpy as np
+from typing import Optional, Dict, Any, Tuple, Union, List
+
+
+class ImageDescriptor:
+    def __init__(self, shape: Tuple[int, ...], dtype: np.dtype) -> None:
+        # TODO: replace with dataclass once py3.6 is dropped.
+        self.shape: shape
+        self.dtype: dtype
+
+
+class PluginV3:
+    """A ImageIO Plugin.
+
+    This is an abstract plugin that documents the v3 plugin API interface. A
+    plugin is an adapter/wrapper around a backend that converts a request from
+    iio.core (e.g., read an image from file) into a sequence of instructions for
+    the backend that fullfill the request.
+
+    Plugin authors may choose to subclass this class when implementing a new
+    plugin, but aren't obliged to do so. As long as the plugin class implements
+    the interface (methods) described below the ImageIO core will treat it just
+    like any other plugin.
+
+
+    Parameters
+    ----------
+    request : iio.Request
+        A request object that represents the users intent. It provides a
+        standard interface to access various the various ImageResources and
+        serves them to the plugin as a file object (or file). Check the docs for
+        details.
+    **kwargs : Any
+        Additional configuration arguments for the plugin or backend. Usually
+        these match with configuration arguments available on the backend and
+        are forwarded to it.
+
+
+    Raises
+    ------
+    InitializationError
+        During ``__init__`` the plugin tests if it can fulfill the request. If
+        it can't, e.g., because the request points to a file in the wrong
+        format, then it should raise an ``InitializationError`` and provide a
+        reason for failure. This reason may be reported to the user.
+    ImportError
+        Plugins will be imported dynamically when listed in
+        ``iio.config.known_plugins`` to fullfill requests. This way, users only
+        have to load plugins/backends they actually use. If this plugin's backend
+        is not installed, it should raise an ``ImportError`` either during
+        module import or during class construction.
+
+    Notes
+    -----
+    Upon successful construction the plugin takes ownership of the provided
+    request. This means that it is the plugin's responsibility to call
+    request.finish() to close the resource when it is no longer needed.
+
+    Plugins _must_ implement a context manager that closes and cleans any
+    resources held by the plugin upon exit.
+
+    """
+
+    def __init__(self, request: Request) -> None:
+        """Initialize a new Plugin Instance.
+
+        See Plugin's docstring for detailed documentation.
+
+        Notes
+        -----
+        The implementation here stores the request as a local variable that is
+        exposed using a @property below. If you inherit from PluginV3, remember
+        to call ``super().__init__(request)``.
+
+        """
+
+        self._request = request
+
+    def read(self, *, index: int = None) -> np.ndarray:
+        """Read a ndimage.
+
+        The ``read`` method loads a (single) ndimage, located at ``index`` from
+        the requested ImageResource.
+
+        It is at the plugin's descretion to decide (and document) what
+        constitutes a single ndimage. A sensible way to make this decision is to
+        choose based on the ImageResource's format and on what users will expect
+        from such a format. For example, a sensible choice for a TIFF file
+        produced by an ImageJ hyperstack is to read it as a volumetric ndimage
+        (1 color dimension followed by 3 spatial dimensions). On the other hand,
+        a sensible choice for a MP4 file produced by Davinci Resolve is to treat
+        each frame as a ndimage (2 spatial dimensions followed by 1 color
+        dimension).
+
+        The value ``index=None`` is special. It requests the plugin to load all
+        ndimages in the file and stack them along a new first axis. For example,
+        if a MP4 file is read with ``index=None`` and the plugin identifies
+        single frames as ndimages, then the plugin should read all frames and
+        stack them into a new ndimage which now contains a time axis as its
+        first axis. If a PNG file (single image format) is read with
+        ``index=None`` the plugin does a very similar thing: It loads all
+        ndimages in the file (here it's just one) and stacks them along a new
+        first axis, effectively prepending an axis with size 1 to the image. If
+        a plugin does not wish to support ``index=None`` it should set a more
+        sensible default and raise a ``ValueError`` when requested to read using
+        ``index=None``.
+
+        Parameters
+        ----------
+        index : int
+            The index of the ndimage to read. If the index is out of bounds a
+            ``ValueError`` is raised. If ``None``, the plugin reads all ndimages
+            in the file and stacks them along a new, prepended, batch dimension.
+            If stacking is impossible, e.g., due to shape missmatch, an
+            exception will be raised.
+        **kwargs : Any
+            The read method may accept any number of plugin-specific keyword
+            arguments to further customize the read behavior. Usually these
+            match the arguments available on the backend and are forwarded to
+            it.
+
+        Returns
+        -------
+        ndimage : np.ndarray
+            A ndimage containing decoded pixel data (sometimes called bitmap).
+
+        Notes
+        -----
+        Plugins may choose a different (more sensible) default value for ``index``.
+
+        The ImageResource from which the plugin should read is managed by the
+        provided request object. Directly accessing the managed ImageResource is
+        _not_ permitted. Instead, you can get FileLike access to the
+        ImageResource via request.get_file().
+
+        If the backend doesn't support reading from FileLike objects, you can
+        request a temporary file to pass to the backend via
+        ``request.get_local_filename()``. This is, however, not very performant
+        (involves copying the Request's content into a temporary file), so you
+        should avoid doing this whenever possible. Consider it a fallback method
+        in case all else fails.
+
+        """
+        raise NotImplementedError()
+
+    def write(self, ndimage: Union[ArrayLike, List[ArrayLike]]) -> Optional[bytes]:
+        """Write a ndimage to a ImageResource.
+
+        The ``write`` method encodes the given ndimage into the format handled
+        by the backend and writes it to the ImageResource. It overwrites
+        any content that may have been previously stored in the file.
+
+        If the backend supports only a single format then it must check if
+        the ImageResource matches that format and raise an exception if not.
+        Typically, this should be done during initialization in the form of a
+        ``InitializationError``.
+
+        If the backend supports more than one format it must determine the
+        requested/desired format. Usually this can be done by inspecting the
+        ImageResource (e.g., by checking ``request.extension``), or by providing
+        a mechanism to explicitly set the format (perhaps with a - sensible -
+        default value). If the plugin can not determine the desired format, it
+        _must not_ write to the ImageResource, but raise an exception instead.
+
+        If the backend supports at least one format that can hold multiple
+        ndimages it should be capable of handling ndimage batches and lists of
+        ndimages. If the ``ndimage`` input is as a list of ndimages, the plugin
+        should expect that the ndimages are not stackable, i.e., that they have
+        different shapes and/or dimensions. Otherwise, the ``ndimage`` may be a
+        batch of multiple ndimages stacked along the first axis of the array.
+        The plugin must be able to discover this, either automatically or via
+        additional `kwargs`. If there is ambiguity in the process, the plugin
+        must clearly document what happens in such cases and, if possible,
+        describe how to resolve this ambiguity.
+
+        Parameters
+        ----------
+        ndimage : ArrayLike
+            The ndimage to encode and write to the current ImageResource.
+        **kwargs : Any
+            The write method may accept any number of plugin-specific keyword
+            arguments to customize the writing behavior. Usually these match the
+            arguments available on the backend and are forwarded to it.
+
+        Returns
+        -------
+        encoded_image : bytes or None
+            If the chosen ImageResource is the special target ``"<bytes>"`` then
+            write should return a byte string containing the encoded image data.
+            Otherwise, it returns None.
+
+        Notes
+        -----
+        The ImageResource to which the plugin should write to is managed by the
+        provided request object. Directly accessing the managed ImageResource is
+        _not_ permitted. Instead, you can get FileLike access to the
+        ImageResource via request.get_file().
+
+        If the backend doesn't support writing to FileLike objects, you can
+        request a temporary file to pass to the backend via
+        ``request.get_local_filename()``. This is, however, not very performant
+        (involves copying the Request's content from a temporary file), so you
+        should avoid doing this whenever possible. Consider it a fallback method
+        in case all else fails.
+
+        """
+        raise NotImplementedError()
+
+    def iter(self) -> np.ndarray:
+        """Iterate the ImageResource.
+
+        This method returns a generator that yields ndimages in the order in which
+        they appear in the file. This is roughly equivalent to::
+
+            idx = 0
+            while True:
+                try:
+                    yield self.read(index=idx)
+                except ValueError:
+                    break
+
+        It works very similar to ``read``, and you can consult the documentation
+        of that method for additional information on desired behavior.
+
+        Parameters
+        ----------
+        **kwargs : Any
+            The iter method may accept any number of plugin-specific keyword
+            arguments to further customize the reading/iteration behavior.
+            Usually these match the arguments available on the backend and are
+            forwarded to it.
+
+        Yields
+        ------
+        ndimage : np.ndarray
+            A ndimage containing decoded pixel data (sometimes called bitmap).
+
+        See Also
+        --------
+        PluginV3.read
+
+        """
+        raise NotImplementedError()
+
+    def descriptor(self, index: int = None) -> ImageDescriptor:
+        """Standardized ndimage metadata.
+
+        Parameters
+        ----------
+        index : int
+            The index of the ndimage for which to return the descriptor. If the
+            index is out of bounds a ``ValueError`` is raised. If ``None``,
+            return the descriptor for the ndimage stack. If this is impossible,
+            e.g., due to shape missmatch, an exception will be raised.
+
+        Returns
+        -------
+        descriptor : ImageDescriptor
+            A dataclass filled with standardized image metadata.
+
+        """
+        raise NotImplementedError()
+
+    def metadata(
+        self, index: int = None, exclude_applied: bool = True
+    ) -> Dict[str, Any]:
+        """Format-Specific ndimage metadata.
+
+        The method reads metadata stored in the ImageResource and returns it as
+        a python dict. The plugin is free to choose which name to give a piece
+        of metadata; however, if possible, it should match the name given by the
+        format. On top, there is no requirement regarding which fields should be
+        present, with exception of ``exclude_applied``.
+
+        If the plugin does return metadata items, it must check the value of
+        ``exclude_applied`` before returning them. If ``exclude applied`` is
+        True, then any metadata item that would be applied to an ndimage
+        returned by ``read`` (or ``iter``) must not be returned. This is done to
+        avoid confusion; for example, if an ImageResource defines the ExIF
+        rotation tag, and the plugin applies the rotation to the data before
+        returning it, then ``exclude_applied`` prevents confusion on whether the
+        tag was already applied or not.
+
+        The _kwarg_ ``index`` behaves similar to its counterpart in ``read``
+        with one exception: If the ``index`` is None, then global metadata is
+        returned instead of returning a combination of all metadata items. If
+        there is no global metadata, the Plugin should return an empty dict or
+        raise an exception. Just like before, the plugin may choose a more
+        sensible default value for ``index``.
+
+        Parameters
+        ----------
+        index : int
+            The index of the ndimage to read. If the index is out of bounds a
+            ``ValueError`` is raised. If ``None``, global metadata is returned.
+        exclude_applied : bool
+            If True (default), do not report metadata fields that the plugin
+            would apply/consume while reading the image.
+
+        Returns
+        -------
+        metadata : dict
+            A dictionary filled with format-specific metadata fields and their
+            values.
+
+        """
+        raise NotImplementedError()
+
+    def close(self) -> None:
+        """Close the ImageResource.
+
+        This method allows a plugin to behave similar to the python build-in ``open``::
+
+            image_file = my_plugin(Request, "r")
+            ...
+            image_file.close()
+
+        It is used by context manager and deconstructor below to avoid leaking
+        ImageResources. If the plugin has no other cleanup to do it doesn#t have
+        to overwrite this method itself and can rely on the implementation
+        below.
+
+        Notes
+        -----
+
+        """
+
+        self.request.finish()
+
+    @property
+    def request(self) -> Request:
+        return self._request
+
+    def __enter__(self) -> "PluginV3":
+        return self
+
+    def __exit__(self, type, value, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -26,7 +26,7 @@ class ImageProperties:
     spacing : Tuple
         A tuple describing the spacing between pixels along each axis of the
         ndimage. If the spacing is uniform along an axis the value corresponding
-        to that axis is a single int. If the spacing is non-uniform, the value
+        to that axis is a single float. If the spacing is non-uniform, the value
         corresponding to that axis is a tuple in which the i-th element
         indicates the spacing between the i-th and (i+1)-th pixel along that
         axis.

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -4,11 +4,11 @@ import numpy as np
 from typing import Optional, Dict, Any, Tuple, Union, List
 
 
-class ImageDescriptor:
+class ImageProperties:
     def __init__(self, shape: Tuple[int, ...], dtype: np.dtype) -> None:
         # TODO: replace with dataclass once py3.6 is dropped.
-        self.shape: shape
-        self.dtype: dtype
+        self.shape = shape
+        self.dtype = dtype
 
 
 class PluginV3:
@@ -244,20 +244,20 @@ class PluginV3:
         """
         raise NotImplementedError()
 
-    def descriptor(self, index: int = None) -> ImageDescriptor:
+    def properties(self, index: int = None) -> ImageProperties:
         """Standardized ndimage metadata.
 
         Parameters
         ----------
         index : int
-            The index of the ndimage for which to return the descriptor. If the
+            The index of the ndimage for which to return properties. If the
             index is out of bounds a ``ValueError`` is raised. If ``None``,
-            return the descriptor for the ndimage stack. If this is impossible,
+            return the properties for the ndimage stack. If this is impossible,
             e.g., due to shape missmatch, an exception will be raised.
 
         Returns
         -------
-        descriptor : ImageDescriptor
+        properties : ImageProperties
             A dataclass filled with standardized image metadata.
 
         """

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -64,12 +64,11 @@ class PluginV3:
     ----------
     request : iio.Request
         A request object that represents the users intent. It provides a
-        standard interface to access various the various ImageResources and
-        serves them to the plugin as a file object (or file). Check the docs for
-        details.
+        standard interface to access the various ImageResources and serves them
+        to the plugin as a file object (or file). Check the docs for details.
     **kwargs : Any
         Additional configuration arguments for the plugin or backend. Usually
-        these match with configuration arguments available on the backend and
+        these match the configuration arguments available on the backend and
         are forwarded to it.
 
 
@@ -163,8 +162,6 @@ class PluginV3:
 
         Notes
         -----
-        Plugins may choose a different (more sensible) default value for ``index``.
-
         The ImageResource from which the plugin should read is managed by the
         provided request object. Directly accessing the managed ImageResource is
         _not_ permitted. Instead, you can get FileLike access to the
@@ -201,14 +198,14 @@ class PluginV3:
 
         If the backend supports at least one format that can hold multiple
         ndimages it should be capable of handling ndimage batches and lists of
-        ndimages. If the ``ndimage`` input is as a list of ndimages, the plugin
-        should expect that the ndimages are not stackable, i.e., that they have
-        different shapes and/or dimensions. Otherwise, the ``ndimage`` may be a
-        batch of multiple ndimages stacked along the first axis of the array.
-        The plugin must be able to discover this, either automatically or via
-        additional `kwargs`. If there is ambiguity in the process, the plugin
-        must clearly document what happens in such cases and, if possible,
-        describe how to resolve this ambiguity.
+        ndimages. If the ``ndimage`` input is a list of ndimages, the plugin
+        should not assume that the ndimages are not stackable, i.e., ndimages
+        may have different shapes. Otherwise, the ``ndimage`` may be a batch of
+        multiple ndimages stacked along the first axis of the array. The plugin
+        must be able to discover this, either automatically or via additional
+        `kwargs`. If there is ambiguity in the process, the plugin must clearly
+        document what happens in such cases and, if possible, describe how to
+        resolve this ambiguity.
 
         Parameters
         ----------
@@ -304,8 +301,9 @@ class PluginV3:
         The method reads metadata stored in the ImageResource and returns it as
         a python dict. The plugin is free to choose which name to give a piece
         of metadata; however, if possible, it should match the name given by the
-        format. On top, there is no requirement regarding which fields should be
-        present, with exception of ``exclude_applied``.
+        format. There is no requirement regarding the fields a plugin must
+        expose; however, if a plugin does expose any,``exclude_applied`` applies
+        to these fields.
 
         If the plugin does return metadata items, it must check the value of
         ``exclude_applied`` before returning them. If ``exclude applied`` is
@@ -320,8 +318,7 @@ class PluginV3:
         with one exception: If the ``index`` is None, then global metadata is
         returned instead of returning a combination of all metadata items. If
         there is no global metadata, the Plugin should return an empty dict or
-        raise an exception. Just like before, the plugin may choose a more
-        sensible default value for ``index``.
+        raise an exception.
 
         Parameters
         ----------
@@ -350,13 +347,10 @@ class PluginV3:
             ...
             image_file.close()
 
-        It is used by context manager and deconstructor below to avoid leaking
-        ImageResources. If the plugin has no other cleanup to do it doesn#t have
+        It is used by the context manager and deconstructor below to avoid leaking
+        ImageResources. If the plugin has no other cleanup to do it doesn't have
         to overwrite this method itself and can rely on the implementation
         below.
-
-        Notes
-        -----
 
         """
 

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -283,7 +283,7 @@ class PluginV3:
         returning it, then ``exclude_applied`` prevents confusion on whether the
         tag was already applied or not.
 
-        The _kwarg_ ``index`` behaves similar to its counterpart in ``read``
+        The `kwarg` ``index`` behaves similar to its counterpart in ``read``
         with one exception: If the ``index`` is None, then global metadata is
         returned instead of returning a combination of all metadata items. If
         there is no global metadata, the Plugin should return an empty dict or

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -113,7 +113,7 @@ class PluginV3:
 
         self._request = request
 
-    def read(self, *, index: int = None) -> np.ndarray:
+    def read(self, *, index: int = 0) -> np.ndarray:
         """Read a ndimage.
 
         The ``read`` method loads a (single) ndimage, located at ``index`` from
@@ -279,7 +279,7 @@ class PluginV3:
         """
         raise NotImplementedError()
 
-    def properties(self, index: int = None) -> ImageProperties:
+    def properties(self, index: int = 0) -> ImageProperties:
         """Standardized ndimage metadata.
 
         Parameters
@@ -298,9 +298,7 @@ class PluginV3:
         """
         raise NotImplementedError()
 
-    def metadata(
-        self, index: int = None, exclude_applied: bool = True
-    ) -> Dict[str, Any]:
+    def metadata(self, index: int = 0, exclude_applied: bool = True) -> Dict[str, Any]:
         """Format-Specific ndimage metadata.
 
         The method reads metadata stored in the ImageResource and returns it as

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -2,13 +2,48 @@ from . import Request
 from numpy.typing import ArrayLike
 import numpy as np
 from typing import Optional, Dict, Any, Tuple, Union, List
+from dataclasses import dataclass
 
 
+@dataclass
 class ImageProperties:
-    def __init__(self, shape: Tuple[int, ...], dtype: np.dtype) -> None:
-        # TODO: replace with dataclass once py3.6 is dropped.
-        self.shape = shape
-        self.dtype = dtype
+    """Standardized Metadata
+
+    ImageProperties represent a set of standardized metadata that is available
+    under the same name for every supported format. If the ImageResource (or
+    format) does not specify the value, a sensible default value is chosen
+    instead.
+
+    Attributes
+    ----------
+    shape : Tuple[int, ...]
+        The shape of the loaded ndimage.
+    dtype : np.dtype
+        The dtype of the loaded ndimage.
+    is_batch : bool
+        If True, the first dimension of the ndimage represents a batch dimension
+        along which several images are stacked.
+    spacing : Tuple
+        A tuple describing the spacing between pixels along each axis of the
+        ndimage. If the spacing is uniform along an axis the value corresponding
+        to that axis is a single int. If the spacing is non-uniform, the value
+        corresponding to that axis is a tuple in which the i-th element
+        indicates the spacing between the i-th and (i+1)-th pixel along that
+        axis.
+
+    """
+
+    shape: Tuple[int, ...]
+    dtype: np.dtype
+    is_batch: bool = False
+    spacing: Tuple = None
+
+    def __post_init__(self):
+        if self.spacing is None:
+            if self.is_batch:
+                self.spacing = (1,) * (len(self.shape) - 1)
+            else:
+                self.spacing = (1,) * len(self.shape)
 
 
 class PluginV3:

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -194,7 +194,7 @@ class PluginV3:
         ImageResource (e.g., by checking ``request.extension``), or by providing
         a mechanism to explicitly set the format (perhaps with a - sensible -
         default value). If the plugin can not determine the desired format, it
-        _must not_ write to the ImageResource, but raise an exception instead.
+        **must not** write to the ImageResource, but raise an exception instead.
 
         If the backend supports at least one format that can hold multiple
         ndimages it should be capable of handling ndimage batches and lists of

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -34,8 +34,6 @@ from PIL import Image, UnidentifiedImageError, ImageSequence, ExifTags
 from ..core.request import Request, IOMode, InitializationError, URI_FILE, URI_BYTES
 from ..core.v3_plugin_api import PluginV3, ImageProperties
 
-from typing import Dict, Any
-
 
 def _is_multichannel(mode: str) -> bool:
     """Returns true if the color mode uses more than one channel.

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -404,4 +404,5 @@ class PillowPlugin(PluginV3):
         return ImageProperties(
             shape=shape,
             dtype=dummy.dtype,
+            is_batch=True if index is None else False,
         )

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -153,7 +153,7 @@ class PillowPlugin(PluginV3):
         self._request.finish()
 
     def read(
-        self, *, index=None, mode=None, rotate=False, apply_gamma=False
+        self, *, index=0, mode=None, rotate=False, apply_gamma=False
     ) -> np.ndarray:
         """
         Parses the given URI and creates a ndarray from it.
@@ -330,12 +330,10 @@ class PillowPlugin(PluginV3):
         if self._request._uri_type == URI_BYTES:
             return self._request.get_file().getvalue()
 
-    def get_meta(self, *, index=None) -> Dict[str, Any]:
+    def get_meta(self, *, index=0) -> Dict[str, Any]:
         return self.metadata(index=index, exclude_applied=False)
 
-    def metadata(
-        self, index: int = None, exclude_applied: bool = True
-    ) -> Dict[str, Any]:
+    def metadata(self, index: int = 0, exclude_applied: bool = True) -> Dict[str, Any]:
         """Read ndimage metadata from the URI
 
         Parameters
@@ -369,7 +367,7 @@ class PillowPlugin(PluginV3):
 
         return metadata
 
-    def properties(self, index: int = None) -> ImageProperties:
+    def properties(self, index: int = 0) -> ImageProperties:
         """Standardized ndimage metadata.
 
         Parameters

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -431,7 +431,7 @@ class PillowPlugin(PluginV3):
         else:
             self._image.seek(index)
 
-        shape = self._image.size
+        shape = self._image.size[::-1]
 
         if self._image.format == "GIF":
             # GIF will have the first mode as P and the following as

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -32,6 +32,9 @@ from typing import Optional, Dict, Any
 import numpy as np
 from PIL import Image, UnidentifiedImageError, ImageSequence, ExifTags
 from ..core.request import Request, IOMode, InitializationError, URI_FILE, URI_BYTES
+from ..core.v3_plugin_api import PluginV3, ImageProperties
+
+from typing import Dict, Any
 
 
 def _is_multichannel(mode: str) -> bool:
@@ -70,6 +73,43 @@ def _is_multichannel(mode: str) -> bool:
     return Image.getmodebands(mode) > 1
 
 
+def _mode_to_dtype(mode: str) -> np.dtype:
+    # this is synced to pillow 9.0.0
+    # refactor if https://github.com/python-pillow/Pillow/issues/5990 gets
+    # resolved in an admissible way
+    _MODE_CONV = {
+        # official modes
+        "1": "|b1",  # Bits need to be extended to bytes
+        "L": "|u1",
+        "LA": "|u1",
+        "I": "i4",
+        "F": "f4",
+        "P": "|u1",
+        "RGB": "|u1",
+        "RGBX": "|u1",
+        "RGBA": "|u1",
+        "CMYK": "|u1",
+        "YCbCr": "|u1",
+        "LAB": "|u1",  # UNDONE - unsigned |u1i1i1
+        "HSV": "|u1",
+        # I;16 == I;16L, and I;32 == I;32L
+        "I;16": "<u2",
+        "I;16B": ">u2",
+        "I;16L": "<u2",
+        "I;16S": "<i2",
+        "I;16BS": ">i2",
+        "I;16LS": "<i2",
+        "I;32": "<u4",
+        "I;32B": ">u4",
+        "I;32L": "<u4",
+        "I;32S": "<i4",
+        "I;32BS": ">i4",
+        "I;32LS": "<i4",
+    }
+
+    return np.dtype(_MODE_CONV[mode])
+
+
 def _exif_orientation_transform(orientation, mode):
     # get transformation that transforms an image from a
     # given EXIF orientation into the standard orientation
@@ -91,7 +131,7 @@ def _exif_orientation_transform(orientation, mode):
     return EXIF_ORIENTATION[orientation]
 
 
-class PillowPlugin(object):
+class PillowPlugin(PluginV3):
     def __init__(self, request: Request) -> None:
         """Instantiate a new Pillow Plugin Object
 
@@ -102,7 +142,8 @@ class PillowPlugin(object):
 
         """
 
-        self._request = request
+        super().__init__(request)
+
         self._image = None
 
         if request.mode.io_mode == IOMode.read:
@@ -230,7 +271,7 @@ class PillowPlugin(object):
             image = image.convert(image.palette.mode)
         image = np.asarray(image)
 
-        meta = self.get_meta()
+        meta = self.metadata(exclude_applied=False)
         if rotate and "Orientation" in meta:
             transformation = _exif_orientation_transform(
                 meta["Orientation"], self._image.mode
@@ -329,6 +370,11 @@ class PillowPlugin(object):
             return self._request.get_file().getvalue()
 
     def get_meta(self, *, index=None) -> Dict[str, Any]:
+        return self.metadata(index=index, exclude_applied=False)
+
+    def metadata(
+        self, index: int = None, exclude_applied: bool = True
+    ) -> Dict[str, Any]:
         """Read ndimage metadata from the URI
 
         Parameters
@@ -342,7 +388,7 @@ class PillowPlugin(object):
         if index is not None:
             self._image.seek(index)
 
-        metadata = self._image.info
+        metadata = self._image.info.copy()
         metadata["mode"] = self._image.mode
         metadata["shape"] = self._image.size
 
@@ -357,13 +403,47 @@ class PillowPlugin(object):
             exif_data.pop("unknown", None)
             metadata.update(exif_data)
 
-        return self._image.info
+        if exclude_applied:
+            metadata.pop("Orientation")
 
-    def __enter__(self) -> "PillowPlugin":
-        return self
+        return metadata
 
-    def __exit__(self, type, value, traceback) -> None:
-        self.close()
+    def properties(self, index: int = None) -> ImageProperties:
+        """Standardized ndimage metadata.
 
-    def __del__(self) -> None:
-        self.close()
+        Parameters
+        ----------
+        index : int
+            The index of the ndimage for which to return properties. If the
+            index is out of bounds a ``ValueError`` is raised. If ``None``,
+            return the properties for the ndimage stack. If this is impossible,
+            e.g., due to shape missmatch, an exception will be raised.
+
+        Returns
+        -------
+        properties : ImageProperties
+            A dataclass filled with standardized image metadata.
+
+        """
+
+        if index is None:
+            self._image.seek(0)
+        else:
+            self._image.seek(index)
+
+        shape = self._image.size
+
+        if self._image.format == "GIF":
+            # GIF will have the first mode as P and the following as
+            # RGB or RGBA depending on the pallette type
+            shape = (*shape, Image.getmodebands(self._image.palette.mode))
+        elif _is_multichannel(self._image.mode):
+            shape = (*shape, Image.getmodebands(self._image.mode))
+
+        if index is None:
+            shape = (self._image.n_frames, *shape)
+
+        return ImageProperties(
+            shape=shape,
+            dtype=_mode_to_dtype(self._image.mode),
+        )

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -363,13 +363,12 @@ class PillowPlugin(PluginV3):
             metadata.update(exif_data)
 
         if exclude_applied:
-            metadata.pop("Orientation")
+            metadata.pop("Orientation", None)
 
         return metadata
 
     def properties(self, index: int = 0) -> ImageProperties:
-        """Standardized ndimage metadata.
-
+        """Standardized ndimage metadata
         Parameters
         ----------
         index : int

--- a/imageio/v3.py
+++ b/imageio/v3.py
@@ -1,5 +1,6 @@
 from typing import Iterator, Optional
 
+from imageio.core.v3_plugin_api import ImageProperties
 import numpy as np
 
 from .core.imopen import imopen
@@ -140,4 +141,46 @@ def imwrite(
     return encoded
 
 
-__all__ = ["imopen", "imread", "imwrite", "imiter"]
+def improps(uri, *, index: int = None, plugin: str = None, **kwargs) -> ImageProperties:
+    """Read standardized Image Metadata.
+
+    Opens the given URI and reads the properties of an ndimage from it. The
+    properties represent standardized metadata. This means that they will have
+    the same name regardless of the format being read or plugin/backend being
+    used. Further, any field will be, where possible, populated with a sensible
+    default (may be `None`) if the ImageResource does not declare a value in its
+    metadata.
+
+    Parameters
+    ----------
+    index : int
+        The index of the ndimage for which to return properties. If the
+        index is out of bounds a ``ValueError`` is raised. If ``None``,
+        return the properties for the ndimage stack. If this is impossible,
+        e.g., due to shape missmatch, an exception will be raised.
+    plugin : {str, None}
+        The plugin to be used. If None, performs a search for a matching
+        plugin.
+    **kwargs :
+        Additional keyword arguments will be passed to the plugin's ``properties``
+        call.
+
+    Returns
+    -------
+    properties : ImageProperties
+        A dataclass filled with standardized image metadata.
+
+    Notes
+    -----
+    Where possible, this will avoid loading pixel data.
+
+    """
+
+    plugin_kwargs = {"legacy_mode": False, "plugin": plugin}
+
+    with imopen(uri, "w", **plugin_kwargs) as img_file:
+        properties = img_file.properties(index=index, **kwargs)
+
+    return properties
+
+__all__ = ["imopen", "imread", "imwrite", "imiter", "improps"]

--- a/imageio/v3.py
+++ b/imageio/v3.py
@@ -4,6 +4,7 @@ from imageio.core.v3_plugin_api import ImageProperties
 import numpy as np
 
 from .core.imopen import imopen
+from typing import Optional, Iterator, Dict, Any
 
 
 def imread(
@@ -142,7 +143,7 @@ def imwrite(
 
 
 def improps(uri, *, index: int = None, plugin: str = None, **kwargs) -> ImageProperties:
-    """Read standardized Image Metadata.
+    """Read standardized metadata.
 
     Opens the given URI and reads the properties of an ndimage from it. The
     properties represent standardized metadata. This means that they will have
@@ -183,4 +184,54 @@ def improps(uri, *, index: int = None, plugin: str = None, **kwargs) -> ImagePro
 
     return properties
 
-__all__ = ["imopen", "imread", "imwrite", "imiter", "improps"]
+
+def immeta(
+    uri,
+    *,
+    index: int = None,
+    plugin: str = None,
+    exclude_applied: bool = True,
+    **kwargs
+) -> Dict[str, Any]:
+    """Read format-specific metadata.
+
+    Opens the given URI and reads metadata for an ndimage from it. The contents
+    of the returned metadata dictionary is specific to both the image format and
+    plugin used to open the ImageResource. To learn about the exact behavior,
+    check the documentation of the relevant plugin. Typically, immeta returns a
+    dictionary specific to the image format, where keys match metadata field
+    names and values are a field's contents.
+
+    Parameters
+    ----------
+    uri : {str, pathlib.Path, bytes, file}
+        The resource to load the image from, e.g. a filename, pathlib.Path, http
+        address or file object, see the docs for more info.
+    index : {int, None}
+        If the URI contains multiple ndimages, select the index-th ndimage from
+        among them and return it.
+    plugin : {str, None}
+        The plugin to be used. If None (default), performs a search for a
+        matching plugin.
+    **kwargs :
+        Additional keyword arguments will be passed to the plugin's metadata
+        method.
+
+    Returns
+    -------
+    image : ndimage
+        The ndimage located at the given URI.
+
+    """
+
+    plugin_kwargs = {"legacy_mode": False, "plugin": plugin}
+
+    with imopen(uri, "r", **plugin_kwargs) as img_file:
+        metadata = img_file.metadata(
+            index=index, exclude_applied=exclude_applied, **kwargs
+        )
+
+    return metadata
+
+
+__all__ = ["imopen", "imread", "imwrite", "imiter", "improps", "immeta"]

--- a/imageio/v3.py
+++ b/imageio/v3.py
@@ -1,10 +1,10 @@
-from typing import Iterator, Optional
+from typing import Any, Dict, Iterator, Optional
 
-from imageio.core.v3_plugin_api import ImageProperties
 import numpy as np
 
+from imageio.core.v3_plugin_api import ImageProperties
+
 from .core.imopen import imopen
-from typing import Optional, Iterator, Dict, Any
 
 
 def imread(

--- a/imageio/v3.py
+++ b/imageio/v3.py
@@ -178,7 +178,7 @@ def improps(uri, *, index: int = None, plugin: str = None, **kwargs) -> ImagePro
 
     plugin_kwargs = {"legacy_mode": False, "plugin": plugin}
 
-    with imopen(uri, "w", **plugin_kwargs) as img_file:
+    with imopen(uri, "r", **plugin_kwargs) as img_file:
         properties = img_file.properties(index=index, **kwargs)
 
     return properties

--- a/imageio/v3.py
+++ b/imageio/v3.py
@@ -8,7 +8,12 @@ from .core.imopen import imopen
 
 
 def imread(
-    uri, *, index: int = None, plugin: str = None, format_hint: str = None, **kwargs
+    uri,
+    *,
+    index: Optional[int] = 0,
+    plugin: str = None,
+    format_hint: str = None,
+    **kwargs
 ) -> np.ndarray:
     """Read an ndimage from a URI.
 
@@ -142,7 +147,9 @@ def imwrite(
     return encoded
 
 
-def improps(uri, *, index: int = None, plugin: str = None, **kwargs) -> ImageProperties:
+def improps(
+    uri, *, index: Optional[int] = 0, plugin: str = None, **kwargs
+) -> ImageProperties:
     """Read standardized metadata.
 
     Opens the given URI and reads the properties of an ndimage from it. The
@@ -188,7 +195,7 @@ def improps(uri, *, index: int = None, plugin: str = None, **kwargs) -> ImagePro
 def immeta(
     uri,
     *,
-    index: int = None,
+    index: Optional[int] = 0,
     plugin: str = None,
     exclude_applied: bool = True,
     **kwargs

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ class build_with_images(sdist):
 
 # pinned to > 8.3.2 due to security vulnerability
 # See: https://github.com/advisories/GHSA-98vv-pw6r-q6q4
-install_requires = ["numpy", "pillow >= 8.3.2"]
+install_requires = ["numpy >= 1.20.0", "pillow >= 8.3.2"]
 
 extras_require = {
     "build": ["wheel"],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -886,6 +886,7 @@ def test_imiter(test_images):
 
     full_image = iio.v3.imread(
         test_images / "newtonscradle.gif",
+        index=None,
         plugin="pillow",
         mode="RGB",
     )

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -689,3 +689,11 @@ def test_gamma_correction(setup_library, test_images):
     # test_regression_302
     for im in (im1, im2, im3):
         assert im.shape == (512, 768, 3) and im.dtype == "uint8"
+
+
+def test_improps(test_images):
+    props = imageio.v3.improps(test_images / "kodim03.png", plugin="PNG-FI")
+
+    assert props.shape == (512, 768, 3)
+    assert props.dtype == np.uint8
+    assert props.is_batch is False

--- a/tests/test_legacy_plugin_wrapper.py
+++ b/tests/test_legacy_plugin_wrapper.py
@@ -22,3 +22,10 @@ def test_exception_message_bytes():
     except ValueError as e:
         assert "This will not be reported." not in str(e)
         assert "<bytes>" in str(e)
+
+
+def test_exclude_applied(test_images):
+    with pytest.raises(ValueError):
+        iio.v3.immeta(
+            test_images / "chelsea.png", exclude_applied=True, plugin="PNG-PIL"
+        )

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -205,9 +205,11 @@ def test_png_transparent_pixel(test_images):
 
 
 def test_png_gamma_correction(test_images):
-    with iio.imopen(test_images / "kodim03.png", "r", plugin="pillow") as f:
-        im1 = f.read()
-        im1_meta = f.get_meta()
+    # opens the file twice, but touches more parts of the API
+    im1 = iio.v3.imread(test_images / "kodim03.png", plugin="pillow")
+    im1_meta = iio.v3.immeta(
+        test_images / "kodim03.png", plugin="pillow", exclude_applied=False
+    )
 
     im2 = iio.v3.imread(
         test_images / "kodim03.png",

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -9,6 +9,7 @@ import numpy as np
 from PIL import Image, ImageSequence
 
 import imageio as iio
+from imageio.core.v3_plugin_api import PluginV3
 from imageio.plugins.pillow import PillowPlugin
 from imageio.core.request import InitializationError
 
@@ -576,3 +577,28 @@ def test_quantized_gif(test_images, tmp_path):
 
     for original_frame, quantized_frame in zip(original, quantized):
         assert len(np.unique(quantized_frame)) <= len(np.unique(original_frame))
+
+
+def test_properties(image_files: Path):
+    file: PluginV3
+
+    # test a flat image (RGB PNG)
+    with iio.v3.imopen(image_files / "chelsea.png", "r", plugin="pillow") as file:
+        properties = file.properties(index=0)
+
+    assert properties.shape == (451, 300, 3)
+    assert properties.dtype == np.uint8
+
+    # test a ndimage (GIF)
+    with iio.v3.imopen(image_files / "newtonscradle.gif", "r", plugin="pillow") as file:
+        properties = file.properties(index=None)
+
+    assert properties.shape == (36, 200, 150, 3)
+    assert properties.dtype == np.uint8
+
+    # test a flat gray image
+    with iio.v3.imopen(image_files / "text.png", "r", plugin="pillow") as file:
+        properties = file.properties(index=None)
+
+    assert properties.shape == (36, 200, 150, 3)
+    assert properties.dtype == np.uint8

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -586,19 +586,17 @@ def test_properties(image_files: Path):
     with iio.v3.imopen(image_files / "chelsea.png", "r", plugin="pillow") as file:
         properties = file.properties(index=0)
 
-    assert properties.shape == (451, 300, 3)
+    assert properties.shape == (300, 451, 3)
     assert properties.dtype == np.uint8
 
     # test a ndimage (GIF)
-    with iio.v3.imopen(image_files / "newtonscradle.gif", "r", plugin="pillow") as file:
-        properties = file.properties(index=None)
-
-    assert properties.shape == (36, 200, 150, 3)
+    properties = iio.v3.improps(image_files / "newtonscradle.gif", plugin="pillow")
+    assert properties.shape == (36, 150, 200, 3)
     assert properties.dtype == np.uint8
 
     # test a flat gray image
     with iio.v3.imopen(image_files / "text.png", "r", plugin="pillow") as file:
-        properties = file.properties(index=None)
+        properties = file.properties(index=0)
 
-    assert properties.shape == (36, 200, 150, 3)
+    assert properties.shape == (172, 448)
     assert properties.dtype == np.uint8

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -1,6 +1,7 @@
 """ Tests for imageio's pillow plugin
 """
 
+from pathlib import Path
 from imageio.core.request import Request
 import os
 import io
@@ -204,7 +205,7 @@ def test_png_transparent_pixel(test_images):
     assert im.shape == (24, 30, 4)
 
 
-def test_png_gamma_correction(test_images):
+def test_png_gamma_correction(test_images: Path):
     # opens the file twice, but touches more parts of the API
     im1 = iio.v3.imread(test_images / "kodim03.png", plugin="pillow")
     im1_meta = iio.v3.immeta(

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -596,7 +596,7 @@ def test_properties(image_files: Path):
     )
     assert properties.shape == (36, 150, 200, 3)
     assert properties.dtype == np.uint8
-    assert properties.is_batch == True
+    assert properties.is_batch is True
 
     # test a flat gray image
     with iio.v3.imopen(image_files / "text.png", "r", plugin="pillow") as file:

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -603,3 +603,8 @@ def test_properties(image_files: Path):
 
     assert properties.shape == (172, 448)
     assert properties.dtype == np.uint8
+
+
+def test_metadata(test_images):
+    meta = iio.v3.immeta(test_images / "newtonscradle.gif")
+    assert "version" in meta and meta["version"] == b"GIF89a"

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -85,7 +85,7 @@ def test_write_multiframe(test_images, tmp_path, im_npy, im_out, im_comp):
 )
 def test_read(test_images, im_in, mode):
     im_path = test_images / im_in
-    iio_im = iio.v3.imread(im_path, plugin="pillow", mode=mode)
+    iio_im = iio.v3.imread(im_path, plugin="pillow", mode=mode, index=None)
 
     pil_im = np.asarray(
         [
@@ -93,8 +93,6 @@ def test_read(test_images, im_in, mode):
             for frame in ImageSequence.Iterator(Image.open(im_path))
         ]
     )
-    if pil_im.shape[0] == 1:
-        pil_im = pil_im.squeeze(axis=0)
 
     assert np.allclose(iio_im, pil_im)
 
@@ -116,7 +114,7 @@ def test_gif_legacy_pillow(test_images, im_in, mode):
 
     im_path = test_images / im_in
     with iio.imopen(im_path, "r", legacy_mode=True, plugin="GIF-PIL") as file:
-        iio_im = file.read(pilmode=mode)
+        iio_im = file.read(pilmode=mode, index=None)
 
     pil_im = np.asarray(
         [
@@ -593,7 +591,9 @@ def test_properties(image_files: Path):
     assert properties.dtype == np.uint8
 
     # test a ndimage (GIF)
-    properties = iio.v3.improps(image_files / "newtonscradle.gif", plugin="pillow")
+    properties = iio.v3.improps(
+        image_files / "newtonscradle.gif", plugin="pillow", index=None
+    )
     assert properties.shape == (36, 150, 200, 3)
     assert properties.dtype == np.uint8
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -596,6 +596,7 @@ def test_properties(image_files: Path):
     )
     assert properties.shape == (36, 150, 200, 3)
     assert properties.dtype == np.uint8
+    assert properties.is_batch == True
 
     # test a flat gray image
     with iio.v3.imopen(image_files / "text.png", "r", plugin="pillow") as file:


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/362 https://github.com/imageio/imageio/issues/382 https://github.com/imageio/imageio/issues/501 https://github.com/imageio/imageio/issues/502 https://github.com/imageio/imageio/issues/503

This PR adds two new functions to the v3 API: `iio.improps` and `iio.immeta`. `improps` returns a ImageProperties object which contains standardized metadata, and `immeta` returns a dict object that contains format-specific metadata. 

It also adds a `imageio.core.v3_plugin_api.PluginV3` class that documents the plugin-side API for v3 plugins.

Further, I added implementations for `metadata` and `properties` to the v3 pillow plugin to support the newly added functions. For this plugin, reading of `properties` happens (as far as I know) without touching pixel data.

@almarklein @jni strike one ⚾ 🎉 

Still pending:

- [x] implement `properties` and `metadata` for legacy_plugin_wrapper (this will likely touch pixel data in the process)
- [x] implement `immeta` wrapper around `imopen`
- [x] `spacing` in `ImageProperties` (@almarklein where is it stored? Do you have an example image I can test with?)