### PR TITLE
FEAT: pyav API for procedural video writing 

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -84,18 +84,6 @@ Read all Images in a Folder
 Note, however, that ``Path().iterdir()`` does not guarantees the order in which
 files are read.
 
-
-Iterate over frames in a movie
-------------------------------
-
-.. code-block:: python
-
-    import imageio.v3 as iio
-
-    for i, frame in enumerate(iio.imiter("imageio:cockatoo.mp4")):
-        print("Mean of frame %i is %1.1f" % (i, frame.mean()))
-
-
 Grab screenshot or image from the clipboard
 -------------------------------------------
 
@@ -155,8 +143,9 @@ Convert a short movie to grayscale
     # write the video
     iio.imwrite("cockatoo_gray.mp4", gray_frames_as_rgb, fps=metadata["fps"])
 
-Read frames in a video
-----------------------
+Read or iterate frames in a video
+---------------------------------
+
 .. note::
     For this to work, you need to install the pyav backend::
 
@@ -181,6 +170,7 @@ Read frames in a video
     for frame in iio.imiter("imageio:cockatoo.mp4", plugin="pyav"):
         print(frame.shape, frame.dtype)
 
+
 Re-encode a (large) video
 -------------------------
 
@@ -197,11 +187,13 @@ Re-encode a (large) video
     source = "imageio:cockatoo.mp4"
     dest = "reencoded_cockatoo.mkv"
 
-    with iio.imopen(source, "r", plugin="pyav") as in_file, iio.imopen(
-        dest, "w", plugin="pyav"
-    ) as out_file:
-        for frame in in_file.iter(format="rgb24"):
-            out_file.write(frame, codec="vp9", is_batch=False)
+    fps = iio.immeta(source, plugin="pyav")["fps"]
+
+    with iio.imopen(dest, "w", plugin="pyav") as out_file:
+        out_file.init_video_stream("vp9", fps=fps)
+
+        for frame in iio.imiter(source, plugin="pyav"):
+            out_file.write_frame(frame)
 
 
 Read medical data (DICOM)

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -666,6 +666,7 @@ class PyAVPlugin(PluginV3):
                     "long_codec": self._video_stream.codec.long_name,
                     "profile": self._video_stream.profile,
                     "duration": duration,
+                    "fps": float(self._video_stream.guessed_rate),
                 }
             )
 

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -1,6 +1,9 @@
 """Read/Write Videos (and images) using PyAV.
 
-Backend Library: `PyAV <https://pyav.org/docs/stable/>`_
+.. note::
+    To use this plugin you need to have `PyAV <https://pyav.org/docs/stable/>`_ installed::
+
+        pip install av
 
 This plugin wraps pyAV, a pythonic binding for the FFMPEG library.
 It is similar to our FFMPEG plugin but offers a more performant and
@@ -33,6 +36,31 @@ context:
     PyAVPlugin.set_video_filter
     PyAVPlugin.container_metadata
     PyAVPlugin.video_stream_metadata
+
+Advanced API
+------------
+
+In addition to the default ImageIO v3 API this plugin exposes custom functions
+that are specific to reading/writing video and its metadata. These are available
+inside the :func:`imopen <imageio.v3.imopen>` context and allow fine-grained
+control over how the video is processed. The functions are documented above and
+below you can find a usage example::
+
+    import imageio.v3 as iio
+
+    with iio.imopen("test.mp4", "w", plugin="pyav") as file:
+        file.init_video_stream("libx264")
+        file.container_metadata["comment"] = "This video has a rotation flag."
+        file.video_stream_metadata["rotate"] = "90"
+
+        for _ in range(5):
+            for frame in iio.imiter("imageio:newtonscradle.gif"):
+                file.write_frame(frame)
+
+    meta = iio.immeta("test.mp4", plugin="pyav")
+    assert meta["comment"] == "This video has a rotation flag."
+
+
 
 Pixel Formats (Colorspaces)
 ---------------------------

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -774,7 +774,7 @@ class PyAVPlugin(PluginV3):
         """
 
         stream = self._container.add_stream(codec, fps)
-        stream.time_base = Fraction(1, fps)
+        stream.time_base = Fraction(1, int(fps))
         if pixel_format is not None:
             stream.pix_fmt = pixel_format
 

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -438,6 +438,21 @@ def test_procedual_writing_with_filter(test_images):
     assert actual.shape == (280, 480, 640, 3)
 
 
