### PR TITLE
BUG: revert to asanyarray

### DIFF
--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -190,7 +190,7 @@ class LegacyPlugin(PluginV3):
             # Write the largest possible block by guessing the meaning of each
             # dimension from the shape/ndim and then checking if any batch
             # dimensions are left.
-            ndimage = np.asarray(ndimage)
+            ndimage = np.asanyarray(ndimage)
             batch_dims = ndimage.ndim
 
             # two spatial dimensions
@@ -212,7 +212,7 @@ class LegacyPlugin(PluginV3):
 
         with self.legacy_get_writer(**kwargs) as writer:
             for image in ndimage:
-                image = np.asarray(image)
+                image = np.asanyarray(image)
 
                 if image.ndim < 2:
                     raise ValueError(


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/860

This PR changes the `np.asarray` calls to `np.asanyarray` calls to avoid a regression on V2 behavior that allows passing in ndarray subtypes to write metadata with `v2.imwrite`.