### PR TITLE
DEV: build docs using python 3.10

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]


### PR DESCRIPTION
A while ago we had trouble building our docs in python 3.9+. This traced back to a surprising interaction between our dynamic plugin loader and sphinx that resulted in autosummary not building the plugin classes anymore.

This PR fixes that behavior using the solution from https://github.com/sphinx-doc/sphinx/issues/10182.