### PR TITLE
DEV: remove unneeded CD steps

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,12 +49,6 @@ jobs:
           echo "::set-output name=release::true"
           echo "Releasing v$(semantic-release print-version)"
         fi
-    - name: Skipping Release
-      if: ${{ steps.skippy.outputs.release == 'false' }}
-      run: echo ${{ steps.skippy.outputs.release }}
-    - name: Releasing New Version
-      if: ${{ steps.skippy.outputs.release == 'true' }}
-      run: echo ${{ steps.skippy.outputs.release }}
   
   docs:
     name: Build Docs


### PR DESCRIPTION
Earlier today I've noticed a regression in `python-semantic-release` (our CD tool). This caused the pipeline to no longer detect changes and thus no longer build new versions.

I started this PR to fix the pipeline, but upstream beat me to it and has already released a new version that fixes the issue. Instead, I am using this PR to do some minor cleanup on the CD workflow that I found along the way.