### PR TITLE
BUG: raise ImportError when iio-ffmpeg is missing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,6 @@ from pathlib import Path
 import imageio.plugins.bsdf
 import imageio.plugins.dicom
 import imageio.plugins.feisem
-import imageio.plugins.ffmpeg
 import imageio.plugins.fits
 import imageio.plugins.freeimage
 import imageio.plugins.gdal
@@ -63,7 +62,7 @@ SphinxDocString._str_member_list = lambda self, name: []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-autodoc_mock_imports = ["av", "cv2", "imageio-ffmpeg"]
+autodoc_mock_imports = ["av", "cv2", "imageio_ffmpeg"]
 
 # The suffix of source filenames.
 source_suffix = ".rst"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,6 @@ from pathlib import Path
 
 
 # import/load the plugins so that they can be documented
-# this may require mocking imports in the future
 import imageio.plugins.bsdf
 import imageio.plugins.dicom
 import imageio.plugins.feisem
@@ -64,7 +63,7 @@ SphinxDocString._str_member_list = lambda self, name: []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-autodoc_mock_imports = ["av", "cv2"]
+autodoc_mock_imports = ["av", "cv2", "imageio-ffmpeg"]
 
 # The suffix of source filenames.
 source_suffix = ".rst"

--- a/docs/imageio_ext.py
+++ b/docs/imageio_ext.py
@@ -7,47 +7,7 @@ import imageio
 
 
 def setup(app):
-    init()
     app.connect("source-read", rstjinja)
-
-
-def init():
-
-    print("Special preparations for imageio docs:")
-
-    for func in [
-        prepare_reader_and_witer,
-    ]:
-        print("  " + func.__doc__.strip())
-        func()
-
-
-def prepare_reader_and_witer():
-    """Prepare Format.Reader and Format.Writer for doc generation."""
-
-    # Create Reader and Writer subclasses that are going to be placed
-    # in the format module so that autoclass can find them. They need
-    # to be new classes, otherwise sphinx considers them aliases.
-    # We create the class using type() so that we can copy the __doc__.
-    Reader = type(
-        "Reader",
-        (imageio.core.format.Format.Reader,),
-        {"__doc__": imageio.core.format.Format.Reader.__doc__},
-    )
-    Writer = type(
-        "Writer",
-        (imageio.core.format.Format.Writer,),
-        {"__doc__": imageio.core.format.Format.Writer.__doc__},
-    )
-
-    imageio.core.format.Reader = Reader
-    imageio.core.format.Writer = Writer
-
-    # We set the docs of the original classes, and remove the original
-    # classes so that Reader and Writer do not show up in the docs of
-    # the Format class.
-    imageio.core.format.Format.Reader = None  # .__doc__ = ''
-    imageio.core.format.Format.Writer = None  # .__doc__ = ''
 
 
 def rstjinja(app, docname, source):

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -69,11 +69,11 @@ that best suits that file-format.
 
 ----
 
-.. autoclass:: imageio.core.format.Reader
+.. autoclass:: imageio.core::Format.Reader
     :inherited-members:
     :members: 
     
-.. autoclass:: imageio.core.format.Writer
+.. autoclass:: imageio.core::Format.Writer
     :inherited-members:
     :members: 
 

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -133,6 +133,7 @@ import logging
 import platform
 import threading
 import subprocess as sp
+import imageio_ffmpeg
 
 import numpy as np
 
@@ -161,26 +162,8 @@ def download(directory=None, force_download=False):  # pragma: no cover
 # For backwards compatibility - we dont use this ourselves
 def get_exe():  # pragma: no cover
     """Wrapper for imageio_ffmpeg.get_ffmpeg_exe()"""
-    import imageio_ffmpeg
 
     return imageio_ffmpeg.get_ffmpeg_exe()
-
-
-_ffmpeg_api = None
-
-
-def _get_ffmpeg_api():
-    global _ffmpeg_api
-    if _ffmpeg_api is None:
-        try:
-            import imageio_ffmpeg
-        except ImportError:
-            raise ImportError(
-                "To use the imageio ffmpeg plugin you need to "
-                "'pip install imageio-ffmpeg'"
-            )
-        _ffmpeg_api = imageio_ffmpeg
-    return _ffmpeg_api
 
 
 class FfmpegFormat(Format):
@@ -221,7 +204,7 @@ class FfmpegFormat(Format):
 
             elif sys.platform.startswith("win"):
                 # Ask ffmpeg for list of dshow device names
-                ffmpeg_api = _get_ffmpeg_api()
+                ffmpeg_api = imageio_ffmpeg
                 cmd = [
                     ffmpeg_api.get_ffmpeg_exe(),
                     "-list_devices",
@@ -275,7 +258,7 @@ class FfmpegFormat(Format):
             fps=None,
         ):
             # Get generator functions
-            self._ffmpeg_api = _get_ffmpeg_api()
+            self._ffmpeg_api = imageio_ffmpeg
             # Process input args
             self._arg_loop = bool(loop)
             if size is None:
@@ -561,7 +544,7 @@ class FfmpegFormat(Format):
             quality=5,
             macro_block_size=16,
         ):
-            self._ffmpeg_api = _get_ffmpeg_api()
+            self._ffmpeg_api = imageio_ffmpeg
             self._filename = self.request.get_local_filename()
             self._pix_fmt = None
             self._depth = None


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/856

This PR slightly refactors the imageio-ffmpeg plugin to raise a `ImportError` when its backend is not installed. This makes our codebase cleaner while also fixing a bug in our test suite that required imageio-ffmpeg to be installed when testing our pyav plugin.