### PR TITLE
MAINT: add missing option to imwrite type hints

### DIFF
--- a/imageio/v3.pyi
+++ b/imageio/v3.pyi
@@ -1,9 +1,9 @@
-from typing import Any, Dict, Iterator, Literal, Optional, overload
+from typing import Any, Dict, Iterator, List, Literal, Optional, Union, overload
 
 import numpy as np
 
-from .core.v3_plugin_api import ImageProperties
 from .core.imopen import imopen as imopen
+from .core.v3_plugin_api import ImageProperties
 from .typing import ArrayLike, ImageResource
 
 def imread(
@@ -26,7 +26,7 @@ def imiter(
 @overload
 def imwrite(
     uri: Literal["<bytes>"],
-    image: ArrayLike,
+    image: Union[ArrayLike, List[ArrayLike]],
     *,
     plugin: str = None,
     extension: str = None,
@@ -36,7 +36,7 @@ def imwrite(
 @overload
 def imwrite(
     uri: ImageResource,
-    image: ArrayLike,
+    image: Union[ArrayLike, List[ArrayLike]],
     *,
     plugin: str = None,
     extension: str = None,


### PR DESCRIPTION
While helping debug a script in a recent discussion (https://github.com/imageio/imageio/issues/829#issuecomment-1194134027) we've noticed a bug in ImageIO's typehints: the option to pass `List[ArrayLike]` as frames was missing. This PR adds that :)