### PR TITLE
DOC: fix typo in test_pyav

### DIFF
--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -55,7 +55,7 @@ def test_mp4_writing(tmp_path, test_images):
     )
 
     # libx264 writing is not deterministic and RGB -> YUV is lossy
-    # so I have good ideas how to do serious assertions on the file
+    # so I have no good ideas how to do serious assertions on the file
     assert mp4_bytes is not None
 
 


### PR DESCRIPTION
Fix a typo in one of the tests. -- No need to review, because it is a one-liner in a comment.