### PR TITLE
MAINT: Cleanly determine write format in pillow

### DIFF
--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -97,6 +97,10 @@ extension_list = [
         priority=["RAW-FI"],
     ),
     FileExtension(
+        extension=".blp",
+        priority=["pillow"],
+    ),
+    FileExtension(
         name="Bitmap",
         extension=".bmp",
         priority=["pillow", "BMP-PIL", "BMP-FI", "ITK"],
@@ -183,7 +187,7 @@ extension_list = [
     ),
     FileExtension(
         name="Windows Bitmap",
-        extension=".DIB",
+        extension=".dib",
         priority=["pillow", "DIB-PIL"],
     ),
     FileExtension(
@@ -334,6 +338,10 @@ extension_list = [
     FileExtension(
         extension=".ia",
         priority=["RAW-FI"],
+    ),
+    FileExtension(
+        extension=".icb",
+        priority=["pillow"],
     ),
     FileExtension(
         name="Mac OS Icon File",
@@ -551,12 +559,12 @@ extension_list = [
     FileExtension(
         name="Moving Picture Experts Group",
         extension=".mpeg",
-        priority=["FFMPEG"],
+        priority=["pillow", "FFMPEG"],
     ),
     FileExtension(
         name="Moving Picture Experts Group",
         extension=".mpg",
-        priority=["FFMPEG"],
+        priority=["pillow", "FFMPEG"],
     ),
     FileExtension(
         name="JPEG Multi-Picture Format",
@@ -616,6 +624,10 @@ extension_list = [
         priority=["RAW-FI"],
     ),
     FileExtension(
+        extension=".palm",
+        priority=["pillow"],
+    ),
+    FileExtension(
         name="Portable Bitmap",
         extension=".pbm",
         priority=["PGM-FI", "PGMRAW-FI"],
@@ -636,6 +648,10 @@ extension_list = [
         priority=["pillow", "PCX-FI", "PCX-PIL"],
     ),
     FileExtension(
+        extension=".pdf",
+        priority=["pillow"],
+    ),
+    FileExtension(
         extension=".pef",
         priority=["RAW-FI"],
     ),
@@ -646,7 +662,7 @@ extension_list = [
     FileExtension(
         name="Portable Greymap",
         extension=".pgm",
-        priority=["PGM-FI", "PGMRAW-FI"],
+        priority=["pillow", "PGM-FI", "PGMRAW-FI"],
     ),
     FileExtension(
         name="Macintosh PICT",
@@ -664,13 +680,12 @@ extension_list = [
         priority=["pillow", "PNG-PIL", "PNG-FI", "ITK"],
     ),
     FileExtension(
-        name="Pbmplus image",
-        extension=".ppm",
-        priority=["pillow", "PPM-PIL"],
+        extension=".pnm",
+        priority=["pillow"],
     ),
     FileExtension(
         name="Pbmplus image",
-        extension=".pbm",
+        extension=".ppm",
         priority=["pillow", "PPM-PIL"],
     ),
     FileExtension(
@@ -796,7 +811,7 @@ extension_list = [
     FileExtension(
         name="Truevision TGA",
         extension=".targa",
-        priority=["TARGA-FI"],
+        priority=["pillow", "TARGA-FI"],
     ),
     FileExtension(
         name="Truevision TGA",
@@ -812,6 +827,14 @@ extension_list = [
         name="Tagged Image File Format",
         extension=".tiff",
         priority=["TIFF", "pillow", "TIFF-PIL", "TIFF-FI", "FEI", "ITK", "GDAL"],
+    ),
+    FileExtension(
+        extension=".vda",
+        priority=["pillow"],
+    ),
+    FileExtension(
+        extension=".vst",
+        priority=["pillow"],
     ),
     FileExtension(
         extension=".vtk",
@@ -844,7 +867,7 @@ extension_list = [
     FileExtension(
         name="Google WebP",
         extension=".webp",
-        priority=["WEBP-FI"],
+        priority=["pillow", "WEBP-FI"],
     ),
     FileExtension(
         name="Windows Meta File",

--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -559,7 +559,7 @@ extension_list = [
     FileExtension(
         name="Moving Picture Experts Group",
         extension=".mpeg",
-        priority=["pillow", "FFMPEG"],
+        priority=["FFMPEG"],
     ),
     FileExtension(
         name="Moving Picture Experts Group",

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -130,20 +130,18 @@ class PillowPlugin(PluginV3):
             extension = self.request.extension or self.request.format_hint
             if extension is None:
                 warnings.warn(
-                    "Can't determine file format to write. Use "
-                    "`format_hint` to disambiguate. "
-                    "This will raise an exception in ImageIO v3.0.0",
-                    FutureWarning,
+                    "Can't determine file format to write as. You _must_"
+                    " set `format` during write or the call will fail. Use "
+                    "`format_hint` to supress this warning. ",
+                    UserWarning,
                 )
                 return
 
-            Image.preinit()
-            if extension in Image.registered_extensions().keys():
-                return
-
-            Image.init()
-            if extension in Image.registered_extensions().keys():
-                return
+            tirage = [Image.preinit, Image.init]
+            for format_loader in tirage:
+                format_loader()
+                if extension in Image.registered_extensions().keys():
+                    return
 
             raise InitializationError(
                 f"Pillow can not write `{extension}` files."

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -264,7 +264,9 @@ class PillowPlugin(PluginV3):
         # check if ndimage is a batch of frames/pages (e.g. for writing GIF)
         # if mode is given, use it; otherwise fall back to image.ndim only
         if mode is not None:
-            is_batch = image.ndim > 3 if Image.getmodebands(mode) > 1 else image.ndim > 2
+            is_batch = (
+                image.ndim > 3 if Image.getmodebands(mode) > 1 else image.ndim > 2
+            )
         elif image.ndim == 2:
             is_batch = False
         elif image.ndim == 3 and image.shape[-1] in [2, 3, 4]:

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -293,13 +293,6 @@ class PillowPlugin(PluginV3):
 
         """
 
-        if format is not None:
-            warnings.warn(
-                "Using `format` is deprecated and it will be removed "
-                "in ImageIO v3.0.0. Use the `format_hint` instead.",
-                DeprecationWarning,
-            )
-
         extension = self.request.extension or self.request.format_hint
 
         save_args = {

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -644,9 +644,9 @@ def test_apng_reading(tmp_path, test_images):
 
 def test_write_format_warning():
     frames = iio.v3.imread("imageio:chelsea.png")
-    bytes_image = iio.v3.imwrite("<bytes>", frames, format_hint=".png")
+    bytes_image = iio.v3.imwrite("<bytes>", frames, format_hint=".png", plugin="pillow")
 
     with pytest.warns(UserWarning):
-        old_bytes = iio.v3.imwrite("<bytes>", frames, format="PNG")
+        old_bytes = iio.v3.imwrite("<bytes>", frames, plugin="pillow", format="PNG")
 
     assert bytes_image == old_bytes

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -645,6 +645,8 @@ def test_apng_reading(tmp_path, test_images):
 def test_write_format_deprecation():
     frames = iio.v3.imread("imageio:chelsea.png")
     bytes_image = iio.v3.imwrite("<bytes>", frames, format_hint=".png")
-    old_bytes = iio.v3.imwrite("<bytes>", frames, format="PNG")
+
+    with pytest.warns(UserWarning):
+        old_bytes = iio.v3.imwrite("<bytes>", frames, format="PNG")
 
     assert bytes_image == old_bytes

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -476,7 +476,7 @@ def test_write_to_bytes():
 
     # writing to bytes with imageIO
     with io.BytesIO() as output:
-        iio.v3.imwrite(output, image, plugin="pillow", format="PNG")
+        iio.v3.imwrite(output, image, plugin="pillow", format_hint=".png")
         iio_contents = output.getvalue()
 
     assert iio_contents == contents
@@ -492,7 +492,7 @@ def test_write_to_bytes_rgba():
 
     # writing to bytes with imageIO
     with io.BytesIO() as output:
-        iio.v3.imwrite(output, image, plugin="pillow", format="PNG", mode="RGBA")
+        iio.v3.imwrite(output, image, plugin="pillow", format_hint=".png", mode="RGBA")
         iio_contents = output.getvalue()
 
     assert iio_contents == contents
@@ -507,7 +507,7 @@ def test_write_to_bytes_imwrite():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format="PNG")
+    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format_hint=".png")
 
     assert contents == bytes_string
 
@@ -521,7 +521,9 @@ def test_write_to_bytes_jpg():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format="JPEG")
+    bytes_string = iio.v3.imwrite(
+        "<bytes>", image, plugin="pillow", format_hint=".jpeg"
+    )
 
     assert contents == bytes_string
 
@@ -532,7 +534,7 @@ def test_write_jpg_to_bytes_io():
 
     image = np.zeros((200, 200), dtype=np.uint8)
     bytes_io = io.BytesIO()
-    iio.v3.imwrite(bytes_io, image, plugin="pillow", format="jpeg", mode="L")
+    iio.v3.imwrite(bytes_io, image, plugin="pillow", format_hint=".jpeg", mode="L")
     bytes_io.seek(0)
 
     image_from_file = iio.v3.imread(bytes_io, plugin="pillow")

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -640,3 +640,11 @@ def test_apng_reading(tmp_path, test_images):
             expected = np.asarray(frame)
             actual = all_frames[idx]
             assert np.allclose(actual, expected)
+
+
+def test_write_format_deprecation():
+    frames = iio.v3.imread("imageio:chelsea.png")
+    bytes_image = iio.v3.imwrite("<bytes>", frames, format_hint=".png")
+    old_bytes = iio.v3.imwrite("<bytes>", frames, format="PNG")
+
+    assert bytes_image == old_bytes

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -642,7 +642,7 @@ def test_apng_reading(tmp_path, test_images):
             assert np.allclose(actual, expected)
 
 
-def test_write_format_deprecation():
+def test_write_format_warning():
     frames = iio.v3.imread("imageio:chelsea.png")
     bytes_image = iio.v3.imwrite("<bytes>", frames, format_hint=".png")
 


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/498, https://github.com/imageio/imageio/issues/604
Solves 50% of: https://github.com/imageio/imageio/issues/324

This PR cleans up the way pillow determines if it can write a format or not and makes use of `format_hint` to choose the writing format when writing to file/likes.

It also adds a few extensions that pillow supports but that we didn't track explicitly yet. Most notably: PDF (writing only) and WEBP (reading and writing). I"ll add a snippet to both issues.
