### PR TITLE
BUG: don't treat im_mode ? as im_mode V

### DIFF
--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -202,11 +202,11 @@ class LegacyPlugin(PluginV3):
                             raise ValueError(
                                 "Image must be 2D " "(grayscale, RGB, or RGBA)."
                             )
-                    else:  # self._request.mode.image_mode == "V"
+                    elif self._request.mode.image_mode == "V":
                         if ndimage.ndim == 3:
                             pass
                         elif ndimage.ndim == 4 and ndimage.shape[3] < 32:
-                            pass  # How large can a tuple be?
+                            pass
                         else:
                             raise ValueError(
                                 "Image must be 3D," " or 4D if each voxel is a tuple."

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import imageio.v2 as iio
+import imageio.v3 as iio3
 from conftest import deprecated_test
 
 tifffile = pytest.importorskip("tifffile", reason="tifffile is not installed")
@@ -194,8 +195,15 @@ def test_invalid_resolution_metadata(tmp_path, resolution):
     assert "resolution" not in read_image.meta
 
 
-def test_read_bytes(tmp_path):
+def test_read_bytes():
     # regression test for: https://github.com/imageio/imageio/issues/703
 
     some_bytes = iio.imwrite("<bytes>", [[0]], format="tiff")
     assert some_bytes is not None
+
+
+def test_write_file():
+    # regression test for
+    # https://github.com/imageio/imageio/issues/810
+    img = np.zeros((32, 32), dtype=np.uint16)
+    iio3.imwrite("v.tif", img)


### PR DESCRIPTION
Closes: #810 

This PR fixes a bug in the legacy plugin wrapper where the branch for requests with arbitrary image mode (`?`) were treated like requests with volume image mode (`V`).

It also adds a regression test for this.
