### PR TITLE
MAINT: Update imopen types

### DIFF
--- a/imageio/core/imopen.pyi
+++ b/imageio/core/imopen.pyi
@@ -1,10 +1,10 @@
-from typing import Literal, overload, Type, TypeVar
-from .v3_plugin_api import PluginV3
+from typing import Literal, Type, TypeVar, overload
+
 from ..plugins.pillow import PillowPlugin
 from ..plugins.pyav import PyAVPlugin
-from .legacy_plugin_wrapper import LegacyPlugin
-
 from ..typing import ImageResource
+from .legacy_plugin_wrapper import LegacyPlugin
+from .v3_plugin_api import PluginV3
 
 CustomPlugin = TypeVar("CustomPlugin", bound=PluginV3)
 
@@ -23,7 +23,7 @@ def imopen(
     plugin: str = None,
     format_hint: str = None,
     legacy_mode: Literal[True],
-    **kwargs
+    **kwargs,
 ) -> LegacyPlugin: ...
 @overload
 def imopen(
@@ -55,5 +55,5 @@ def imopen(
     *,
     plugin: Type[CustomPlugin],
     format_hint: str = None,
-    **kwargs
+    **kwargs,
 ) -> CustomPlugin: ...

--- a/imageio/core/imopen.pyi
+++ b/imageio/core/imopen.pyi
@@ -1,46 +1,59 @@
-from typing import Any, Literal, overload, Union
+from typing import Literal, overload, Type, TypeVar
 from .v3_plugin_api import PluginV3
 from ..plugins.pillow import PillowPlugin
 from ..plugins.pyav import PyAVPlugin
 from .legacy_plugin_wrapper import LegacyPlugin
 
+from ..typing import ImageResource
+
+CustomPlugin = TypeVar("CustomPlugin", bound=PluginV3)
+
 @overload
 def imopen(
-    uri,
+    uri: ImageResource,
     io_mode: Literal["r", "w"],
     *,
-    plugin: Literal["pyav"],
     format_hint: str = None,
-    legacy_mode: Literal[False],
-    **kwargs
-) -> PyAVPlugin: ...
+) -> PluginV3: ...
 @overload
 def imopen(
-    uri,
+    uri: ImageResource,
     io_mode: Literal["r", "w"],
     *,
-    plugin: Literal["pillow"],
-    format_hint: str = None,
-    legacy_mode: Literal[False],
-    **kwargs
-) -> PillowPlugin: ...
-@overload
-def imopen(
-    uri,
-    io_mode: Literal["r", "w"],
-    *,
-    plugin: Union[str, Any] = None,
+    plugin: str = None,
     format_hint: str = None,
     legacy_mode: Literal[True],
     **kwargs
 ) -> LegacyPlugin: ...
 @overload
 def imopen(
-    uri,
+    uri: ImageResource,
     io_mode: Literal["r", "w"],
     *,
-    plugin: Union[str, Any] = None,
     format_hint: str = None,
-    legacy_mode: bool = False,
-    **kwargs
+    legacy_mode: Literal[False] = False,
 ) -> PluginV3: ...
+@overload
+def imopen(
+    uri: ImageResource,
+    io_mode: Literal["r", "w"],
+    *,
+    plugin: Literal["pyav"],
+    container: str = None,
+) -> PyAVPlugin: ...
+@overload
+def imopen(
+    uri: ImageResource,
+    io_mode: Literal["r", "w"],
+    *,
+    plugin: Literal["pillow"],
+) -> PillowPlugin: ...
+@overload
+def imopen(
+    uri: ImageResource,
+    io_mode: Literal["r", "w"],
+    *,
+    plugin: Type[CustomPlugin],
+    format_hint: str = None,
+    **kwargs
+) -> CustomPlugin: ...

--- a/imageio/typing.py
+++ b/imageio/typing.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import Union
+from typing import Union, BinaryIO
 from pathlib import Path
 
 try:
@@ -8,7 +8,7 @@ except ImportError:
     # numpy<1.20 fall back to using ndarray
     from numpy import ndarray as ArrayLike
 
-ImageResource = Union[str, BytesIO, Path]
+ImageResource = Union[str, BytesIO, Path, BinaryIO]
 
 
 __all__ = [

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -61,9 +61,7 @@ def test_metadata(test_images: Path):
 
 
 def test_properties(test_images: Path):
-    with iio.imopen(
-        str(test_images / "cockatoo.mp4"), "r", plugin="pyav"
-    ) as plugin:
+    with iio.imopen(str(test_images / "cockatoo.mp4"), "r", plugin="pyav") as plugin:
         with pytest.raises(IOError):
             # subsampled format
             plugin.properties(format="yuv420p")

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -62,7 +62,7 @@ def test_metadata(test_images: Path):
 
 def test_properties(test_images: Path):
     with iio.imopen(
-        str(test_images / "cockatoo.mp4"), "r", plugin="pyav", legacy_mode=False
+        str(test_images / "cockatoo.mp4"), "r", plugin="pyav"
     ) as plugin:
         with pytest.raises(IOError):
             # subsampled format


### PR DESCRIPTION
As discussed in https://github.com/imageio/imageio/pull/791#discussion_r852858808 it seems sensible to reorganize the type hints for imopen so that they become more user friendly. This PR does that.