### PR TITLE
Raise error if fps is specified

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -280,6 +280,11 @@ class PillowPlugin(PluginV3):
         image.
 
         """
+        if "fps" in kwargs:
+            raise NotImplementedError(
+                f"The keyword, `fps`, is no longer supported; specify `duration`"
+                f"in milliseconds instead, e.g. `fps=60` == `duration=1/60/1000`"
+            )
 
         extension = self.request.extension or self.request.format_hint
 

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -281,7 +281,7 @@ class PillowPlugin(PluginV3):
 
         """
         if "fps" in kwargs:
-            raise NotImplementedError(
+            raise TypeError(
                 "The keyword `fps` is no longer supported. Use `duration`"
                 "(in ms) instead, e.g. `fps=60` == `duration=1/60/1000`."
             )

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -282,8 +282,8 @@ class PillowPlugin(PluginV3):
         """
         if "fps" in kwargs:
             raise NotImplementedError(
-                "The keyword, `fps`, is no longer supported; specify `duration`"
-                "in milliseconds instead, e.g. `fps=60` == `duration=1/60/1000`"
+                "The keyword `fps` is no longer supported. Use `duration`"
+                "(in ms) instead, e.g. `fps=60` == `duration=1/60/1000`."
             )
 
         extension = self.request.extension or self.request.format_hint

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -282,8 +282,8 @@ class PillowPlugin(PluginV3):
         """
         if "fps" in kwargs:
             raise NotImplementedError(
-                f"The keyword, `fps`, is no longer supported; specify `duration`"
-                f"in milliseconds instead, e.g. `fps=60` == `duration=1/60/1000`"
+                "The keyword, `fps`, is no longer supported; specify `duration`"
+                "in milliseconds instead, e.g. `fps=60` == `duration=1/60/1000`"
             )
 
         extension = self.request.extension or self.request.format_hint

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -255,6 +255,23 @@ def test_gif_gray(test_images, tmp_path):
     )
 
 
+def test_gif_fps_error(test_images, tmp_path):
+    im = iio.v3.imread(
+        test_images / "newtonscradle.gif",
+        plugin="pillow",
+        mode="L",
+    )
+
+    with pytest.raises(NotImplementedError, match="The keyword `fps`"):
+        iio.v3.imwrite(
+            tmp_path / "test.gif",
+            im[..., 0],
+            plugin="pillow",
+            fps=60,
+            mode="L",
+        )
+
+
 def test_gif_irregular_duration(test_images, tmp_path):
     im = iio.v3.imread(
         test_images / "newtonscradle.gif",

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -262,7 +262,7 @@ def test_gif_fps_error(test_images, tmp_path):
         mode="L",
     )
 
-    with pytest.raises(TypeError, match="The keyword, `fps`"):
+    with pytest.raises(TypeError):
         iio.v3.imwrite(
             tmp_path / "test.gif",
             im[..., 0],

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -262,7 +262,7 @@ def test_gif_fps_error(test_images, tmp_path):
         mode="L",
     )
 
-    with pytest.raises(NotImplementedError, match="The keyword `fps`"):
+    with pytest.raises(NotImplementedError, match="The keyword, `fps`"):
         iio.v3.imwrite(
             tmp_path / "test.gif",
             im[..., 0],
@@ -296,23 +296,6 @@ def test_gif_palletsize(test_images, tmp_path):
 
     iio.v3.imwrite(tmp_path / "test.gif", im, plugin="pillow", palletsize=100)
     # TODO: assert pallet size is 128
-
-
-def test_gif_loop_and_fps(test_images, tmp_path):
-    # Note: I think this test tests pillow kwargs, not imageio functionality
-    # maybe we should drop it?
-
-    im = iio.v3.imread(
-        test_images / "newtonscradle.gif",
-        plugin="pillow",
-        mode="RGBA",
-    )
-
-    with iio.v3.imopen(tmp_path / "test.gif", "w", plugin="pillow") as file:
-        for frame in im:
-            file.write(frame, palettesize=100, fps=20, loop=2)
-
-    # This test had no assert; how to assert fps and loop count?
 
 
 def test_gif_indexed_read(test_images):

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -298,6 +298,23 @@ def test_gif_palletsize(test_images, tmp_path):
     # TODO: assert pallet size is 128
 
 
+def test_gif_loop_and_fps(test_images, tmp_path):
+    # Note: I think this test tests pillow kwargs, not imageio functionality
+    # maybe we should drop it?
+
+    im = iio.v3.imread(
+        test_images / "newtonscradle.gif",
+        plugin="pillow",
+        mode="RGBA",
+    )
+
+    with iio.v3.imopen(tmp_path / "test.gif", "w", plugin="pillow") as file:
+        for frame in im:
+            file.write(frame, palettesize=100, duration=0.00005, loop=2)
+
+    # This test had no assert; how to assert fps and loop count?
+
+
 def test_gif_indexed_read(test_images):
     idx = 0
     numpy_im = np.load(test_images / "newtonscradle_rgb.npy")[idx, ...]

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -298,7 +298,7 @@ def test_gif_palletsize(test_images, tmp_path):
     # TODO: assert pallet size is 128
 
 
-def test_gif_loop_and_fps(test_images, tmp_path):
+def test_gif_loop_and_duration(test_images, tmp_path):
     # Note: I think this test tests pillow kwargs, not imageio functionality
     # maybe we should drop it?
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -262,7 +262,7 @@ def test_gif_fps_error(test_images, tmp_path):
         mode="L",
     )
 
-    with pytest.raises(NotImplementedError, match="The keyword, `fps`"):
+    with pytest.raises(TypeError, match="The keyword, `fps`"):
         iio.v3.imwrite(
             tmp_path / "test.gif",
             im[..., 0],


### PR DESCRIPTION
Closes #870 

Since imageio v2 supported `fps`, imageio v3 should inform the user that it's no longer supported rather than quietly ignoring.