### PR TITLE
MAINT: ignore exclude_applied on legacy plugins

### DIFF
--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -293,8 +293,8 @@ class LegacyPlugin(PluginV3):
             The index of the ndimage to read. If the index is out of bounds a
             ``ValueError`` is raised. If ``None``, global metadata is returned.
         exclude_applied : bool
-            If True (default), do not report metadata fields that the plugin
-            would apply/consume while reading the image.
+            This parameter exists for compatibility and has no effect. Legacy
+            plugins always report all metadata they find.
 
         Returns
         -------

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -304,11 +304,6 @@ class LegacyPlugin(PluginV3):
 
         """
 
-        if exclude_applied:
-            raise ValueError(
-                "Legacy plugins don't support excluding applied metadata fields."
-            )
-
         if index is None:
             index = _legacy_default_index(self._format)
 

--- a/tests/test_legacy_plugin_wrapper.py
+++ b/tests/test_legacy_plugin_wrapper.py
@@ -24,13 +24,6 @@ def test_exception_message_bytes():
         assert "<bytes>" in str(e)
 
 
-def test_exclude_applied(test_images):
-    with pytest.raises(ValueError):
-        iio.v3.immeta(
-            test_images / "chelsea.png", exclude_applied=True, plugin="PNG-PIL"
-        )
-
-
 def test_ellipsis_index(test_images):
     img = iio.v3.imread(test_images / "chelsea.png", plugin="PNG-FI", index=...)
     assert img.shape == (1, 300, 451, 3)


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/843

Legacy plugins are unable to respect `exclude_applied` when reading metadata without a massive refactor to the current codebase. We used to `raise` in this scenario, but perhaps it is better UX to silently ignore this considering that this causes an exception by default. I'm happy to give it a try and see if it causes issues.