### PR TITLE
FEAT: enable HTTP based streams in pyav

### DIFF
--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -256,7 +256,14 @@ class PyAVPlugin(PluginV3):
 
         if request.mode.io_mode == IOMode.read:
             try:
-                self._container = av.open(request.get_file())
+                if request._uri_type == 5:  # 5 is the value of URI_HTTP
+                    # pyav should read from HTTP by itself. This enables reading
+                    # HTTP-based streams like DASH. Note that solving streams
+                    # like this is temporary until the new request object gets
+                    # implemented.
+                    self._container = av.open(request.raw_uri)
+                else:
+                    self._container = av.open(request.get_file())
                 self._video_stream = self._container.streams.video[0]
                 self._decoder = self._container.decode(video=0)
             except av.AVError:

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -371,3 +371,19 @@ def test_sequential_reading(test_images):
         actual_imgs = [first_read, second_read]
 
     np.allclose(actual_imgs, expected_imgs)
+
+
+def test_uri_reading(test_images):
+    uri = "https://dash.akamaized.net/dash264/TestCases/2c/qualcomm/1/MultiResMPEG2.mpd"
+
+    with av.open(uri) as container:
+        for idx, frame in enumerate(container.decode(video=0)):
+            if idx < 250:
+                continue
+
+            expected = frame.to_ndarray(format="rgb24")
+            break
+
+    actual = iio.imread(uri, plugin="pyav", index=250)
+
+    np.allclose(actual, expected)


### PR DESCRIPTION
PyAV/FFmpeg supports [DASH streams](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP), which we currently don't. This PR addresses that by making pyav use the raw HTTP URL instead of using `request.get_file()`.