### PR TITLE
BUG: read metadata of current frame when iterating + APNG fast path

### DIFF
--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -81,6 +81,12 @@ extension_list = [
         priority=["RAW-FI"],
     ),
     FileExtension(
+        name="Animated Portable Network Graphics",
+        external_link="https://en.wikipedia.org/wiki/APNG",
+        extension=".apng",
+        priority=["pillow"],
+    ),
+    FileExtension(
         name="Audio Video Interleave",
         extension=".avi",
         priority=["FFMPEG"],

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -232,7 +232,7 @@ class PillowPlugin(PluginV3):
             image = image.convert(image.palette.mode)
         image = np.asarray(image)
 
-        meta = self.metadata(exclude_applied=False)
+        meta = self.metadata(index=self._image.tell(), exclude_applied=False)
         if rotate and "Orientation" in meta:
             transformation = _exif_orientation_transform(
                 meta["Orientation"], self._image.mode
@@ -344,7 +344,7 @@ class PillowPlugin(PluginV3):
             for the last read ndimage/frame.
         """
 
-        if index is not None:
+        if index is not None and self._image.tell() != index:
             self._image.seek(index)
 
         metadata = self._image.info.copy()

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -3,7 +3,6 @@
 
 from pathlib import Path
 
-from matplotlib import image
 from imageio.core.request import Request
 import os
 import io

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -2,6 +2,8 @@
 """
 
 from pathlib import Path
+
+from matplotlib import image
 from imageio.core.request import Request
 import os
 import io
@@ -609,6 +611,13 @@ def test_properties(image_files: Path):
 def test_metadata(test_images):
     meta = iio.v3.immeta(test_images / "newtonscradle.gif")
     assert "version" in meta and meta["version"] == b"GIF89a"
+
+    with iio.v3.imopen(
+        test_images / "newtonscradle.gif", "r", plugin="pillow"
+    ) as image_file:
+        image_file.read(index=5)
+        meta = image_file.metadata(index=0)
+        assert "version" in meta and meta["version"] == b"GIF89a"
 
 
 def test_apng_reading(tmp_path, test_images):

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -609,3 +609,24 @@ def test_properties(image_files: Path):
 def test_metadata(test_images):
     meta = iio.v3.immeta(test_images / "newtonscradle.gif")
     assert "version" in meta and meta["version"] == b"GIF89a"
+
+
+def test_apng_reading(tmp_path, test_images):
+    # create a APNG
+    img = iio.v3.imread(test_images / "newtonscradle.gif", index=None)
+    iio.v3.imwrite(tmp_path / "test.apng", img)
+
+    # test single image read
+    with Image.open(tmp_path / "test.apng") as im:
+        im.seek(8)
+        expected = np.asarray(im)
+    actual = iio.v3.imread(tmp_path / "test.apng", index=8)
+    assert np.allclose(actual, expected)
+
+    # test reading all frames
+    all_frames = iio.v3.imread(tmp_path / "test.apng", index=None)
+    with Image.open(tmp_path / "test.apng") as im:
+        for idx, frame in enumerate(ImageSequence.Iterator(im)):
+            expected = np.asarray(frame)
+            actual = all_frames[idx]
+            assert np.allclose(actual, expected)


### PR DESCRIPTION
This PR adds APNG to our list of extensions and enables a fast-path for it.

It also fixes a bug: When iterating over images in pillow (imiter), we need the frames metadata (to apply gamma or orientation), but we didn't extract frame-specific metadata before and instead extracted the metadata from the first frame each time. This PR fixes this behavior :)