### PR TITLE
BUG: reset request when iterating over plugins

### DIFF
--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -1499,11 +1499,6 @@ extension_list = [
     ),
     FileExtension(
         name="QuickTime / MOV",
-        extension=".mp4",
-        priority=["pyav"],
-    ),
-    FileExtension(
-        name="QuickTime / MOV",
         extension=".psp",
         priority=["pyav"],
     ),

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -235,6 +235,9 @@ def imopen(uri, io_mode, *, plugin=None, format_hint=None, legacy_mode=False, **
         if legacy_mode and not config.is_legacy:
             continue
 
+        # each plugin gets its own request
+        request = Request(uri, io_mode, format_hint=format_hint)
+
         try:
             plugin_instance = config.plugin_class(request, **kwargs)
         except InitializationError:

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -34,6 +34,15 @@ def test_mp4_read(test_images: Path):
     np.allclose(result, expected)
 
 
+def test_mp4_read_bytes(test_images):
+    encoded_video = (test_images / "cockatoo.mp4").read_bytes()
+
+    img_expected = iio.imread(encoded_video, index=5)
+    img = iio.imread(encoded_video, plugin="pyav", index=5)
+
+    np.allclose(img, img_expected)
+
+
 def test_mp4_writing(tmp_path, test_images):
     frames = iio.imread(test_images / "newtonscradle.gif")
 


### PR DESCRIPTION
While testing the ability to directly decode videos from byte strings I noticed that there is a bug in `imopen`. 

Plugins clean up after themself and, in the process, call `request.finish()`, which backfires when we iterate over all plugins since the next plugin in the list receives a finished request, which had it's `request._bytes` garbage collected. This PR fixes this by creating a fresh request for every plugin being tested and adds a regression/unit test for this.

It also removes a duplicate entry in our known extensions that I found :)