### PR TITLE
FEAT: allow writing bayer images

### DIFF
--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -629,9 +629,12 @@ class PyAVPlugin(PluginV3):
                     )
                     plane_array[...] = img[idx]
             else:
-                n_channels = len(pixel_format.components)
-                plane = frame.planes[0]
+                if in_pixel_format.startswith("bayer_"):
+                    n_channels = 1
+                else:
+                    n_channels = len(pixel_format.components)
 
+                plane = frame.planes[0]
                 plane_shape = (plane.height, plane.width)
                 plane_strides = (plane.line_size, n_channels * img_dtype.itemsize)
                 if n_channels > 1:

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -315,3 +315,36 @@ def test_invalid_resource(tmp_path):
 
     with pytest.raises(IOError):
         iio.imwrite(tmp_path / "foo.abc", img, plugin="pyav")
+
+
+def test_bayer_write():
+    image_shape = (128, 128)
+    image = np.zeros(image_shape, dtype="uint8")
+    buffer = io.BytesIO()
+
+    with iio.imopen(buffer, "w", plugin="pyav", format_hint=".mp4") as file:
+        image[...] = 0
+        for i in range(256):
+            image[::2, ::2] = i
+            file.write(
+                image, is_batch=False, codec="h264", in_pixel_format="bayer_rggb8"
+            )
+
+        image[...] = 0
+        for i in range(256):
+            image[0::2, 1::2] = i
+            image[1::2, 0::2] = i
+            file.write(
+                image, is_batch=False, codec="h264", in_pixel_format="bayer_rggb8"
+            )
+
+        image[...] = 0
+        for i in range(256):
+            image[1::2, 1::2] = i
+            file.write(
+                image, is_batch=False, codec="h264", in_pixel_format="bayer_rggb8"
+            )
+
+    buffer.seek(0)
+    img = iio.imread(buffer, plugin="pyav")
+    assert img.shape == (768, 128, 128, 3)


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/761

This PR adds the ability to provide ndimages formatted as bayer/raw images when writing with pyav, i.e., it allows `in_pixel_format="bayer_..:"` when writing. 

I would have added the same for reading, i.e., the ability to use `format="bayer_..."`, but that will have to wait until pyav adds support for these formats.