### PR TITLE
Add stacklevel=2 to some warnings.

### DIFF
--- a/imageio/__init__.py
+++ b/imageio/__init__.py
@@ -91,6 +91,7 @@ def imread(uri, format=None, **kwargs):
         " iio.v3.imread. To keep the current behavior (and make this warning dissapear)"
         " use `import imageio.v2 as imageio` or call `imageio.v2.imread` directly.",
         DeprecationWarning,
+        stacklevel=2,
     )
 
     return imread_v2(uri, format=format, **kwargs)

--- a/imageio/core/format.py
+++ b/imageio/core/format.py
@@ -656,6 +656,7 @@ class FormatManager(object):
             "The usage of `FormatManager` is deprecated and it will be "
             "removed in Imageio v3. Use `iio.imopen` instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         if not isinstance(name, str):
@@ -713,6 +714,7 @@ class FormatManager(object):
             "\t- modify `iio.config.known_extensions[<extension>].priority`"
             " to control a specific extension.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         # Check and sanitize imput
@@ -769,6 +771,7 @@ class FormatManager(object):
             "To migrate `FormatManager.add_format` add the plugin directly to "
             "`iio.config.known_plugins`.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         if not isinstance(iio_format, Format):
@@ -843,6 +846,7 @@ class FormatManager(object):
             "`FormatManager` is deprecated and it will be removed in ImageIO v3."
             "To migrate `FormatManager.get_format_names` use `iio.config.known_plugins.keys()` instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         return [f.name for f in self._formats]

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -107,6 +107,7 @@ def imopen(
             " directly as input to `imopen` is discouraged. This will raise"
             " an exception in ImageIO v3.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         request = uri


### PR DESCRIPTION
This is really important to do as with this value, the warning message
point to the file/line of the caller, not actually where the warning is
issued. This mean that when I see this error in CI, I directly know
where to fix it in downstream projects (in my case napari).

Otherwise It takes me forever to find where the caller is, and I'm
likely to not fix it.