### PR TITLE
BUG: frame-level metadata and duration in pyav

### DIFF
--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -914,12 +914,14 @@ class PyAVPlugin(PluginV3):
 
         if index is ...:
             # useful flags defined on the container and/or video stream
+            duration = float(self._video_stream.duration * self._video_stream.time_base)
             metadata.update(
                 {
                     "video_format": self._video_stream.codec_context.pix_fmt,
                     "codec": self._video_stream.codec.name,
                     "long_codec": self._video_stream.codec.long_name,
                     "profile": self._video_stream.profile,
+                    "duration": duration,
                 }
             )
 

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -942,7 +942,7 @@ class PyAVPlugin(PluginV3):
         # side data
         metadata.update({key: value for key, value in desired_frame.side_data.items()})
 
-        return self._container.metadata
+        return metadata
 
     def _seek(self, index, *, constant_framerate: bool = True) -> None:
         """Seeks to the frame at the given index."""

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -64,9 +64,11 @@ def test_metadata(test_images: Path):
         meta = plugin.metadata()
         assert meta["profile"] == "High 4:4:4 Predictive"
         assert meta["codec"] == "h264"
+        assert meta["encoder"] == "Lavf56.4.101"
 
         meta = plugin.metadata(index=4)
-        assert meta["encoder"] == "Lavf56.4.101"
+        assert meta["time"] == 0.2
+        assert meta["key_frame"] is False
 
 
 def test_properties(test_images: Path):

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -65,6 +65,7 @@ def test_metadata(test_images: Path):
         assert meta["profile"] == "High 4:4:4 Predictive"
         assert meta["codec"] == "h264"
         assert meta["encoder"] == "Lavf56.4.101"
+        assert meta["duration"] == 14
 
         meta = plugin.metadata(index=4)
         assert meta["time"] == 0.2


### PR DESCRIPTION
This PR fixes a bug in the pyav plugin that returns the container metadata instead of returning frame-level metadata. It also exposes the video duration (in seconds) when reading global metadata for a video.