### PR TITLE
MAINT: expose v3 plugins through v2 API

### DIFF
--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -134,14 +134,10 @@ def imopen(
             def loader(request, **kwargs):
                 return config.plugin_class(request, **kwargs)
 
-        elif not legacy_mode:
+        else:
 
             def loader(request, **kwargs):
                 return plugin(request, **kwargs)
-
-        else:
-            request.finish()
-            raise ValueError("The `plugin` argument must be a string.")
 
         try:
             return loader(request, **kwargs)
@@ -170,10 +166,6 @@ def imopen(
             for plugin_name in candidate_format.priority:
                 config = known_plugins[plugin_name]
 
-                # v2 compatibility; delete in v3
-                if legacy_mode and not config.is_legacy:
-                    continue
-
                 try:
                     candidate_plugin = config.plugin_class
                 except ImportError:
@@ -198,10 +190,6 @@ def imopen(
         for candidate_format in known_extensions[request.extension]:
             for plugin_name in candidate_format.priority:
                 config = known_plugins[plugin_name]
-
-                # v2 compatibility; delete in v3
-                if legacy_mode and not config.is_legacy:
-                    continue
 
                 try:
                     candidate_plugin = config.plugin_class
@@ -247,11 +235,6 @@ def imopen(
 
     # fallback option: try all plugins
     for config in known_plugins.values():
-        # Note: for v2 compatibility
-        # this branch can be removed in ImageIO v3.0
-        if legacy_mode and not config.is_legacy:
-            continue
-
         # each plugin gets its own request
         request = Request(uri, io_mode, format_hint=format_hint)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -793,7 +793,7 @@ def test_imwrite_not_subclass(tmpdir):
             pass
 
         def __array__(self, dtype=None):
-            return np.zeros((4, 4), dtype=dtype)
+            return np.zeros((4, 4), dtype=np.uint8)
 
     filename = os.path.join(str(tmpdir), "foo.bmp")
     iio.v2.imwrite(filename, Foo())
@@ -892,7 +892,7 @@ def test_imopen_installable_plugin(clear_plugins):
 
 
 def test_legacy_object_image_writing(tmp_path):
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         iio.mimwrite(tmp_path / "foo.gif", np.array([[0]], dtype=object))
 
 
@@ -987,9 +987,6 @@ def test_imopen_explicit_plugin_input(clear_plugins, tmp_path):
         tmp_path / "foo.tiff", "w", legacy_mode=False, plugin=PillowPlugin
     ) as f:
         assert isinstance(f, PillowPlugin)
-
-    with pytest.raises(ValueError):
-        iio.v3.imopen(tmp_path / "foo.tiff", "w", legacy_mode=True, plugin=PillowPlugin)
 
 
 @deprecated_test

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 from imageio import core
 from imageio.core import IS_PYPY
-from pytest import raises, skip
+from pytest import raises
 from conftest import deprecated_test
 
 
@@ -489,12 +489,13 @@ def test_gif(setup_library, tmp_path):
     )
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("darwin"),
+    reason="On OSX quantization of freeimage is unstable",
+)
 def test_animated_gif(setup_library, tmp_path):
 
     fnamebase = str(tmp_path / "test")
-
-    if sys.platform.startswith("darwin"):
-        skip("On OSX quantization of freeimage is unstable")
 
     # Get images
     im = get_ref_im(4, 0, 0)
@@ -544,7 +545,6 @@ def test_animated_gif(setup_library, tmp_path):
     assert W._palettesize == 128
     # Fail
     raises(IndexError, R.get_meta_data, -1)
-    raises(ValueError, iio.mimsave, fname, ims, palettesize=300)
     raises(
         ValueError,
         iio.mimsave,

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -111,56 +111,58 @@ def test_png(test_images, tmp_path):
             for colors in (0, 1, 3, 4):
                 fname = fnamebase + "%i.%i.%i.png" % (isfloat, crop, colors)
                 rim = get_ref_im(colors, crop, isfloat)
-                imageio.imsave(fname, rim)
-                im = imageio.imread(fname)
+                imageio.imsave(fname, rim, format="PNG-PIL")
+                im = imageio.imread(fname, format="PNG-PIL")
                 mul = 255 if isfloat else 1
                 assert_close(rim * mul, im, 0.1)  # lossless
 
     # Parameters
-    im = imageio.imread(test_images / "chelsea.png", ignoregamma=True)
+    im = imageio.imread(test_images / "chelsea.png", ignoregamma=True, format="PNG-PIL")
     imageio.imsave(fnamebase + ".png", im, interlaced=True)
 
     # Parameter fail
     with pytest.raises(TypeError):
-        imageio.imread(test_images / "chelsea.png", notavalidk=True)
+        imageio.imread(test_images / "chelsea.png", notavalidk=True, format="PNG-PIL")
 
     with pytest.raises(TypeError):
-        imageio.imsave(fnamebase + ".png", im, notavalidk=True)
+        imageio.imsave(fnamebase + ".png", im, notavalidk=True, format="PNG-PIL")
 
     # Compression
-    imageio.imsave(fnamebase + "1.png", im, compression=0)
-    imageio.imsave(fnamebase + "2.png", im, compression=9)
+    imageio.imsave(fnamebase + "1.png", im, compression=0, format="PNG-PIL")
+    imageio.imsave(fnamebase + "2.png", im, compression=9, format="PNG-PIL")
     s1 = os.stat(fnamebase + "1.png").st_size
     s2 = os.stat(fnamebase + "2.png").st_size
     assert s2 < s1
     # Fail
     with pytest.raises(ValueError):
-        imageio.imsave(fnamebase + ".png", im, compression=12)
+        imageio.imsave(fnamebase + ".png", im, compression=12, format="PNG-PIL")
 
     # Quantize
-    imageio.imsave(fnamebase + "1.png", im, quantize=256)
-    imageio.imsave(fnamebase + "2.png", im, quantize=4)
+    imageio.imsave(fnamebase + "1.png", im, quantize=256, format="PNG-PIL")
+    imageio.imsave(fnamebase + "2.png", im, quantize=4, format="PNG-PIL")
 
-    im = imageio.imread(fnamebase + "2.png")  # touch palette read code
+    im = imageio.imread(
+        fnamebase + "2.png", format="PNG-PIL"
+    )  # touch palette read code
     s1 = os.stat(fnamebase + "1.png").st_size
     s2 = os.stat(fnamebase + "2.png").st_size
     assert s1 > s2
     # Fail
     fname = fnamebase + "1.png"
     with pytest.raises(ValueError):
-        imageio.imsave(fname, im[:, :, :3], quantize=300)
+        imageio.imsave(fname, im[:, :, :3], quantize=300, format="PNG-PIL")
 
     with pytest.raises(ValueError):
-        imageio.imsave(fname, im[:, :, 0], quantize=100)
+        imageio.imsave(fname, im[:, :, 0], quantize=100, format="PNG-PIL")
 
     # 16b bit images
     im = imageio.imread(test_images / "chelsea.png")[:, :, 0]
-    imageio.imsave(fnamebase + "1.png", im.astype("uint16") * 2)
-    imageio.imsave(fnamebase + "2.png", im)
+    imageio.imsave(fnamebase + "1.png", im.astype("uint16") * 2, format="PNG-PIL")
+    imageio.imsave(fnamebase + "2.png", im, format="PNG-PIL")
     s1 = os.stat(fnamebase + "1.png").st_size
     s2 = os.stat(fnamebase + "2.png").st_size
     assert s2 < s1
-    im2 = imageio.imread(fnamebase + "1.png")
+    im2 = imageio.imread(fnamebase + "1.png", format="PNG-PIL")
     assert im2.dtype == np.uint16
 
     # issue #352 - prevent low-luma uint16 truncation to uint8
@@ -171,8 +173,8 @@ def test_png(test_images, tmp_path):
         [{"prefer_uint8": False}, np.uint16],
     ]
     for preference, dtype in preferences_dtypes:
-        imageio.imwrite(fnamebase + ".png", arr, **preference)
-        im = imageio.imread(fnamebase + ".png")
+        imageio.imwrite(fnamebase + ".png", arr, **preference, format="PNG-PIL")
+        im = imageio.imread(fnamebase + ".png", format="PNG-PIL")
         assert im.dtype == dtype
 
 
@@ -197,19 +199,24 @@ def test_jpg(tmp_path):
             for colors in (0, 1, 3):
                 fname = fnamebase + "%i.%i.%i.jpg" % (isfloat, crop, colors)
                 rim = get_ref_im(colors, crop, isfloat)
-                imageio.imsave(fname, rim)
-                im = imageio.imread(fname)
+                imageio.imsave(fname, rim, format="JPEG-PIL")
+                im = imageio.imread(fname, format="JPEG-PIL")
                 mul = 255 if isfloat else 1
                 assert_close(rim * mul, im, 1.1)  # lossy
 
     # No alpha in JPEG
     fname = fnamebase + ".jpg"
     with pytest.raises(Exception):
-        imageio.imsave(fname, im4)
+        imageio.imsave(fname, im4, format="JPEG-PIL")
 
     # Parameters
     imageio.imsave(
-        fnamebase + ".jpg", im3, progressive=True, optimize=True, baseline=True
+        fnamebase + ".jpg",
+        im3,
+        progressive=True,
+        optimize=True,
+        baseline=True,
+        format="JPEG-PIL",
     )
 
     # Parameter fail - We let Pillow kwargs thorugh
@@ -217,13 +224,13 @@ def test_jpg(tmp_path):
     # pytest.raises(TypeError, imageio.imsave, fnamebase + '.jpg', im, notavalidk=1)
 
     # Compression
-    imageio.imsave(fnamebase + "1.jpg", im3, quality=10)
-    imageio.imsave(fnamebase + "2.jpg", im3, quality=90)
+    imageio.imsave(fnamebase + "1.jpg", im3, quality=10, format="JPEG-PIL")
+    imageio.imsave(fnamebase + "2.jpg", im3, quality=90, format="JPEG-PIL")
     s1 = os.stat(fnamebase + "1.jpg").st_size
     s2 = os.stat(fnamebase + "2.jpg").st_size
     assert s2 > s1
     with pytest.raises(ValueError):
-        imageio.imsave(fnamebase + ".jpg", im, quality=120)
+        imageio.imsave(fnamebase + ".jpg", im, quality=120, format="JPEG-PIL")
 
 
 @deprecated_test
@@ -248,17 +255,17 @@ def test_jpg_more(test_images, tmp_path):
 
     # Test EXIF stuff
     fname = test_images / "rommel.jpg"
-    im = imageio.imread(fname)
+    im = imageio.imread(fname, format="JPEG-PIL")
     assert im.shape[0] > im.shape[1]
-    im = imageio.imread(fname, exifrotate=False)
+    im = imageio.imread(fname, exifrotate=False, format="JPEG-PIL")
     assert im.shape[0] < im.shape[1]
-    im = imageio.imread(fname, exifrotate=2)  # Rotation in Python
+    im = imageio.imread(fname, exifrotate=2, format="JPEG-PIL")  # Rotation in Python
     assert im.shape[0] > im.shape[1]
     # Write the jpg and check that exif data is maintained
     if sys.platform.startswith("darwin"):
         return  # segfaults on my osx VM, why?
-    imageio.imsave(fnamebase + "rommel.jpg", im)
-    im = imageio.imread(fname)
+    imageio.imsave(fnamebase + "rommel.jpg", im, format="JPEG-PIL")
+    im = imageio.imread(fname, format="JPEG-PIL")
     assert im.meta.EXIF_MAIN
 
 
@@ -275,8 +282,8 @@ def test_gif(tmp_path):
                     continue  # quantize fails, see also png
                 fname = fnamebase + "%i.%i.%i.gif" % (isfloat, crop, colors)
                 rim = get_ref_im(colors, crop, isfloat)
-                imageio.imsave(fname, rim)
-                im = imageio.imread(fname)
+                imageio.imsave(fname, rim, format="GIF-PIL")
+                im = imageio.imread(fname, format="GIF-PIL")
                 mul = 255 if isfloat else 1
                 if colors not in (0, 1):
                     im = im[:, :, :3]
@@ -285,10 +292,10 @@ def test_gif(tmp_path):
 
     # Parameter fail
     with pytest.raises(TypeError):
-        imageio.imread(fname, notavalidkwarg=True)
+        imageio.imread(fname, notavalidkwarg=True, format="GIF-PIL")
 
     with pytest.raises(TypeError):
-        imageio.imsave(fnamebase + "1.gif", im, notavalidk=True)
+        imageio.imsave(fnamebase + "1.gif", im, notavalidk=True, format="GIF-PIL")
 
 
 @deprecated_test
@@ -297,7 +304,7 @@ def test_animated_gif(test_images, tmp_path):
     fnamebase = str(tmp_path / "test")
 
     # Read newton's cradle
-    ims = imageio.mimread(test_images / "newtonscradle.gif")
+    ims = imageio.mimread(test_images / "newtonscradle.gif", format="GIF-PIL")
     assert len(ims) == 36
     for im in ims:
         assert im.shape == (150, 200, 4)
@@ -320,10 +327,10 @@ def test_animated_gif(test_images, tmp_path):
                 ims1 = [x.astype(np.float32) / 256 for x in ims1]
             ims1 = [x[:, :, :colors] for x in ims1]
             fname = fnamebase + ".animated.%i.gif" % colors
-            imageio.mimsave(fname, ims1, duration=0.2)
+            imageio.mimsave(fname, ims1, duration=0.2, format="GIF-PIL")
             # Retrieve
             print("fooo", fname, isfloat, colors)
-            ims2 = imageio.mimread(fname)
+            ims2 = imageio.mimread(fname, format="GIF-PIL")
             ims1 = [x[:, :, :3] for x in ims]  # fresh ref
             ims2 = [x[:, :, :3] for x in ims2]  # discart alpha
             for im1, im2 in zip(ims1, ims2):
@@ -331,45 +338,55 @@ def test_animated_gif(test_images, tmp_path):
 
     # We can also store grayscale
     fname = fnamebase + ".animated.%i.gif" % 1
-    imageio.mimsave(fname, [x[:, :, 0] for x in ims], duration=0.2)
-    imageio.mimsave(fname, [x[:, :, :1] for x in ims], duration=0.2)
+    imageio.mimsave(fname, [x[:, :, 0] for x in ims], duration=0.2, format="GIF-PIL")
+    imageio.mimsave(fname, [x[:, :, :1] for x in ims], duration=0.2, format="GIF-PIL")
 
     # Irragular duration. You probably want to check this manually (I did)
     duration = [0.1 for i in ims]
     for i in [2, 5, 7]:
         duration[i] = 0.5
-    imageio.mimsave(fnamebase + ".animated_irr.gif", ims, duration=duration)
+    imageio.mimsave(
+        fnamebase + ".animated_irr.gif", ims, duration=duration, format="GIF-PIL"
+    )
 
     # Other parameters
-    imageio.mimsave(fnamebase + ".animated.loop2.gif", ims, loop=2, fps=20)
-    R = imageio.read(fnamebase + ".animated.loop2.gif")
-    W = imageio.save(fnamebase + ".animated.palettes100.gif", palettesize=100)
+    imageio.mimsave(
+        fnamebase + ".animated.loop2.gif", ims, loop=2, fps=20, format="GIF-PIL"
+    )
+    R = imageio.read(fnamebase + ".animated.loop2.gif", format="GIF-PIL")
+    W = imageio.save(
+        fnamebase + ".animated.palettes100.gif", palettesize=100, format="GIF-PIL"
+    )
     assert W._writer.opt_palette_size == 128
     # Fail
     with pytest.raises(IndexError):
         R.get_meta_data(-1)
 
     with pytest.raises(ValueError):
-        imageio.mimsave(fname, ims, palettesize=300)
+        imageio.mimsave(fname, ims, palettesize=300, format="GIF-PIL")
 
     with pytest.raises(ValueError):
-        imageio.mimsave(fname, ims, quantizer="foo")
+        imageio.mimsave(fname, ims, quantizer="foo", format="GIF-PIL")
 
     with pytest.raises(ValueError):
-        imageio.mimsave(fname, ims, duration="foo")
+        imageio.mimsave(fname, ims, duration="foo", format="GIF-PIL")
 
     # Add one duplicate image to ims to touch subractangle with not change
     ims.append(ims[-1])
 
     # Test subrectangles
-    imageio.mimsave(fnamebase + ".subno.gif", ims, subrectangles=False)
-    imageio.mimsave(fnamebase + ".subyes.gif", ims, subrectangles=True)
+    imageio.mimsave(
+        fnamebase + ".subno.gif", ims, subrectangles=False, format="GIF-PIL"
+    )
+    imageio.mimsave(
+        fnamebase + ".subyes.gif", ims, subrectangles=True, format="GIF-PIL"
+    )
     s1 = os.stat(fnamebase + ".subno.gif").st_size
     s2 = os.stat(fnamebase + ".subyes.gif").st_size
     assert s2 < s1
 
     # Meta (dummy, because always {})
-    imageio.mimsave(fname, [x[:, :, 0] for x in ims], duration=0.2)
+    imageio.mimsave(fname, [x[:, :, 0] for x in ims], duration=0.2, format="GIF-PIL")
     assert isinstance(imageio.read(fname).get_meta_data(), dict)
 
 
@@ -385,11 +402,11 @@ def test_images_with_transparency(test_images):
     # Not alpha channel, but transparent pixels, see issue #245 and #246
 
     fname = test_images / "imageio_issue245.gif"
-    im = imageio.imread(fname)
+    im = imageio.imread(fname, format="GIF-PIL")
     assert im.shape == (24, 30, 4)
 
     fname = test_images / "imageio_issue246.png"
-    im = imageio.imread(fname)
+    im = imageio.imread(fname, format="PNG-PIL")
     assert im.shape == (24, 30, 4)
 
 
@@ -399,9 +416,9 @@ def test_gamma_correction(test_images):
     fname = test_images / "kodim03.png"
 
     # Load image three times
-    im1 = imageio.imread(fname)
-    im2 = imageio.imread(fname, ignoregamma=True)
-    im3 = imageio.imread(fname, ignoregamma=False)
+    im1 = imageio.imread(fname, format="PNG-PIL")
+    im2 = imageio.imread(fname, ignoregamma=True, format="PNG-PIL")
+    im3 = imageio.imread(fname, ignoregamma=False, format="PNG-PIL")
 
     # Default is to ignore gamma
     assert np.all(im1 == im2)
@@ -439,8 +456,8 @@ def test_bmp(test_images):
     fname = test_images / "scribble_P_RGB.bmp"
 
     imageio.imread(fname)
-    imageio.imread(fname, pilmode="RGB")
-    imageio.imread(fname, pilmode="RGBA")
+    imageio.imread(fname, pilmode="RGB", format="BMP-PIL")
+    imageio.imread(fname, pilmode="RGBA", format="BMP-PIL")
 
 
 @deprecated_test
@@ -460,16 +477,16 @@ def test_scipy_imread_compat(test_images):
     except TypeError as err:
         assert "pilmode" in str(err)
 
-    im = imageio.imread(fname, pilmode="RGBA")
+    im = imageio.imread(fname, pilmode="RGBA", format="PNG-PIL")
     assert im.shape == (300, 451, 4) and im.dtype == "uint8"
 
-    im = imageio.imread(fname, pilmode="L")
+    im = imageio.imread(fname, pilmode="L", format="PNG-PIL")
     assert im.shape == (300, 451) and im.dtype == "uint8"
 
-    im = imageio.imread(fname, pilmode="F")
+    im = imageio.imread(fname, pilmode="F", format="PNG-PIL")
     assert im.shape == (300, 451) and im.dtype == "float32"
 
-    im = imageio.imread(fname, as_gray=True)
+    im = imageio.imread(fname, as_gray=True, format="PNG-PIL")
     assert im.shape == (300, 451) and im.dtype == "float32"
 
     # Force using pillow (but really, Pillow's imageio's first choice! Except


### PR DESCRIPTION
The aim of this PR is to refactor the core and expose new plugins via the "old" v2 API. This way, we can deprecate and remove plugins that have been ported to v3 over time and we can also allow the v2 API to stay relevant and have access to new plugins.