### PR TITLE
BUG: seeking to last frame caused EoF in pyav

### DIFF
--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -390,3 +390,8 @@ def test_uri_reading(test_images):
     actual = iio.imread(uri, plugin="pyav", index=250)
 
     np.allclose(actual, expected)
+
+
+def test_seek_last(test_images):
+    frame = iio.imread(test_images / "cockatoo.mp4", plugin="pyav", index=279)
+    assert frame.shape == (720, 1280, 3)


### PR DESCRIPTION
I noticed a bug in pyav that would cause a EoF exception when you try to read only the last frame of the image, e.g. something like

```python
import imageio.v3 as iio

props = iio.improps("imageio:cockatoo.mp4", plugin="pyav")
frame = iio.imread("imageio:cockatoo.mp4", index=props.shape[0]-1, plugin="pyav")
```

This was caused be me getting the decoder after seeking via `container.decode` instead of reusing the decoder I used for seeking. I thought the object was shared, but apparently it is not ... this PR fixes that.