### PR TITLE
BUG: ensure pts increases even if pyav doesn't flush the frame immediately

### DIFF
--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -266,6 +266,7 @@ class PyAVPlugin(PluginV3):
                     msg = f"PyAV does not support `{request.raw_uri}`"
                 raise InitializationError(msg) from None
         else:
+            self.frames_written = 0
             file_handle = self.request.get_file()
             filename = getattr(file_handle, "name", None)
             extension = self.request.extension or self.request.format_hint
@@ -615,7 +616,8 @@ class PyAVPlugin(PluginV3):
         ]
 
         for img in ndimage:
-            frame.pts = self._video_stream.frames
+            frame.pts = self.frames_written
+            self.frames_written += 1
             # manual packing of ndarray into frame
             # (this should live in pyAV, but it doesn't support many formats
             # and PRs there are slow)
@@ -655,7 +657,6 @@ class PyAVPlugin(PluginV3):
                 self._container.mux(packet)
 
         for out_frame in ffmpeg_filter:
-            out_frame.pts = self._video_stream.frames
             for packet in stream.encode(out_frame):
                 self._container.mux(packet)
 

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -272,7 +272,7 @@ def test_variable_fps_seek(test_images):
     assert np.allclose(actual, expected)
 
 
-def test_multiple_writes(test_images, tmp_path):
+def test_multiple_writes(test_images):
     out_buffer = io.BytesIO()
     with iio.imopen(out_buffer, "w", plugin="pyav", format_hint=".mp4") as file:
         for frame in iio.imiter(


### PR DESCRIPTION
When writing video with pyav frames may be buffered inside the codec instead of being written immediately. If this happens we currently lose track of how many frames have been written (as we check the stream and see how many are in there). This PR updates our frame counting to use our own counter which is independent of any buffering that pyav or FFmpeg may do internally.