### PR TITLE
DEV: deprecate python 3.6 support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.6", "3.7", "3.8", "3.9"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - name: Linux py37 full
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ name: CI
 # 
 # - Linting/Style (Black)
 # - Invokes the unit tests in no-internet mode on python 3.8
-# - runs unit test on cypthon in matrix mode (python 3.6, 3.7, 3.8, 3.9) x (3 major OS)
-# - runs unit tests on pypy in matrix mode (pypy 3.6, 3.7) x (3 major OS)
+# - runs unit test on cypthon in matrix mode (python 3.X) x (3 major OS)
+# - runs unit tests on pypy in matrix mode (pypy 3.X) x (3 major OS)
 
 
 on:
@@ -63,7 +63,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.6", "3.7", "3.8", "3.9"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - name: Linux py37 full
             os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Website: https://imageio.readthedocs.io/
 Imageio is a Python library that provides an easy interface to read and
 write a wide range of image data, including animated images, video,
 volumetric data, and scientific formats. It is cross-platform, runs on
-Python 3.6+, and is easy to install.
+Python 3.7+, and is easy to install.
 </p>
 
 <p>
@@ -54,7 +54,7 @@ As a user, you just have to remember a handful of functions:
     <li>Simple interface via a concise set of functions</li>
     <li>Easy to <a href='https://imageio.readthedocs.io/en/stable/getting_started/installation.html'>install</a> using Conda or pip</li>
     <li>Few dependencies (only NumPy and Pillow)</li>
-    <li>Pure Python, runs on Python 3.6+, and PyPy</li>
+    <li>Pure Python, runs on Python 3.7+, and PyPy</li>
     <li>Cross platform, runs on Windows, Linux, macOS</li>
     <li>Lots of supported <a href='https://imageio.readthedocs.io/en/stable/formats/index.html'>formats</a></li>
     <li>Read/Write support for various [resources](https://imageio.readthedocs.io/en/stable/getting_started/requests.html) (files, URLs, bytes(), file objects, ...)</li>
@@ -66,9 +66,9 @@ As a user, you just have to remember a handful of functions:
 
 Minimal requirements:
 <ul>
-    <li>Python 3.6+</li>
-    <li>NumPy</li>
-    <li>Pillow</li>
+    <li>Python 3.7+</li>
+    <li>NumPy >=1.20.0</li>
+    <li>Pillow >= 8.3.2</li>
 </ul>
 
 Optional Python packages:

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -665,7 +665,7 @@ class FrameCatcher(threading.Thread):
         self._frame_is_new = False
         self._lock = threading.RLock()
         threading.Thread.__init__(self)
-        self.setDaemon(True)  # do not let this thread hold up Python shutdown
+        self.daemon = True # do not let this thread hold up Python shutdown
         self._should_stop = False
         self.start()
 

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -665,7 +665,7 @@ class FrameCatcher(threading.Thread):
         self._frame_is_new = False
         self._lock = threading.RLock()
         threading.Thread.__init__(self)
-        self.daemon = True # do not let this thread hold up Python shutdown
+        self.daemon = True  # do not let this thread hold up Python shutdown
         self._should_stop = False
         self.start()
 

--- a/setup.py
+++ b/setup.py
@@ -241,9 +241,9 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/tasks/install_python.ps1
+++ b/tasks/install_python.ps1
@@ -96,7 +96,7 @@ function InstallPip ($python_home) {
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -eq "3.6") {
+    if ($python_version -eq "3.7") {
         $filename = "Miniconda3-4.4.10-Windows-" + $platform_suffix + ".exe"
     } else {
         $filename = "Miniconda2-4.4.10-Windows-" + $platform_suffix + ".exe"


### PR DESCRIPTION
Closes: #723 

Not much to be said. removes testing for python 3.6 and adds testing for 3.10. Also bumps all references of 3.6 to 3.7 where appropriate.