### PR TITLE
BUG: include PYI files in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,8 @@ package_data = [
     "resources/images/*.*",
     "resources/freeimage/*.*",
     "py.typed",
+    "**/*.pyi",
+    "*.pyi",
 ]
 
 


### PR DESCRIPTION
Closes: #820 

This PR adds the PYI files to imageio's wheel. This way, mypy should be able to pick up on type hints and this should solve #820 