### PR TITLE
BUG: Provide users with the ability to read TIFF images that have the tags ``XResolution`` or ``YResolution`` with 0 in the denominator.

### DIFF
--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -466,16 +466,10 @@ class TiffFormat(Format):
             if 282 in page.tags and 283 in page.tags and 296 in page.tags:
                 resolution_x = page.tags[282].value
                 resolution_y = page.tags[283].value
-                if resolution_x[1] == 0:
+                if resolution_x[1] == 0 or resolution_y[1] == 0:
                     warnings.warn(
                         "Ignoring resulution metadata, "
-                        "because the x-direction has 0 denominator.",
-                        RuntimeWarning,
-                    )
-                elif resolution_y[1] == 0:
-                    warnings.warn(
-                        "Ignoring resulution metadata, "
-                        "because the y-direction has 0 denominator.",
+                        "because at least one direction has a 0 denominator.",
                         RuntimeWarning,
                     )
                 else:

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -465,12 +465,12 @@ class TiffFormat(Format):
             if 282 in page.tags and 283 in page.tags and 296 in page.tags:
                 resolution_x = page.tags[282].value
                 resolution_y = page.tags[283].value
-
-                meta["resolution"] = (
-                    resolution_x[0] / resolution_x[1],
-                    resolution_y[0] / resolution_y[1],
-                    page.tags[296].value.name,
-                )
+                if resolution_x[1] != 0 and resolution_y[1] != 0:
+                    meta["resolution"] = (
+                        resolution_x[0] / resolution_x[1],
+                        resolution_y[0] / resolution_y[1],
+                        page.tags[296].value.name,
+                    )
 
             return meta
 

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -169,6 +169,7 @@ from ..core import Format
 from ..core.request import URI_BYTES, URI_FILE
 
 import numpy as np
+import warnings
 
 
 try:
@@ -465,7 +466,19 @@ class TiffFormat(Format):
             if 282 in page.tags and 283 in page.tags and 296 in page.tags:
                 resolution_x = page.tags[282].value
                 resolution_y = page.tags[283].value
-                if resolution_x[1] != 0 and resolution_y[1] != 0:
+                if resolution_x[1] == 0:
+                    warnings.warn(
+                        "Ignoring resulution metadata, "
+                        "because the x-direction has 0 denominator.",
+                        RuntimeWarning,
+                    )
+                elif resolution_y[1] == 0:
+                    warnings.warn(
+                        "Ignoring resulution metadata, "
+                        "because the y-direction has 0 denominator.",
+                        RuntimeWarning,
+                    )
+                else:
                     meta["resolution"] = (
                         resolution_x[0] / resolution_x[1],
                         resolution_y[0] / resolution_y[1],

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -176,16 +176,16 @@ def test_invalid_resolution_metadata(tmp_path, resolution):
     # Overwrite low level metadata the exact way we want it
     # to avoid any re-interpretation of the metadata by imageio
     # For example, it seems that (0, 0) gets rewritten as (0, 1)
-    with tifffile.TiffFile(tif_path, mode='r+b') as tif:
+    with tifffile.TiffFile(tif_path, mode="r+b") as tif:
         tags = tif.pages[0].tags
-        tags['XResolution'].overwrite(resolution)
-        tags['YResolution'].overwrite(resolution)
+        tags["XResolution"].overwrite(resolution)
+        tags["YResolution"].overwrite(resolution)
 
     # Validate with low level library that the invalid metadata is written
-    with tifffile.TiffFile(tif_path, mode='rb') as tif:
+    with tifffile.TiffFile(tif_path, mode="rb") as tif:
         tags = tif.pages[0].tags
-        assert tags['XResolution'].value == resolution
-        assert tags['YResolution'].value == resolution
+        assert tags["XResolution"].value == resolution
+        assert tags["YResolution"].value == resolution
 
     read_image = iio.imread(tmp_path / "test.tif")
 

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -144,6 +144,8 @@ def test_imagej_hyperstack(tmp_path):
 @pytest.mark.parametrize(
     "dpi,expected_resolution",
     [
+        ((0, 1), (0, 1, "INCH")),
+        ((0, 12), (0, 12, "INCH")),
         ((100, 200), (100, 200, "INCH")),
         ((0.5, 0.5), (0.5, 0.5, "INCH")),
         (((1, 3), (1, 3)), (1 / 3, 1 / 3, "INCH")),
@@ -160,6 +162,34 @@ def test_resolution_metadata(tmp_path, dpi, expected_resolution):
 
     assert read_image.meta["resolution"] == expected_resolution
     assert read_image.meta["resolution_unit"] == 2
+
+
+@pytest.mark.parametrize("resolution", [(1, 0), (0, 0)])
+def test_invalid_resolution_metadata(tmp_path, resolution):
+    data = np.zeros((200, 100), dtype=np.uint8)
+
+    tif_path = tmp_path / "test.tif"
+
+    writer = imageio.get_writer(tif_path)
+    writer.append_data(data)
+    writer.close()
+    # Overwrite low level metadata the exact way we want it
+    # to avoid any re-interpretation of the metadata by imageio
+    # For example, it seems that (0, 0) gets rewritten as (0, 1)
+    with tifffile.TiffFile(tif_path, mode='r+b') as tif:
+        tags = tif.pages[0].tags
+        tags['XResolution'].overwrite(resolution)
+        tags['YResolution'].overwrite(resolution)
+
+    # Validate with low level library that the invalid metadata is written
+    with tifffile.TiffFile(tif_path, mode='rb') as tif:
+        tags = tif.pages[0].tags
+        assert tags['XResolution'].value == resolution
+        assert tags['YResolution'].value == resolution
+
+    read_image = iio.imread(tmp_path / "test.tif")
+
+    assert "resolution" not in read_image.meta
 
 
 def test_read_bytes(tmp_path):

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -187,7 +187,8 @@ def test_invalid_resolution_metadata(tmp_path, resolution):
         assert tags["XResolution"].value == resolution
         assert tags["YResolution"].value == resolution
 
-    read_image = iio.imread(tmp_path / "test.tif")
+    with pytest.warns(RuntimeWarning):
+        read_image = iio.imread(tmp_path / "test.tif")
 
     assert "resolution" not in read_image.meta
 


### PR DESCRIPTION
It seems that certain tiffs can have the tag but the denominator can be 0.

Not sure how to handle them correctly, but I'm leaving this here as a placeholder.

We can try to recreate the TIFF and add it to a test.