### PR TITLE
FEAT: add is_batch kwarg to pillow

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -248,17 +248,24 @@ class PillowPlugin(PluginV3):
 
         Parameters
         ----------
-        image : ndarray
-            The ndimage to write.
-        mode : {str, None}
+        image : ndarray or list
+            The ndimage to write. If a list is given each element is expected to
+            be an ndimage.
+        mode : str
             Specify the image's color format. If None (default), the mode is
             inferred from the array's shape and dtype. Possible modes can be
             found at:
             https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
-        format : {str, None}
-            Optional format override.  If omitted, the format to use is
+        format : str
+            Optional format override. If omitted, the format to use is
             determined from the filename extension. If a file object was used
             instead of a filename, this parameter must always be used.
+        is_batch : bool
+            Explicitly tell the writer that ``image`` is a batch of images
+            (True) or not (False). If None, the writer will guess this from the
+            provided ``mode`` or ``image.shape``. While the latter often works,
+            it may cause problems for small images due to aliasing of spatial
+            and color-channel axes.
         kwargs : ...
             Extra arguments to pass to pillow. If a writer doesn't recognise an
             option, it is silently ignored. The available options are described

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -232,6 +232,7 @@ class PillowPlugin(PluginV3):
         *,
         mode: str = None,
         format: str = None,
+        is_batch: bool = None,
         **kwargs,
     ) -> Optional[bytes]:
         """
@@ -284,13 +285,12 @@ class PillowPlugin(PluginV3):
             is_batch = True
         else:
             ndimage = np.asarray(ndimage)
-            is_batch = None
 
         # check if ndimage is a batch of frames/pages (e.g. for writing GIF)
         # if mode is given, use it; otherwise fall back to image.ndim only
-        if is_batch is True:
-            pass  # ndimage was list; we know it is a batch
-        if mode is not None:
+        if is_batch is not None:
+            pass
+        elif mode is not None:
             is_batch = (
                 ndimage.ndim > 3 if Image.getmodebands(mode) > 1 else ndimage.ndim > 2
             )

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -580,8 +580,3 @@ def test_write_format_warning():
         old_bytes = iio.v3.imwrite("<bytes>", frames, plugin="pillow", format="PNG")
 
     assert bytes_image == old_bytes
-
-
-# def test_trailing_dim():
-#     x = np.zeros((10, 30, 1), dtype=np.uint8)
-#     foo = iio.v3.imwrite("<bytes>", x, extension=".jpg", is_batch=False)

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -580,3 +580,8 @@ def test_write_format_warning():
         old_bytes = iio.v3.imwrite("<bytes>", frames, plugin="pillow", format="PNG")
 
     assert bytes_image == old_bytes
+
+
+# def test_trailing_dim():
+#     x = np.zeros((10, 30, 1), dtype=np.uint8)
+#     foo = iio.v3.imwrite("<bytes>", x, extension=".jpg", is_batch=False)


### PR DESCRIPTION
This PR adds a new kwarg to `PillowPlugin.write` called `is_batch`. Currently, we try to figure out if the passed ndarray is an image or an image batch by looking at the shape or mode. This isn't always correct due to the aliasing of shapes, e.g., a `(5, 5, 3)` image could be a 5x5 RGB image or a batch of 5 5x3 grayscale images.

This PR hence adds `is_batch` as an optional kwarg to allow the user to explicitly pass this information if relevant.