### PR TITLE
DOC: note on preferring venv

### DIFF
--- a/docs/user_guide/freezing.rst
+++ b/docs/user_guide/freezing.rst
@@ -17,6 +17,11 @@ command-line switch when calling pyinstaller that will gather all plugins:
 
   pyinstaller --collect-submodules imageio <entry_script.py>
 
+Note that it is generally recommended to do this from within a virtual
+environment in which you don't have unnecessary backends installed. Otherwise,
+any backend that is present will be included in the package and, if it is not
+being used, may increase package size unnecessarily.
+
 Alternatively, if you want to limit the plugins used, you can include them
 individually using ``--hidden-import``:
 


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/766

In https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/396 @paulmueller added dynamically imported plugins to the list of modules that are automagically collected when freezing imageio. A result of the discussions in that PR was that it is recommended to package apps inside a virtual environment and the PR here adds a note about this to our docs.