### PR TITLE
DOC: remove link to download tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/imageio.svg)](https://pypi.python.org/pypi/imageio/)
 [![PyPI Version](https://img.shields.io/pypi/v/imageio.svg)](https://pypi.python.org/pypi/imageio/)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/imageio?color=blue)](https://pypistats.org/packages/imageio)
+[PyPI Downloads](https://img.shields.io/pypi/dm/imageio?color=blue)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4972048.svg)](https://doi.org/10.5281/zenodo.4972048)
 
 


### PR DESCRIPTION
I added a download tracker based on pypi stats a while ago, and we apparently keep hitting a rate limit with it. I don't know if this is because our project's GH is getting too much traffic (7k/month shouldn't be too much tbh), or because of something else.

As a first step, I will remove the link to the tracker (and only keep the image) to see if that resolves the situation. If not, I will investigate further and potentially ask the people over at pypistats how to improve this.