### PR TITLE
Better legacy batch detection

### DIFF
--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -35,6 +35,8 @@ class FileExtension:
     external_link : str
         A link to further information about the format. Typically, the format's
         specification.
+    volume_support : str
+        If True, the format/extension supports volumetric image data.
 
     Examples
     --------
@@ -48,7 +50,14 @@ class FileExtension:
     """
 
     def __init__(
-        self, *, extension, priority, name=None, description=None, external_link=None
+        self,
+        *,
+        extension,
+        priority,
+        name=None,
+        description=None,
+        external_link=None,
+        volume_support=False
     ):
         self.extension = extension
         self.priority = priority
@@ -56,6 +65,7 @@ class FileExtension:
         self.description = description
         self.external_link = external_link
         self.default_priority = priority.copy()
+        self.volume_support = volume_support
 
     def reset(self):
         self.priority = self.default_priority.copy()
@@ -608,6 +618,7 @@ extension_list = [
         name="Numpy Array",
         extension=".npz",
         priority=["NPZ"],
+        volume_support=True,
     ),
     FileExtension(
         extension=".nrrd",
@@ -841,6 +852,7 @@ extension_list = [
             "pyav",
             "opencv",
         ],
+        volume_support=True,
     ),
     FileExtension(
         name="Tagged Image File Format",
@@ -856,6 +868,7 @@ extension_list = [
             "pyav",
             "opencv",
         ],
+        volume_support=True,
     ),
     FileExtension(
         extension=".vda",

--- a/imageio/config/extensions.pyi
+++ b/imageio/config/extensions.pyi
@@ -6,6 +6,7 @@ class FileExtension:
     name: Optional[str] = None
     description: Optional[str] = None
     external_link: Optional[str] = None
+    volume_support: bool
 
     def __init__(
         self,

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -182,10 +182,8 @@ class LegacyPlugin(PluginV3):
             particular format.
         """
 
-        if isinstance(ndimage, (list, tuple)):
+        if is_batch or isinstance(ndimage, (list, tuple)):
             pass  # ndimage is list of images
-        elif is_batch is True:
-            pass
         elif is_batch is False:
             ndimage = [ndimage]
         else:
@@ -211,9 +209,6 @@ class LegacyPlugin(PluginV3):
 
             if batch_dims == 0:
                 ndimage = [ndimage]
