### PR TITLE
BUG: allow multiple reads from imopen

### DIFF
--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -392,8 +392,17 @@ class PyAVPlugin(PluginV3):
 
             return frames
 
-        self._video_stream.thread_type = thread_type or "SLICE"
-        self._video_stream.codec_context.thread_count = thread_count
+        thread_type = thread_type or "SLICE"
+        if thread_type != self._video_stream.thread_type:
+            self._video_stream.thread_type = thread_type or "SLICE"
+        if (
+            thread_count != 0
+            and thread_count != self._video_stream.codec_context.thread_count
+        ):
+            # in FFMPEG thread_count == 0 means use the default count, which we
+            # change to mean don't change the thread count.
+            self._video_stream.codec_context.thread_count = thread_count
+
         ffmpeg_filter = self._build_filter(filter_sequence, filter_graph)
         ffmpeg_filter.send(None)  # init
 

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -341,8 +341,8 @@ class PyAVPlugin(PluginV3):
 
             - `"SLICE"`: threads assemble parts of the current frame
             - `"FRAME"`: threads may assemble future frames
-            - None (default): Uses SLICE when reading single frames and FRAME
-              when reading batches of frames.
+            - None (default): Uses ``"FRAME"`` if ``index=...`` and ffmpeg's
+              default otherwise.
 
 
         Returns
@@ -392,9 +392,8 @@ class PyAVPlugin(PluginV3):
 
             return frames
 
-        thread_type = thread_type or "SLICE"
-        if thread_type != self._video_stream.thread_type:
-            self._video_stream.thread_type = thread_type or "SLICE"
+        if thread_type is not None and thread_type != self._video_stream.thread_type:
+            self._video_stream.thread_type = thread_type
         if (
             thread_count != 0
             and thread_count != self._video_stream.codec_context.thread_count
@@ -450,7 +449,7 @@ class PyAVPlugin(PluginV3):
             The threading model to be used. One of
 
             - `"SLICE"` (default): threads assemble parts of the current frame
-            - `"FRAME"`: threads may assemble future frames
+            - `"FRAME"`: threads may assemble future frames (faster for bulk reading)
 
 
         Yields

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -366,6 +366,8 @@ def test_sequential_reading(test_images):
     ]
 
     with iio.imopen(test_images / "cockatoo.mp4", "r", plugin="pyav") as img_file:
-        actual_imgs = [img_file.read(index=1), img_file.read(index=5)]
+        first_read = img_file.read(index=1, thread_type="FRAME", thread_count=2)
+        second_read = img_file.read(index=5)
+        actual_imgs = [first_read, second_read]
 
     np.allclose(actual_imgs, expected_imgs)

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -357,3 +357,15 @@ def test_bayer_write():
     buffer.seek(0)
     img = iio.imread(buffer, plugin="pyav")
     assert img.shape == (768, 128, 128, 3)
+
+
+def test_sequential_reading(test_images):
+    expected_imgs = [
+        iio.imread(test_images / "cockatoo.mp4", index=1),
+        iio.imread(test_images / "cockatoo.mp4", index=5),
+    ]
+
+    with iio.imopen(test_images / "cockatoo.mp4", "r", plugin="pyav") as img_file:
+        actual_imgs = [img_file.read(index=1), img_file.read(index=5)]
+
+    np.allclose(actual_imgs, expected_imgs)


### PR DESCRIPTION
While answering a question on SO I found a bug in our pyav plugin that prevents calling `PyAVPlugin.read(...)` more than once.

The reason was that pyav doesn't allow re-assigning or changing the threading model (`thread_type`). Even if we try to assign the current value it will break. The same happens for the thread count. This PR addresses that by checking the value first and only setting it if it is different from the current value.