### PR TITLE
BUG: allow v3.imread to read dicom

### DIFF
--- a/imageio/plugins/_dicom.py
+++ b/imageio/plugins/_dicom.py
@@ -798,9 +798,7 @@ def process_directory(request, progressIndicator, readPixelData=False):
     elif os.path.isfile(request.filename):
         path = os.path.dirname(request.filename)
     else:  # pragma: no cover - tested earlier
-        raise ValueError(
-            "Dicom plugin needs a valid filename to examine " "the directory"
-        )
+        raise ValueError("Dicom plugin needs a valid filename to examine the directory")
 
     # Check files
     files = []

--- a/imageio/plugins/dicom.py
+++ b/imageio/plugins/dicom.py
@@ -248,6 +248,17 @@ class DicomFormat(Format):
             else:
                 raise RuntimeError("DICOM plugin should know what to expect.")
 
+        def _get_slice_data(self, index):
+            nslices = self._data.shape[0] if (self._data.ndim == 3) else 1
+
+            # Allow index >1 only if this file contains >1
+            if nslices > 1:
+                return self._data[index], self._info
+            elif index == 0:
+                return self._data, self._info
+            else:
+                raise IndexError("Dicom file contains only one slice.")
+
         def _get_data(self, index):
             if self._data is None:
                 dcm = self.series[0][0]
@@ -257,13 +268,7 @@ class DicomFormat(Format):
             nslices = self._data.shape[0] if (self._data.ndim == 3) else 1
 
             if self.request.mode[1] == "i":
-                # Allow index >1 only if this file contains >1
-                if nslices > 1:
-                    return self._data[index], self._info
-                elif index == 0:
-                    return self._data, self._info
-                else:
-                    raise IndexError("Dicom file contains only one slice.")
+                return self._get_slice_data(index)
             elif self.request.mode[1] == "I":
                 # Return slice from volume, or return item from series
                 if index == 0 and nslices > 1:
@@ -294,12 +299,7 @@ class DicomFormat(Format):
                 )
             else:
                 # mode is `?` and there is only one series. Each slice is an ndimage.
-                if nslices > 1:
-                    return self._data[index], self._info
-                elif index == 0:
-                    return self._data, self._info
-                else:
-                    raise IndexError("Dicom file contains only one slice.")
+                return self._get_slice_data(index)
 
         def _get_meta_data(self, index):
             if self._data is None:

--- a/imageio/plugins/dicom.py
+++ b/imageio/plugins/dicom.py
@@ -282,8 +282,24 @@ class DicomFormat(Format):
                         self.series[index].get_numpy_array(),
                         self.series[index].info,
                     )
-            else:  # pragma: no cover
-                raise ValueError("DICOM plugin should know what to expect.")
+            # mode is `?` (typically because we are using V3). If there is a
+            # series (multiple files), index referrs to the element of the
+            # series and we read volumes. If there is no series, index
+            # referrs to the slice in the volume we read "flat" images.
+            elif len(self.series) > 1:
+                # mode is `?` and there are multiple series. Each series is a ndimage.
+                return (
+                    self.series[index].get_numpy_array(),
+                    self.series[index].info,
+                )
+            else:
+                # mode is `?` and there is only one series. Each slice is an ndimage.
+                if nslices > 1:
+                    return self._data[index], self._info
+                elif index == 0:
+                    return self._data, self._info
+                else:
+                    raise IndexError("Dicom file contains only one slice.")
 
         def _get_meta_data(self, index):
             if self._data is None:

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import imageio.v2 as iio
+import imageio.v3 as iio3
 from imageio import core
 import imageio.plugins.dicom
 from conftest import deprecated_test
@@ -187,3 +188,12 @@ def test_different_read_modes_with_readers(examples):
         R = iio.read(fname, "DICOM", "?")
         with pytest.raises(RuntimeError):
             R.get_length()
+
+
+def test_v3_reading(test_images):
+    # this is a regression test for
+    # https://github.com/imageio/imageio/issues/862
+    expected = iio.imread(test_images / "dicom_file01.dcm")
+    actual = iio3.imread(test_images / "dicom_file01.dcm")
+
+    assert np.allclose(actual, expected)


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/862

This PR adds logic to handle image mode `?` for DICOM images. It does so by checking how many series the request has. If there is more than one it will treat a series as ndimage and if there is only one it will treat the slices/images inside the series as ndimages. This allows the v3 API (which defaults to image mode `?` for legacy plugins) to read dicom.