### PR TITLE
BUG: write single TIFF page for single RGB image

### DIFF
--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -183,7 +183,7 @@ class LegacyPlugin(PluginV3):
 
         if is_batch is not None:
             pass
-        elif isinstance(ndimage, list):
+        elif isinstance(ndimage, (list, tuple)):
             is_batch = True
         elif ndimage.ndim == 2:
             is_batch = False

--- a/imageio/v2.py
+++ b/imageio/v2.py
@@ -393,6 +393,9 @@ def volwrite(uri, im, format=None, **kwargs):
 
     imopen_args = decypher_format_arg(format)
     imopen_args["legacy_mode"] = True
+
+    kwargs["is_batch"] = False
+
     with imopen(uri, "wv", **imopen_args) as file:
         return file.write(im, **kwargs)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -700,13 +700,10 @@ def test_functions(test_images, tmp_path):
     assert os.path.isfile(fname6)
 
     # Fail for save functions
-    raises(ValueError, iio.imsave, fname2, np.zeros((100, 100, 5)))
     raises(ValueError, iio.imsave, fname2, 42)
-    raises(ValueError, iio.mimsave, fname5, [np.zeros((100, 100, 5))])
     raises(ValueError, iio.mimsave, fname5, [42])
     raises(ValueError, iio.volsave, fname6, np.zeros((100, 100, 100, 40)))
     raises(ValueError, iio.volsave, fname6, 42)
-    raises(ValueError, iio.mvolsave, fname6, [np.zeros((90, 90, 90, 40))])
     raises(ValueError, iio.mvolsave, fname6, [42])
 
 

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -236,7 +236,7 @@ def test_tiff_page_writing():
 
 
 def test_bool_writing():
-    # test related to
+    # regression test for
     # https://github.com/imageio/imageio/issues/852
 
     expected = (np.arange(255 * 123) % 2 == 0).reshape((255, 123))

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -4,6 +4,7 @@
 import datetime
 import numpy as np
 import pytest
+import io
 
 import imageio.v2 as iio
 import imageio.v3 as iio3
@@ -219,3 +220,16 @@ def test_stk_volume():
     actual = iio3.imread("test.stk")
 
     np.allclose(actual, expected)
+
+
+def test_tiff_page_writing():
+    # regression test for
+    # https://github.com/imageio/imageio/issues/849
+    base_image = np.full((256, 256, 3), 42, dtype=np.uint8)
+
+    buffer = io.BytesIO()
+    iio3.imwrite(buffer, base_image, extension=".tiff")
+    buffer.seek(0)
+
+    with tifffile.TiffFile(buffer) as file:
+        assert len(file.pages) == 1

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -233,3 +233,15 @@ def test_tiff_page_writing():
 
     with tifffile.TiffFile(buffer) as file:
         assert len(file.pages) == 1
+
+
+def test_bool_writing():
+    # test related to
+    # https://github.com/imageio/imageio/issues/852
+
+    expected = (np.arange(255 * 123) % 2 == 0).reshape((255, 123))
+
+    img_bytes = iio3.imwrite("<bytes>", expected, extension=".tiff")
+    actual = iio.imread(img_bytes)
+
+    assert np.allclose(actual, expected)


### PR DESCRIPTION
Closes: #849 , https://github.com/imageio/imageio/issues/852

This PR refactors the way we deduce if an ndimage is a single image or a batch of images when writing with legacy plugins. Previously we used the image mode for this; however, this sometimes yields wrong results. For example, a `(256, 256, 3)` image would be saved as 256 `(256, 3)` pages instead of one `(256, 256, 3)` page. 

This PR also addresses an unclear error message that could be seen when passing non-numeric images to ImageIO. Instead of stating the wrong dtype it would use the name of the object instead. This PR addresses this problem as well.

This PR fixes this and also adds a regression test.