### PR TITLE
DEV: make RTD fail on warnings during CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,6 +59,7 @@ jobs:
   docs:
     name: Build Docs
     needs: initial_check
+    if: needs.initial_check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,13 +59,12 @@ jobs:
   docs:
     name: Build Docs
     needs: initial_check
-    if: needs.initial_check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.8'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,22 @@ on:
 
 
 jobs:
+  docs-GH:
+    name: Build Docs
+    needs: initial_check
+    if: needs.initial_check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install Dependencies
+      run: |
+        pip install -e .[docs]
+    - name: Build Docs
+      run: sphinx-build -W ./docs ./build
+
   style:
     name: "Linting"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,12 @@ on:
 jobs:
   docs-GH:
     name: Build Docs
-    needs: initial_check
-    if: needs.initial_check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.8'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: '3.8'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,6 +2,7 @@ version: 2
 
 sphinx:
    configuration: docs/conf.py
+   fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF
 formats:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ import imageio.plugins.swf
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath("."))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,6 @@ import imageio.plugins.swf
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath("."))
-sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -25,7 +25,7 @@ done in the form of additional keyword arguments (``kwarg``). Below you can find
 a list of available plugins and which arguments they support.
 
 .. autosummary::
-    :toctree: _backends/
+    :toctree: ../_autosummary/
     :template: plugin.rst
 
     imageio.plugins.bsdf

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -27,7 +27,7 @@ Functions for reading
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
-    :toctree: _core_29/
+    :toctree: ../_autosummary/
 
     imageio.imread
     imageio.mimread
@@ -39,7 +39,7 @@ Functions for writing
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
-    :toctree: _core_29/
+    :toctree: ../_autosummary/
 
     imageio.imwrite
     imageio.mimwrite

--- a/imageio/plugins/__init__.py
+++ b/imageio/plugins/__init__.py
@@ -39,7 +39,7 @@ class plugins:
         You can always check existing plugins if you want to see examples.
 
     What methods to implement
-    --------------------------
+    -------------------------
 
     To implement a new plugin, create a new class that inherits from
     :class:`imageio.core.Format`. and implement the following functions:

--- a/imageio/plugins/__init__.py
+++ b/imageio/plugins/__init__.py
@@ -26,7 +26,7 @@ class plugins:
     ImageIO to access a new backend. Plugins are quite object oriented, and
     the relevant classes and their interaction are documented here:
 
-        .. currentmodule:: imageio
+    .. currentmodule:: imageio
 
     .. autosummary::
         :toctree: ../_autosummary

--- a/imageio/plugins/__init__.py
+++ b/imageio/plugins/__init__.py
@@ -29,7 +29,7 @@ class plugins:
         .. currentmodule:: imageio
 
     .. autosummary::
-        :toctree: _autosummary
+        :toctree: ../_autosummary
         :template: better_class.rst
 
         imageio.core.Format
@@ -45,7 +45,7 @@ class plugins:
     :class:`imageio.core.Format`. and implement the following functions:
 
     .. autosummary::
-        :toctree: _autosummary
+        :toctree: ../_autosummary
 
         imageio.core.Format.__init__
         imageio.core.Format._can_read


### PR DESCRIPTION
I noticed our CD failing while building the docs (it is set up to fail on warning to avoid broken links in the stable docs). This PR maches that behavior in our CI pipeline and also fixes the broken link (once I've tracked it down).