### PR TITLE
BUG: Rename format_hint to extension and prefer it to file extension

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -49,7 +49,7 @@ Imageio can read from filenames, file objects.
     frames = iio.imread(web_image, index=None)
 
     # from bytes
-    bytes_image = iio.imwrite("<bytes>", frames, format_hint=".gif")
+    bytes_image = iio.imwrite("<bytes>", frames, extension=".gif")
     frames = iio.imread(bytes_image, index=None)
 
     # from byte streams
@@ -234,7 +234,7 @@ Writing to Bytes (Encoding)
 ---------------------------
 
 You can convert ndimages into byte strings. For this, you have to hint the
-desired format (using ``format_hint=``), as a byte string doesn't specify any
+desired extension (using ``extension=``), as a byte string doesn't specify any
 information about the format or color space to use. Note that, if the backend
 supports writing to file-like objects, the entire process will happen without
 touching your file-system.
@@ -247,14 +247,14 @@ touching your file-system.
     img = iio.imread('imageio:astronaut.png')
 
     # png-encoded bytes string
-    png_encoded = iio.imwrite("<bytes>", img, format_hint=".png")
+    png_encoded = iio.imwrite("<bytes>", img, extension=".png")
     
     # jpg-encoded bytes string
-    jpg_encoded = iio.imwrite("<bytes>", img, format_hint=".jpeg")
+    jpg_encoded = iio.imwrite("<bytes>", img, extension=".jpeg")
 
     # RGBA bytes string
     img = iio.imread('imageio:astronaut.png', mode="RGBA")
-    png_encoded = iio.imwrite("<bytes>", img, format_hint=".png")
+    png_encoded = iio.imwrite("<bytes>", img, extension=".png")
 
 Writing to BytesIO
 ------------------
@@ -271,11 +271,11 @@ Similar to writing to byte strings, you can also write to BytesIO directly.
 
     # write as PNG
     output = io.BytesIO()
-    iio.imwrite(output, img, plugin="pillow", format_hint=".png")
+    iio.imwrite(output, img, plugin="pillow", extension=".png")
     
     # write as JPG
     output = io.BytesIO()
-    iio.imwrite(output, img, plugin="pillow", format_hint=".jpeg")
+    iio.imwrite(output, img, plugin="pillow", extension=".jpeg")
 
 Optimizing a GIF using pygifsicle
 ------------------------------------

--- a/docs/reference/core_v3.rst
+++ b/docs/reference/core_v3.rst
@@ -62,8 +62,8 @@ arguments (`kwargs`) to overwrite any defaults ImageIO uses when reading or
 writing. The following `kwargs` are always available:
 
 - ``plugin``: The name of the plugin to use for reading/writing.
-- ``format_hint``: A format hint to help ImageIO select the correct plugin if no
-  ``plugin`` was specified.
+- ``extension``: Treat the provided ImageResource as if it had the given
+  extension.
 - ``index`` (reading only): The index of the ndimage to read. Useful if the format
   supports storing more than one (GIF, multi-page TIFF, video, etc.).
 

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -12,7 +12,16 @@ from .request import (
 )
 
 
-def imopen(uri, io_mode, *, plugin=None, format_hint=None, legacy_mode=False, **kwargs):
+def imopen(
+    uri,
+    io_mode,
+    *,
+    plugin=None,
+    extension=None,
+    format_hint=None,
+    legacy_mode=False,
+    **kwargs,
+):
     """Open an ImageResource.
 
     .. warning::
@@ -46,6 +55,10 @@ def imopen(uri, io_mode, *, plugin=None, format_hint=None, legacy_mode=False, **
         The plugin to use. If set to None (default) imopen will perform a
         search for a matching plugin. If not None, this takes priority over
         the provided format hint.
+    extension : str
+        If not None, treat the provided ImageResource as if it had the given
+        extension. This affects the order in which backends are considered, and
+        when writing this may also influence the format used when encoding.
     format_hint : str
         A format hint to help optimize plugin selection given as the format's
         extension, e.g. ".png". This can speed up the selection process for
@@ -88,12 +101,6 @@ def imopen(uri, io_mode, *, plugin=None, format_hint=None, legacy_mode=False, **
 
     """
 
