### PR TITLE
DOCS: Change mode to "I" in optimization example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -367,7 +367,7 @@ Putting everything together:
         axis=0
     )
     
-    iio.imwrite(gif_path, frames, mode=I)
+    iio.imwrite(gif_path, frames, mode="I")
             
     optimize(gif_path)
 


### PR DESCRIPTION
Fix a small typo in the documentation. 