### PR TITLE
BUG: resolve infinite recursion in python 3.11 (and add CI for pypy-3.9)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - name: Linux py37 full
             os: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.7", "3.8", "3.9", "3.10"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - name: Linux py37 full
             os: ubuntu-latest
@@ -116,7 +116,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.7", "pypy-3.8"]
+        pyversion: ["pypy-3.7", "pypy-3.8", , "pypy-3.9"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up pypy

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,7 +116,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.7", "pypy-3.8", , "pypy-3.9"]
+        pyversion: ["pypy-3.7", "pypy-3.8", "pypy-3.9"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up pypy

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         include:
           - name: Linux py37 full
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.7", "3.8", "3.9", "3.10"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - name: Linux py37 full
             os: ubuntu-latest
@@ -115,7 +115,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.7", "pypy-3.8"]
+        pyversion: ["pypy-3.7", "pypy-3.8", "pypy-3.9"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up pypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,12 +94,12 @@ jobs:
           python-version: ${{ matrix.pyversion }}
       - name: Install dependencies for tests
         shell: bash
-        if: matrix.pyversion != "3.11-dev"
+        if: matrix.pyversion != '3.11-dev'
         run: |
             pip install .[test,all-plugins]
       - name: Install dependencies for 3.11-dev tests
         shell: bash
-        if: matrix.pyversion == "3.11-dev"
+        if: matrix.pyversion == '3.11-dev'
         run: |
             pip install .[test,ffmpeg,tifffile]
       - name: Install optional dependencies for tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
         shell: bash
         if: matrix.pyversion != '3.11-dev'
         run: |
-            pip install .[test,all-plugins]
+            pip install --no-deps .
+            pip install numpy tifffile
       - name: Install dependencies for 3.11-dev tests
         shell: bash
         if: matrix.pyversion == '3.11-dev'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - name: Linux py37 full
             os: ubuntu-latest
@@ -94,15 +94,8 @@ jobs:
           python-version: ${{ matrix.pyversion }}
       - name: Install dependencies for tests
         shell: bash
-        if: matrix.pyversion != '3.11-dev'
         run: |
             pip install .[test,all-plugins]
-      - name: Install dependencies for 3.11-dev tests
-        shell: bash
-        if: matrix.pyversion == '3.11-dev'
-        run: |
-            pip install --no-deps .
-            pip install numpy tifffile pytest coverage fsspec
       - name: Install optional dependencies for tests
         if: matrix.TEST_FULL == 1
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         if: matrix.pyversion == '3.11-dev'
         run: |
             pip install --no-deps .
-            pip install numpy tifffile pytest coverage
+            pip install numpy tifffile pytest coverage fsspec
       - name: Install optional dependencies for tests
         if: matrix.TEST_FULL == 1
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,14 @@ jobs:
           python-version: ${{ matrix.pyversion }}
       - name: Install dependencies for tests
         shell: bash
+        if: matrix.pyversion != "3.11-dev"
         run: |
             pip install .[test,all-plugins]
+      - name: Install dependencies for 3.11-dev tests
+        shell: bash
+        if: matrix.pyversion == "3.11-dev"
+        run: |
+            pip install .[test,ffmpeg,tifffile]
       - name: Install optional dependencies for tests
         if: matrix.TEST_FULL == 1
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,13 @@ jobs:
         shell: bash
         if: matrix.pyversion != '3.11-dev'
         run: |
-            pip install --no-deps .
-            pip install numpy tifffile
+            pip install .[test,all-plugins]
       - name: Install dependencies for 3.11-dev tests
         shell: bash
         if: matrix.pyversion == '3.11-dev'
         run: |
-            pip install .[test,ffmpeg,tifffile]
+            pip install --no-deps .
+            pip install numpy tifffile pytest coverage
       - name: Install optional dependencies for tests
         if: matrix.TEST_FULL == 1
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         include:
           - name: Linux py37 full
             os: ubuntu-latest

--- a/imageio/plugins/freeimage.py
+++ b/imageio/plugins/freeimage.py
@@ -26,9 +26,15 @@ flags : int
 """
 
 import numpy as np
+import pytest
 
 from ..core import Format, image_as_uint
 from ..core.request import RETURN_BYTES
+
+
+pytest.importorskip("._freeimage")
+
+
 from ._freeimage import fi, download, IO_FLAGS, FNAME_PER_PLATFORM  # noqa
 
 

--- a/imageio/plugins/freeimage.py
+++ b/imageio/plugins/freeimage.py
@@ -26,17 +26,10 @@ flags : int
 """
 
 import numpy as np
-import pytest
 
 from ..core import Format, image_as_uint
 from ..core.request import RETURN_BYTES
-
-
-pytest.importorskip("._freeimage")
-
-
-from ._freeimage import fi, download, IO_FLAGS, FNAME_PER_PLATFORM  # noqa
-
+from ._freeimage import FNAME_PER_PLATFORM, IO_FLAGS, download, fi  # noqa
 
 # todo: support files with only meta data
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -1,23 +1,17 @@
 """ Tests for imageio's pillow plugin
 """
 
+import io
+import os
 from pathlib import Path
 
-from imageio.core.request import Request
-import os
-import io
-import pytest
-import numpy as np
-
 import imageio as iio
+import numpy as np
+import pytest
+from imageio.core.request import InitializationError, Request
 from imageio.core.v3_plugin_api import PluginV3
 from imageio.plugins.pillow import PillowPlugin
-from imageio.core.request import InitializationError
-
-
-pytest.importorskip("PIL")
-
-from PIL import Image, ImageSequence  # type: ignore # noqa: E402
+from PIL import Image, ImageSequence  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -8,12 +8,16 @@ import os
 import io
 import pytest
 import numpy as np
-from PIL import Image, ImageSequence  # type: ignore
 
 import imageio as iio
 from imageio.core.v3_plugin_api import PluginV3
 from imageio.plugins.pillow import PillowPlugin
 from imageio.core.request import InitializationError
+
+
+pytest.importorskip("PIL")
+
+from PIL import Image, ImageSequence  # type: ignore # noqa: E402
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes: #817 

This PR includes pypy 3.9 in our test matrix. It also adds a refactor of the plugin submodule that should fix the bug reported in #817

Edit: I removed the addition of cpython 3.11-dev to CI from this PR because pillow does not seem to have a prebuilt wheel for this python version yet. Building from source fails without us digging into providing the required dependencies on GH actions, which is IMO beyond the scope of this PR. So - for now - there is no CI for python 3.11, but I am very happy to revisit once upstream dependencies have adopted 3.11.