### PR TITLE
DOC: add missing ! to download tracker banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/imageio.svg)](https://pypi.python.org/pypi/imageio/)
 [![PyPI Version](https://img.shields.io/pypi/v/imageio.svg)](https://pypi.python.org/pypi/imageio/)
-[PyPI Downloads](https://img.shields.io/pypi/dm/imageio?color=blue)
+![PyPI Downloads](https://img.shields.io/pypi/dm/imageio?color=blue)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4972048.svg)](https://doi.org/10.5281/zenodo.4972048)
 
 


### PR DESCRIPTION
Looks like I removed 1 character too many. Images should start with a !, but I seem to have deleted that accidentally.