-
-        if len(ndimage) == 0:
-            raise RuntimeError("Can't write zero images.")
 
         with self.legacy_get_writer(**kwargs) as writer:
             for image in ndimage:

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -183,48 +183,54 @@ class LegacyPlugin(PluginV3):
         """
 
         if isinstance(ndimage, (list, tuple)):
-            is_batch = True
-            ndimage = np.stack(ndimage, axis=0)
+            pass  # ndimage is list of images
+        elif is_batch is True:
+            pass
+        elif is_batch is False:
+            ndimage = [ndimage]
         else:
+            # Write the largest possible block by guessing the meaning of each
+            # dimension from the shape/ndim and then checking if any batch
+            # dimensions are left.
             ndimage = np.asarray(ndimage)
+            batch_dims = ndimage.ndim
 
-        batch_dims = ndimage.ndim
+            # two spatial dimensions
+            batch_dims = max(batch_dims - 2, 0)
 
-        if ndimage.ndim < 2:
-            raise ValueError("The image must have at least two spatial dimensions.")
+            # packed (channel-last) image
+            if ndimage.ndim >= 3 and ndimage.shape[-1] < 5:
+                batch_dims = max(batch_dims - 1, 0)
+
+            # format supports volumetric images
+            ext_infos = known_extensions.get(self._request.extension, list())
+            for ext_info in ext_infos:
+                if self._format.name in ext_info.priority and ext_info.volume_support:
+                    batch_dims = max(batch_dims - 1, 0)
+                    break
+
+            if batch_dims == 0:
+                ndimage = [ndimage]
 
         if len(ndimage) == 0:
             raise RuntimeError("Can't write zero images.")
 
-        if not np.issubdtype(ndimage[0].dtype, np.number) and not np.issubdtype(
-            ndimage[0].dtype, bool
-        ):
-            raise ValueError(f"ndimage is not numeric, but `{ndimage[0].dtype}`.")
-
-        batch_dims -= 2  # two spatial dimensions
-
-        if ndimage.ndim >= 3 and ndimage.shape[-1] < 5:
-            # image is packed (channel-last)
-            batch_dims = max(batch_dims - 1, 0)
-
-        volume_support = False
-        ext_infos = known_extensions.get(self._request.extension, list())
-        for ext_info in ext_infos:
-            if self._format.name in ext_info.priority:
-                volume_support = ext_info.volume_support
-                break
-        if is_batch in [None, False] and volume_support:
-            # image is a volume
-            batch_dims = max(batch_dims - 1, 0)
-
-        if is_batch is None:
-            is_batch = batch_dims > 0
-
-        if not is_batch:
-            ndimage = np.asarray(ndimage)[None, ...]
-
         with self.legacy_get_writer(**kwargs) as writer:
             for image in ndimage:
+                image = np.asarray(image)
+
+                if image.ndim < 2:
+                    raise ValueError(
+                        "The image must have at least two spatial dimensions."
+                    )
+
+                if not np.issubdtype(image.dtype, np.number) and not np.issubdtype(
+                    image.dtype, bool
+                ):
+                    raise ValueError(
+                        f"All images have to be numeric, and not `{image.dtype}`."
+                    )
+
                 writer.append_data(image)
 
         return writer.request.get_result()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -969,11 +969,6 @@ def test_memory_size(test_images):
     assert len(im) == 36
 
 
-def test_legacy_write_empty(tmp_path):
-    with pytest.raises(RuntimeError):
-        iio.v3.imwrite(tmp_path / "foo.tiff", np.ones((0, 10, 10)))
-
-
 def test_imopen_explicit_plugin_input(clear_plugins, tmp_path):
     with pytest.raises(OSError):
         iio.v3.imopen(tmp_path / "foo.tiff", "w", legacy_mode=False)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -654,3 +654,13 @@ def test_read_stream(test_images):
     expected = iio3.imread("imageio:cockatoo.mp4", index=5)
 
     assert np.allclose(result, expected)
+
+
+def test_write_stream(test_images, tmp_path):
+    # regression test
+    expected = iio3.imread(test_images / "newtonscradle.gif")
+    iio3.imwrite(tmp_path / "test.mp4", expected, plugin="FFMPEG")
+
+    # Note: No assertions here, because video compression is lossy and
+    # imageio-python changes the shape of the array. Our PyAV plugin (which
+    # should be preferred) does not have the latter limitaiton :)

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -611,7 +611,7 @@ def test_ico(setup_library, tmp_path):
 
 # Skip on Windows xref: https://github.com/imageio/imageio/issues/21
 @pytest.mark.skipif(
-    sys.platform.startswith("win"),
+    platform.system() == "Windows",
     reason="Windows has a known issue with multi-icon files",
 )
 def test_multi_icon_ico(setup_library, tmp_path):

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -245,3 +245,13 @@ def test_bool_writing():
     actual = iio.imread(img_bytes)
 
     assert np.allclose(actual, expected)
+
+
+def test_roundtrip(tmp_path):
+    # regression test for
+    # https://github.com/imageio/imageio/issues/854
+
+    iio3.imwrite(tmp_path / "test.tiff", np.ones((10, 64, 64), "u4"))
+    actual = iio3.imread(tmp_path / "test.tiff")
+
+    assert actual.shape == (10, 64, 64)


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/854

This PR performs another refactor of `LegacyPlugin.write`. It adds a sophisticated way of auto-detecting if a ndimage is a batch by identifying and counting non-batch dimensions. In particular, it adds a `volume_support` flag to `config.FileExtension` to allow indicating if a format supports volumetric data. Using this flag, we can more clearly decide if a ndimage that should be written to a given format is a volume or a batch of images.
