### PR TITLE
DOC: add GA token

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,7 @@ html_theme_options = {
         },
     ],
     "use_edit_page_button": True,
+    "google_analytics_id": "G-EFE74Z5D7E",
 }
 html_context = {
     # "github_url": "https://github.com", # or your GitHub Enterprise interprise


### PR DESCRIPTION
This PR adds a google analytics token to the docs.

My long-term idea here is to build some kind of mechanism through which we can discover how the library is used, what features (and backends) are in demand, what is missing, and what needs to be improved. Issues and bug reports are nice, but they tend to only flag the cases where something breaks. So to get a better understanding of the situation, I'd like to know what parts of the docs people actually look at.