### PR TITLE
BUG: handle PIL paletts with <256 color palettes

### DIFF
--- a/imageio/plugins/pillow_legacy.py
+++ b/imageio/plugins/pillow_legacy.py
@@ -671,7 +671,8 @@ def _palette_is_grayscale(pil_image):
     elif pil_image.info.get("transparency", None):  # see issue #475
         return False
     # get palette as an array with R, G, B columns
-    palette = np.asarray(pil_image.getpalette()).reshape((256, 3))
+    # Note: starting in pillow 9.1 palettes may have less than 256 entries
+    palette = np.asarray(pil_image.getpalette()).reshape((-1, 3))
     # Not all palette colors are used; unused colors have junk values.
     start, stop = pil_image.getextrema()
     valid_palette = palette[start : stop + 1]


### PR DESCRIPTION
Closes: #774 

As of pillow 9.1 palettes (at least for PNG) may now contain less than 256 entries. This broke our legacy pillow plugin where 256 entries per palette were hardcoded. This PR fixes the issue by removing that hardcoding.