+def test_rotation_flag_metadata(tmp_path):
+    with iio.imopen(tmp_path / "test.mp4", "w", plugin="pyav") as file:
+        file.init_video_stream("libx264")
+        file.container_metadata["comment"] = "This video has a rotation flag."
+        file.video_stream_metadata["rotate"] = "90"
+
+        for _ in range(5):
+            for frame in iio.imiter("imageio:newtonscradle.gif"):
+                file.write_frame(frame)
+
+    meta = iio.immeta(tmp_path / "test.mp4", plugin="pyav")
+    assert meta["comment"] == "This video has a rotation flag."
+    assert meta["rotate"] == "90"
+
+
 def test_read_filter(test_images):
     image = iio.imread(
         test_images / "cockatoo.mp4",

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -66,6 +66,7 @@ def test_metadata(test_images: Path):
         assert meta["codec"] == "h264"
         assert meta["encoder"] == "Lavf56.4.101"
         assert meta["duration"] == 14
+        assert meta["fps"] == 20.0
 
         meta = plugin.metadata(index=4)
         assert meta["time"] == 0.2

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -179,7 +179,7 @@ def test_filter_graph(test_images):
     assert frames.shape == (56, 480, 640, 3)
 
 
-def test_write_bytes(test_images, tmp_path):
+def test_write_bytes(test_images):
     img = iio.imread(
         test_images / "cockatoo.mp4",
         plugin="pyav",
@@ -193,7 +193,6 @@ def test_write_bytes(test_images, tmp_path):
         img,
         extension=".mp4",
         plugin="pyav",
-        in_pixel_format="yuv444p",
         codec="libx264",
     )
 
@@ -210,7 +209,12 @@ def test_read_png(test_images):
 def test_write_png(test_images, tmp_path):
     img_expected = iio.imread(test_images / "chelsea.png", plugin="pyav", index=0)
     iio.imwrite(
-        tmp_path / "out.png", img_expected, plugin="pyav", codec="png", is_batch=False
+        tmp_path / "out.png",
+        img_expected,
+        plugin="pyav",
+        codec="png",
+        is_batch=False,
+        out_pixel_format="rgb24",
     )
     img_actual = iio.imread(tmp_path / "out.png", plugin="pyav")
 
@@ -285,11 +289,14 @@ def test_variable_fps_seek(test_images):
 
 
 def test_multiple_writes(test_images):
+    # Note: when opening videos via imopen prefer using the additional API for
+    # writing (see eg. test_procedual_writing)
     out_buffer = io.BytesIO()
     with iio.imopen(out_buffer, "w", plugin="pyav", extension=".mp4") as file:
         for frame in iio.imiter(
             test_images / "newtonscradle.gif",
             plugin="pyav",
+            format="rgba",
         ):
             file.write(frame, is_batch=False, codec="libx264", in_pixel_format="rgba")
 
@@ -395,3 +402,47 @@ def test_uri_reading(test_images):
 def test_seek_last(test_images):
     frame = iio.imread(test_images / "cockatoo.mp4", plugin="pyav", index=279)
     assert frame.shape == (720, 1280, 3)
+
+
+def test_procedual_writing(test_images):
+    buffer = io.BytesIO()
+    with iio.imopen(buffer, "w", plugin="pyav", extension=".mp4") as file:
+        file.init_video_stream("h264")
+        for frame in iio.imiter(test_images / "cockatoo.mp4", plugin="pyav"):
+            file.write_frame(frame)
+
+    buffer.seek(0)
+    actual = iio.imread(buffer, plugin="pyav", extension=".mp4")
+
+    assert actual.shape == (280, 720, 1280, 3)
+
+
+def test_procedual_writing_with_filter(test_images):
+    buffer = io.BytesIO()
+    with iio.imopen(buffer, "w", plugin="pyav", extension=".mp4") as file:
+        file.init_video_stream("h264", fps=30)
+        file.set_video_filter(
+            filter_sequence=[
+                ("scale", {"size": "vga", "flags": "lanczos"}),
+            ]
+        )
+        for frame in iio.imiter(
+            test_images / "cockatoo.mp4", plugin="pyav", format="yuv444p"
+        ):
+            file.write_frame(frame, pixel_format="yuv444p")
+
+    buffer.seek(0)
+    actual = iio.imread(buffer, plugin="pyav", extension=".mp4")
+
+    assert actual.shape == (280, 480, 640, 3)
+
+
+def test_read_filter(test_images):
+    image = iio.imread(
+        test_images / "cockatoo.mp4",
+        index=5,
+        plugin="pyav",
+        filter_sequence=[("scale", {"size": "vga", "flags": "lanczos"})],
+    )
+
+    assert image.shape == (480, 640, 3)


### PR DESCRIPTION
Closes: #841 

This PR adds a set of functions to the pyav plugin that make it easier to generate video procedurally, i.e., to write a video frame-by-frame instead of writing frames in bulk. For simple scenarios, this was already possible before through repeated calls to `PyAVPlugin.write`, but this involved setting a lot of kwargs for each call. It also didn't support using filters across multiple call to `write` and there was no way to set metadata. This PR makes cleans most of that up.

The functions extend the basic imageIO API in a plugin-specific way and are available after opening a ImageResource via `iio.imopen`. (Thanks to our type-hinting setup they will even appear as suggestions inside the context manager 😍 🚀 )

**Examples**

```python
import imageio.v3 as iio

# before this PR
# Note 1: this is roughly the extent of what was possible before
# Note 2: this is still possible (the PR is backwards compatible)
with iio.imopen("test.mp4", "w", plugin="pyav") as file:
    for _ in range(5):
        for frame in iio.imiter("imageio:newtonscradle.gif"):
            file.write(frame, is_batch=False, codec="libx264")

# after this PR
with iio.imopen("test.mp4", "w", plugin="pyav") as file:
    file.init_video_stream("libx264")
    for _ in range(5):
        for frame in iio.imiter("imageio:newtonscradle.gif"):
            file.write_frame(frame)
```

New things that this PR adds

```python
import imageio.v3 as iio

# filter output frames before writing them
with iio.imopen("test.mp4", "w", plugin="pyav") as file:
    file.init_video_stream("libx264")
    file.set_video_filter([("scale", "vga")])

    for _ in range(5):
        for frame in iio.imiter("imageio:newtonscradle.gif"):
            file.write_frame(frame)
```

```python
import imageio.v3 as iio

# set stream-level and container-level metadata
with iio.imopen("test.mp4", "w", plugin="pyav") as file:
    file.init_video_stream("libx264")
    file.container_metadata["comment"] = "This video has a rotation flag."
    file.video_stream_metadata["rotate"] = "90"

    for _ in range(5):
        for frame in iio.imiter("imageio:newtonscradle.gif"):
            file.write_frame(frame)

meta = iio.immeta("test.mp4", plugin="pyav")
assert meta["comment"] == "This video has a rotation flag."
```