### PR TITLE
TEST: refactor the way in which the needs_internet marker is applied

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,11 +66,7 @@ def working_directory(path):
         os.chdir(prev_cwd)
 
 
-# uses the fixture marking workaround from:
-# https://github.com/pytest-dev/pytest/issues/1368#issuecomment-466339463
-@pytest.fixture(
-    scope="session", params=[pytest.param(0, marks=pytest.mark.needs_internet)]
-)
+@pytest.fixture(scope="session")
 def test_images(request):
     """A collection of test images.
 
@@ -176,6 +172,12 @@ def tmp_userdir(tmp_path):
         os.environ[user_dir_env] = old_user_dir
     else:
         del os.environ[user_dir_env]
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "test_images" in getattr(item, "fixturenames", ()):
+            item.add_marker("needs_internet")
 
 
 def deprecated_test(fn):


### PR DESCRIPTION
This is a QoL change for people that use an IDE like vscode that has some niceties built in when using pytest or unittest. Currently, all tests that are marked with `needs_internet` are considered a parameterized test, which is odd because most of them are not. This gives them a funny appearance in the list of tests:

![image](https://user-images.githubusercontent.com/4402489/164619432-144142c0-febd-4313-8d79-d1cea77d6380.png)

This PR fixes that (and keeps actual behavior the same):

![image](https://user-images.githubusercontent.com/4402489/164619589-5722b36c-43e0-40fb-b15b-695efb3d4509.png)