-    if format_hint is not None and format_hint[0] != ".":
-        raise ValueError(
-            "`format_hint` should be a file extension starting with a `.`,"
-            f" but is `{format_hint}`."
-        )
-
     if isinstance(uri, Request) and legacy_mode:
         warnings.warn(
             "`iio.core.Request` is a low-level object and using it"
@@ -107,7 +114,7 @@ def imopen(uri, io_mode, *, plugin=None, format_hint=None, legacy_mode=False, **
         io_mode = request.mode.io_mode
         request.format_hint = format_hint
     else:
-        request = Request(uri, io_mode, format_hint=format_hint)
+        request = Request(uri, io_mode, format_hint=format_hint, extension=extension)
 
     source = "<bytes>" if isinstance(uri, bytes) else uri
 

--- a/imageio/core/imopen.pyi
+++ b/imageio/core/imopen.pyi
@@ -14,6 +14,7 @@ def imopen(
     uri: ImageResource,
     io_mode: Literal["r", "w"],
     *,
+    extension: str = None,
     format_hint: str = None,
 ) -> PluginV3: ...
 @overload
@@ -23,6 +24,7 @@ def imopen(
     *,
     plugin: str = None,
     format_hint: str = None,
+    extension: str = None,
     legacy_mode: Literal[True],
     **kwargs,
 ) -> LegacyPlugin: ...
@@ -32,6 +34,7 @@ def imopen(
     io_mode: Literal["r", "w"],
     *,
     format_hint: str = None,
+    extension: str = None,
     legacy_mode: Literal[False] = False,
 ) -> PluginV3: ...
 @overload
@@ -40,6 +43,7 @@ def imopen(
     io_mode: Literal["r", "w"],
     *,
     plugin: Literal["pillow"],
+    extension: str = None,
     format_hint: str = None,
 ) -> PillowPlugin: ...
 @overload
@@ -48,6 +52,7 @@ def imopen(
     io_mode: Literal["r", "w"],
     *,
     plugin: Literal["pyav"],
+    extension: str = None,
     format_hint: str = None,
     container: str = None,
 ) -> PyAVPlugin: ...
@@ -57,6 +62,7 @@ def imopen(
     io_mode: Literal["r", "w"],
     *,
     plugin: Literal["opencv"],
+    extension: str = None,
     format_hint: str = None,
 ) -> OpenCVPlugin: ...
 @overload
@@ -65,6 +71,7 @@ def imopen(
     io_mode: Literal["r", "w"],
     *,
     plugin: Type[CustomPlugin],
+    extension: str = None,
     format_hint: str = None,
     **kwargs,
 ) -> CustomPlugin: ...

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -213,7 +213,7 @@ class Request(object):
 
     """
 
-    def __init__(self, uri, mode, *, format_hint: str = None, **kwargs):
+    def __init__(self, uri, mode, *, extension=None, format_hint: str = None, **kwargs):
 
         # General
         self.raw_uri = uri
@@ -248,13 +248,32 @@ class Request(object):
         self._parse_uri(uri)
 
         # Set extension
-        if self._filename is not None:
+        if extension is not None:
+            if extension[0] != ".":
+                raise ValueError(
+                    "`extension` should be a file extension starting with a `.`,"
+                    f" but is `{extension}`."
+                )
+            self._extension = extension
+        elif self._filename is not None:
             if self._uri_type in (URI_FILENAME, URI_ZIPPED):
                 path = self._filename
             else:
                 path = urlparse(self._filename).path
             ext = Path(path).suffix.lower()
             self._extension = ext if ext != "" else None
+
+        if format_hint is not None:
+            warnings.warn(
+                "The usage of `format_hint` is deprecated and will be removed in ImageIO v3."
+                " Use `extension` instead."
+            )
+
+        if format_hint is not None and format_hint[0] != ".":
+            raise ValueError(
+                "`format_hint` should be a file extension starting with a `.`,"
+                f" but is `{format_hint}`."
+            )
 
         self.format_hint = format_hint
 

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -526,9 +526,7 @@ class Request(object):
         else:
             # Get filename
             if self.extension is not None:
-                ext = self.extension
-            elif self.format_hint is not None:
-                ext = self.format_hint
+                ext = self.extensions
             else:
                 ext = os.path.splitext(self._filename)[1]
             self._filename_local = tempfile.mktemp(ext, "imageio_")

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -526,7 +526,7 @@ class Request(object):
         else:
             # Get filename
             if self.extension is not None:
-                ext = self.extensions
+                ext = self.extension
             else:
                 ext = os.path.splitext(self._filename)[1]
             self._filename_local = tempfile.mktemp(ext, "imageio_")

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -529,8 +529,6 @@ class Request(object):
                 ext = self.extension
             elif self.format_hint is not None:
                 ext = self.format_hint
-            elif self._uri_type in (URI_HTTP, URI_FTP):
-                ext = os.path.splitext(self._filename.split("?")[0])[1]
             else:
                 ext = os.path.splitext(self._filename)[1]
             self._filename_local = tempfile.mktemp(ext, "imageio_")

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -525,7 +525,9 @@ class Request(object):
             return self._filename
         else:
             # Get filename
-            if self.format_hint is not None:
+            if self.extension is not None:
+                ext = self.extension
+            elif self.format_hint is not None:
                 ext = self.format_hint
             elif self._uri_type in (URI_HTTP, URI_FTP):
                 ext = os.path.splitext(self._filename.split("?")[0])[1]

--- a/imageio/core/request.pyi
+++ b/imageio/core/request.pyi
@@ -63,7 +63,13 @@ class Request(object):
     @property
     def firstbytes(self) -> bytes: ...
     def __init__(
-        self, uri: ImageResource, mode: str, *, format_hint: str = None, **kwargs
+        self,
+        uri: ImageResource,
+        mode: str,
+        *,
+        extension: str = None,
+        format_hint: str = None,
+        **kwargs
     ) -> None: ...
     def _parse_uri(self, uri: ImageResource) -> None: ...
     def get_file(self) -> BinaryIO: ...

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -98,7 +98,7 @@ class PillowPlugin(PluginV3):
                 warnings.warn(
                     "Can't determine file format to write as. You _must_"
                     " set `format` during write or the call will fail. Use "
-                    "`format_hint` to supress this warning. ",
+                    "`extension` to supress this warning. ",
                     UserWarning,
                 )
                 return

--- a/imageio/v2.py
+++ b/imageio/v2.py
@@ -98,7 +98,7 @@ def decypher_format_arg(format_name):
     else:
         raise IndexError(f"No format known by name `{plugin}`.")
 
-    return {"plugin": plugin, "format_hint": extension}
+    return {"plugin": plugin, "extension": extension}
 
 
 # Base functions that return a reader/writer

--- a/imageio/v3.py
+++ b/imageio/v3.py
@@ -3,7 +3,7 @@ import numpy as np
 from .core.imopen import imopen
 
 
-def imread(uri, *, index=None, plugin=None, format_hint=None, **kwargs):
+def imread(uri, *, index=None, plugin=None, extension=None, format_hint=None, **kwargs):
     """Read an ndimage from a URI.
 
     Opens the given URI and reads an ndimage from it. The exact behavior
@@ -25,6 +25,9 @@ def imread(uri, *, index=None, plugin=None, format_hint=None, **kwargs):
         The plugin to use. If set to None (default) imread will perform a
         search for a matching plugin. If not None, this takes priority over
         the provided format hint  (if present).
+    extension : str
+        If not None, treat the provided ImageResource as if it had the given
+        extension. This affects the order in which backends are considered.
     format_hint : str
         A format hint to help optimize plugin selection given as the format's
         extension, e.g. ".png". This can speed up the selection process for
@@ -40,7 +43,12 @@ def imread(uri, *, index=None, plugin=None, format_hint=None, **kwargs):
         The ndimage located at the given URI.
     """
 
-    plugin_kwargs = {"legacy_mode": False, "plugin": plugin, "format_hint": format_hint}
+    plugin_kwargs = {
+        "legacy_mode": False,
+        "plugin": plugin,
+        "format_hint": format_hint,
+        "extension": extension,
+    }
 
     call_kwargs = kwargs
     if index is not None:
@@ -50,7 +58,7 @@ def imread(uri, *, index=None, plugin=None, format_hint=None, **kwargs):
         return np.asarray(img_file.read(**call_kwargs))
 
 
-def imiter(uri, *, plugin=None, format_hint=None, **kwargs):
+def imiter(uri, *, plugin=None, extension=None, format_hint=None, **kwargs):
     """Read a sequence of ndimages from a URI.
 
     Returns an iterable that yields ndimages from the given URI. The exact
@@ -67,6 +75,9 @@ def imiter(uri, *, plugin=None, format_hint=None, **kwargs):
         The plugin to use. If set to None (default) imiter will perform a
         search for a matching plugin. If not None, this takes priority over
         the provided format hint (if present).
+    extension : str
+        If not None, treat the provided ImageResource as if it had the given
+        extension. This affects the order in which backends are considered.
     format_hint : str
         A format hint to help optimize plugin selection given as the format's
         extension, e.g. ".png". This can speed up the selection process for
@@ -86,7 +97,12 @@ def imiter(uri, *, plugin=None, format_hint=None, **kwargs):
     """
 
     with imopen(
-        uri, "r", legacy_mode=False, plugin=plugin, format_hint=format_hint
+        uri,
+        "r",
+        legacy_mode=False,
+        plugin=plugin,
+        format_hint=format_hint,
+        extension=extension,
     ) as img_file:
         for image in img_file.iter(**kwargs):
             # Note: casting to ndarray here to ensure compatibility
@@ -94,7 +110,7 @@ def imiter(uri, *, plugin=None, format_hint=None, **kwargs):
             yield np.asarray(image)
 
 
-def imwrite(uri, image, *, plugin=None, format_hint=None, **kwargs):
+def imwrite(uri, image, *, plugin=None, extension=None, format_hint=None, **kwargs):
     """Write an ndimage to the given URI.
 
     The exact behavior depends on the file type and plugin used. To learn about
@@ -111,6 +127,10 @@ def imwrite(uri, image, *, plugin=None, format_hint=None, **kwargs):
         The plugin to use. If set to None (default) imwrite will perform a
         search for a matching plugin. If not None, this takes priority over
         the provided format hint (if present).
+    extension : str
+        If not None, treat the provided ImageResource as if it had the given
+        extension. This affects the order in which backends are considered, and
+        may also influence the format used when encoding.
     format_hint : str
         A format hint to help optimize plugin selection given as the format's
         extension, e.g. ".png". This can speed up the selection process for
@@ -131,14 +151,19 @@ def imwrite(uri, image, *, plugin=None, format_hint=None, **kwargs):
     """
 
     with imopen(
-        uri, "w", legacy_mode=False, plugin=plugin, format_hint=format_hint
+        uri,
+        "w",
+        legacy_mode=False,
+        plugin=plugin,
+        format_hint=format_hint,
+        extension=extension,
     ) as img_file:
         encoded = img_file.write(image, **kwargs)
 
     return encoded
 
 
-def improps(uri, *, index=None, plugin=None, **kwargs):
+def improps(uri, *, index=None, plugin=None, extension=None, **kwargs):
     """Read standardized metadata.
 
     Opens the given URI and reads the properties of an ndimage from it. The
@@ -159,6 +184,9 @@ def improps(uri, *, index=None, plugin=None, **kwargs):
     plugin : {str, None}
         The plugin to be used. If None, performs a search for a matching
         plugin.
+    extension : str
+        If not None, treat the provided ImageResource as if it had the given
+        extension. This affects the order in which backends are considered.
     **kwargs :
         Additional keyword arguments will be passed to the plugin's ``properties``
         call.
@@ -174,7 +202,7 @@ def improps(uri, *, index=None, plugin=None, **kwargs):
 
     """
 
-    plugin_kwargs = {"legacy_mode": False, "plugin": plugin}
+    plugin_kwargs = {"legacy_mode": False, "plugin": plugin, "extension": extension}
 
     call_kwargs = kwargs
     if index is not None:
@@ -186,7 +214,9 @@ def improps(uri, *, index=None, plugin=None, **kwargs):
     return properties
 
 
-def immeta(uri, *, index=None, plugin=None, exclude_applied=True, **kwargs):
+def immeta(
+    uri, *, index=None, plugin=None, extension=None, exclude_applied=True, **kwargs
+):
     """Read format-specific metadata.
 
     Opens the given URI and reads metadata for an ndimage from it. The contents
@@ -209,6 +239,9 @@ def immeta(uri, *, index=None, plugin=None, exclude_applied=True, **kwargs):
     plugin : {str, None}
         The plugin to be used. If None (default), performs a search for a
         matching plugin.
+    extension : str
+        If not None, treat the provided ImageResource as if it had the given
+        extension. This affects the order in which backends are considered.
     **kwargs :
         Additional keyword arguments will be passed to the plugin's metadata
         method.
@@ -220,7 +253,7 @@ def immeta(uri, *, index=None, plugin=None, exclude_applied=True, **kwargs):
 
     """
 
-    plugin_kwargs = {"legacy_mode": False, "plugin": plugin}
+    plugin_kwargs = {"legacy_mode": False, "plugin": plugin, "extension": extension}
 
     call_kwargs = kwargs
     call_kwargs["exclude_applied"] = exclude_applied

--- a/imageio/v3.pyi
+++ b/imageio/v3.pyi
@@ -11,11 +11,17 @@ def imread(
     *,
     index: Optional[int] = 0,
     plugin: str = None,
+    extension: str = None,
     format_hint: str = None,
     **kwargs
 ) -> np.ndarray: ...
 def imiter(
-    uri: ImageResource, *, plugin: str = None, format_hint: str = None, **kwargs
+    uri: ImageResource,
+    *,
+    plugin: str = None,
+    extension: str = None,
+    format_hint: str = None,
+    **kwargs
 ) -> Iterator[np.ndarray]: ...
 @overload
 def imwrite(
@@ -23,6 +29,7 @@ def imwrite(
     image: ArrayLike,
     *,
     plugin: str = None,
+    extension: str = None,
     format_hint: str = None,
     **kwargs
 ) -> bytes: ...
@@ -32,17 +39,24 @@ def imwrite(
     image: ArrayLike,
     *,
     plugin: str = None,
+    extension: str = None,
     format_hint: str = None,
     **kwargs
 ) -> None: ...
 def improps(
-    uri, *, index: Optional[int] = 0, plugin: str = None, **kwargs
+    uri,
+    *,
+    index: Optional[int] = 0,
+    plugin: str = None,
+    extension: str = None,
+    **kwargs
 ) -> ImageProperties: ...
 def immeta(
     uri,
     *,
     index: Optional[int] = 0,
     plugin: str = None,
+    extension: str = None,
     exclude_applied: bool = True,
     **kwargs
 ) -> Dict[str, Any]: ...

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1004,10 +1004,10 @@ def test_sort_order_restore():
     assert old_order == new_order
 
 
-def test_imopen_format_hint(image_files):
+def test_imopen_extension(image_files):
     image_bytes = Path(image_files / "chelsea.png").read_bytes()
 
-    with iio.v3.imopen(image_bytes, "r", format_hint=".png") as resource:
+    with iio.v3.imopen(image_bytes, "r", extension=".png") as resource:
         result = resource.read()
 
     expected = iio.v3.imread(image_files / "chelsea.png")
@@ -1016,11 +1016,20 @@ def test_imopen_format_hint(image_files):
 
 
 @pytest.mark.parametrize("invalid_file", [".jpg"], indirect=["invalid_file"])
-def test_imopen_format_hint_malformatted(invalid_file, test_images):
+def test_imopen_extension_malformatted(invalid_file, test_images):
     with pytest.raises(ValueError):
-        # format_hint should be ".png"
-        iio.v3.imopen(invalid_file, "r", format_hint="PNG")
+        # extension should be ".png"
+        iio.v3.imopen(invalid_file, "r", extension="PNG")
 
     with pytest.warns(UserWarning):
-        # format_hint is invalid and should emit a warning
-        iio.v3.imread(test_images / "chelsea.png", format_hint=".cap")
+        # extension is invalid and should emit a warning
+        iio.v3.imread(test_images / "chelsea.png", extension=".cap")
+
+
+def test_writing_foreign_extension(test_images, tmp_path):
+    expected = iio.v3.imread(test_images / "chelsea.png")
+
+    iio.v3.imwrite(tmp_path / "test.png.part", expected, extension=".png")
+    actual = iio.v3.imread(tmp_path / "test.png.part", extension=".png")
+
+    np.allclose(actual, expected)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1042,3 +1042,26 @@ def test_writing_foreign_extension(test_images, tmp_path):
 def test_format_hint_malformatted(test_images):
     with pytest.raises(ValueError):
         iio.core.Request(test_images / "chelsea.png", "r", format_hint="PNG")
+
+
+@deprecated_test
+def test_format_hint(test_images):
+    im_new = iio.v3.imread(test_images / "chelsea.png", format_hint=".png")
+    im_old = iio.v2.imread(test_images / "chelsea.png", format=".png")
+
+    assert np.allclose(im_new, im_old)
+
+    req = iio.core.Request("https://sample.com/my/resource", "r", format_hint=".jpg")
+    filename = req.get_local_filename()
+
+    assert Path(filename).suffix == ".jpg"
+
+
+def test_standard_images():
+    im = np.ones((800, 600, 3), dtype=np.uint8)
+
+    with pytest.raises(RuntimeError):
+        iio.v3.imwrite("imageio:chelsea.png", im)
+
+    with pytest.raises(ValueError):
+        iio.v3.imread("imageio:nonexistant_standard_image.png")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1023,7 +1023,7 @@ def test_imopen_extension_malformatted(invalid_file, test_images):
 
     with pytest.warns(UserWarning):
         # extension is invalid and should emit a warning
-        iio.v3.imread(test_images / "chelsea.png", extension=".cap")
+        iio.v3.imread(test_images / "chelsea.png", format_hint=".cap")
 
 
 def test_writing_foreign_extension(test_images, tmp_path):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1031,5 +1031,8 @@ def test_writing_foreign_extension(test_images, tmp_path):
 
     iio.v3.imwrite(tmp_path / "test.png.part", expected, extension=".png")
     actual = iio.v3.imread(tmp_path / "test.png.part", extension=".png")
+    np.allclose(actual, expected)
 
+    iio.v2.imwrite(tmp_path / "test2.jpg.part", expected, format=".jpg")
+    actual = iio.v3.imread(tmp_path / "test2.jpg.part", extension=".jpg")
     np.allclose(actual, expected)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1036,3 +1036,9 @@ def test_writing_foreign_extension(test_images, tmp_path):
     iio.v2.imwrite(tmp_path / "test2.jpg.part", expected, format=".jpg")
     actual = iio.v3.imread(tmp_path / "test2.jpg.part", extension=".jpg")
     np.allclose(actual, expected)
+
+
+@deprecated_test
+def test_format_hint_malformatted(test_images):
+    with pytest.raises(ValueError):
+        iio.core.Request(test_images / "chelsea.png", "r", format_hint="PNG")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1047,7 +1047,11 @@ def test_format_hint_malformatted(test_images):
 @deprecated_test
 def test_format_hint(test_images):
     im_new = iio.v3.imread(test_images / "chelsea.png", format_hint=".png")
-    im_old = iio.v2.imread(test_images / "chelsea.png", format=".png")
+
+    with iio.v3.imopen(
+        test_images / "chelsea.png", "r", format_hint=".png", legacy_mode=True
+    ) as file:
+        im_old = file.read()
 
     assert np.allclose(im_new, im_old)
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -650,7 +650,7 @@ def test_read_stream(test_images):
 
     video_blob = Path(test_images / "cockatoo.mp4").read_bytes()
 
-    result = iio3.imread(video_blob, index=5, format_hint=".mp4")
+    result = iio3.imread(video_blob, index=5, extension=".mp4")
     expected = iio3.imread("imageio:cockatoo.mp4", index=5)
 
     assert np.allclose(result, expected)

--- a/tests/test_opencv.py
+++ b/tests/test_opencv.py
@@ -100,7 +100,7 @@ def test_write_bytes(test_images):
     img_expected = iio.imread(test_images / "chelsea.png")
 
     img_encoded = iio.imwrite(
-        "<bytes>", img_expected, plugin="opencv", format_hint=".png"
+        "<bytes>", img_expected, plugin="opencv", extension=".png"
     )
     result = iio.imread(img_encoded)
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -395,7 +395,7 @@ def test_write_to_bytes():
 
     # writing to bytes with imageIO
     with io.BytesIO() as output:
-        iio.v3.imwrite(output, image, plugin="pillow", format_hint=".png")
+        iio.v3.imwrite(output, image, plugin="pillow", extension=".png")
         iio_contents = output.getvalue()
 
     assert iio_contents == contents
@@ -411,7 +411,7 @@ def test_write_to_bytes_rgba():
 
     # writing to bytes with imageIO
     with io.BytesIO() as output:
-        iio.v3.imwrite(output, image, plugin="pillow", format_hint=".png", mode="RGBA")
+        iio.v3.imwrite(output, image, plugin="pillow", extension=".png", mode="RGBA")
         iio_contents = output.getvalue()
 
     assert iio_contents == contents
@@ -426,7 +426,7 @@ def test_write_to_bytes_imwrite():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", format_hint=".png")
+    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", extension=".png")
 
     assert contents == bytes_string
 
@@ -440,9 +440,7 @@ def test_write_to_bytes_jpg():
         contents = output.getvalue()
 
     # write with ImageIO
-    bytes_string = iio.v3.imwrite(
-        "<bytes>", image, plugin="pillow", format_hint=".jpeg"
-    )
+    bytes_string = iio.v3.imwrite("<bytes>", image, plugin="pillow", extension=".jpeg")
 
     assert contents == bytes_string
 
@@ -453,7 +451,7 @@ def test_write_jpg_to_bytes_io():
 
     image = np.zeros((200, 200), dtype=np.uint8)
     bytes_io = io.BytesIO()
-    iio.v3.imwrite(bytes_io, image, plugin="pillow", format_hint=".jpeg", mode="L")
+    iio.v3.imwrite(bytes_io, image, plugin="pillow", extension=".jpeg", mode="L")
     bytes_io.seek(0)
 
     image_from_file = iio.v3.imread(bytes_io, plugin="pillow")
@@ -578,7 +576,7 @@ def test_apng_metadata(tmp_path, test_images):
 
 def test_write_format_warning():
     frames = iio.v3.imread("imageio:chelsea.png")
-    bytes_image = iio.v3.imwrite("<bytes>", frames, format_hint=".png", plugin="pillow")
+    bytes_image = iio.v3.imwrite("<bytes>", frames, extension=".png", plugin="pillow")
 
     with pytest.warns(UserWarning):
         old_bytes = iio.v3.imwrite("<bytes>", frames, plugin="pillow", format="PNG")

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -40,7 +40,7 @@ def test_mp4_writing(tmp_path, test_images):
     mp4_bytes = iio.imwrite(
         "<bytes>",
         frames,
-        format_hint=".mp4",
+        extension=".mp4",
         plugin="pyav",
         codec="libx264",
     )
@@ -179,7 +179,7 @@ def test_write_bytes(test_images, tmp_path):
     img_bytes = iio.imwrite(
         "<bytes>",
         img,
-        format_hint=".mp4",
+        extension=".mp4",
         plugin="pyav",
         in_pixel_format="yuv444p",
         codec="libx264",
@@ -274,7 +274,7 @@ def test_variable_fps_seek(test_images):
 
 def test_multiple_writes(test_images):
     out_buffer = io.BytesIO()
-    with iio.imopen(out_buffer, "w", plugin="pyav", format_hint=".mp4") as file:
+    with iio.imopen(out_buffer, "w", plugin="pyav", extension=".mp4") as file:
         for frame in iio.imiter(
             test_images / "newtonscradle.gif",
             plugin="pyav",
@@ -322,7 +322,7 @@ def test_bayer_write():
     image = np.zeros(image_shape, dtype="uint8")
     buffer = io.BytesIO()
 
-    with iio.imopen(buffer, "w", plugin="pyav", format_hint=".mp4") as file:
+    with iio.imopen(buffer, "w", plugin="pyav", extension=".mp4") as file:
         image[...] = 0
         for i in range(256):
             image[::2, ::2] = i


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/781

This PR adds a `extension` kwarg to all functions in the v3 namespace, imopen, and Request. If not None, this argument internally overwrites the ImageResource's file extension (if any). 

When reading, this is useful to direct the plugin selection process to find the correct/matching backend faster. When writing, this has the same plugin selection benefits, but will also determine the encoder to use. This means that writing files with uncommon, or no extensions is now possible, which is something we previously regressed on.