### PR TITLE
BUG: Support `compression` and `compressionargs` in tifffile plugin

### DIFF
--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -164,7 +164,7 @@ class LegacyPlugin(PluginV3):
         self._request._kwargs = kwargs
         return self._format.get_writer(self._request)
 
-    def write(self, ndimage, *, is_batch=None, **kwargs):
+    def write(self, ndimage, *, is_batch=None, metadata=None, **kwargs):
         """
         Write an ndimage to the URI specified in path.
 
@@ -248,7 +248,7 @@ class LegacyPlugin(PluginV3):
                         f"All images have to be numeric, and not `{image.dtype}`."
                     )
 
-                writer.append_data(image)
+                writer.append_data(image, metadata)
 
         return writer.request.get_result()
 

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -180,6 +180,8 @@ class LegacyPlugin(PluginV3):
             If True, treat the supplied ndimage as a batch of images. If False,
             treat the supplied ndimage as a single image. If None, try to
             determine ``is_batch`` from the ndimage's shape and ndim.
+        metadata : dict
+            The metadata passed to write alongside the image.
         kwargs : ...
             Further keyword arguments are passed to the writer. See
             :func:`.help` to see what arguments are available for a

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -123,6 +123,17 @@ description : str
 compress : int
     Values from 0 to 9 controlling the level of zlib (deflate) compression.
     If 0, data are written uncompressed (default).
+compression : str, (int, int)
+    Compression scheme used while writing the image. If omitted (default) the
+    image is not uncompressed. Compression cannot be used to write contiguous
+    series. Compressors may require certain data shapes, types or value ranges.
+    For example, JPEG compression requires grayscale or RGB(A), uint8 or 12-bit
+    uint16. JPEG compression is experimental. JPEG markers and TIFF tags may not
+    match. Only a limited set of compression schemes are implemented. 'ZLIB' is
+    short for ADOBE_DEFLATE. The value is written to the Compression tag.
+compressionargs:
+    Extra arguments passed to compression codec, e.g., compression level. Refer
+    to the Imagecodecs implementation for supported arguments.
 predictor : bool
     If True, horizontal differencing is applied before compression.
     Note that using an int literal 1 actually means no prediction scheme

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -536,8 +536,12 @@ class TiffFormat(Format):
                             "The use of `compress` is deprecated. Use `compression` and `compressionargs` instead.",
                             DeprecationWarning,
                         )
-                        ret["compression"] = "zlib"
-                        ret["compressionargs"] = {"level": value}
+
+                        if _tifffile.__version__ < "2022":
+                            ret["compression"] = (8, value)
+                        else:
+                            ret["compression"] = "zlib"
+                            ret["compressionargs"] = {"level": value}
                     else:
                         ret[key] = value
             return ret

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -191,6 +191,8 @@ WRITE_METADATA_KEYS = (
     "resolution",
     "description",
     "compress",
+    "compression",
+    "compressionargs",
     "predictor",
     "volume",
     "writeshape",
@@ -529,6 +531,13 @@ class TiffFormat(Format):
                     # 1(=NONE) translation to False expected by TiffWriter.save
                     if key == "predictor" and not isinstance(value, bool):
                         ret[key] = value > 1
+                    elif key == "compress" and value != 0:
+                        warnings.warn(
+                            "The use of `compress` is deprecated. Use `compression` and `compressionargs` instead.",
+                            DeprecationWarning,
+                        )
+                        ret["compression"] = "zlib"
+                        ret["compressionargs"] = {"level": value}
                     else:
                         ret[key] = value
             return ret

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ plugins = {
     "spe": [],
     "swf": [],
     "tifffile": ["tifffile"],
-    "pyav": ["av"],
+    "pyav": ["av!=10.0.0"],
 }
 
 cpython_only_plugins = {

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -117,6 +117,7 @@ def test_video_format_to_dtype():
         "d3d11",
         "d3d11va_vld",
         "videotoolbox_vld",
+        "vaapi",
         "vaapi_idct",
         "opencl",
         "cuda",

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -5,6 +5,7 @@ import datetime
 import numpy as np
 import pytest
 import io
+import warnings
 
 import imageio.v2 as iio
 import imageio.v3 as iio3
@@ -312,6 +313,16 @@ def test_multiple_ndimages(tmp_path):
 
 def test_compression(tmp_path):
     img = np.ones((128, 128))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        iio.imwrite(tmp_path / "test.tiff", img, metadata={"compress": 5})
+
+    with tifffile.TiffFile(tmp_path / "test.tiff") as file:
+        # this should be tifffile.COMPRESSION.ADOBE_DEFLATE
+        # but that isn't supported by tifffile on python 3.7
+        assert file.pages[0].compression == 8
+        print("")
 
     iio.imwrite(tmp_path / "test.tiff", img, metadata={"compression": "zlib"})
     with tifffile.TiffFile(tmp_path / "test.tiff") as file:

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -315,7 +315,9 @@ def test_compression(tmp_path):
 
     iio.imwrite(tmp_path / "test.tiff", img, metadata={"compression": "zlib"})
     with tifffile.TiffFile(tmp_path / "test.tiff") as file:
-        assert file.pages[0].compression == tifffile.COMPRESSION.ADOBE_DEFLATE
+        # this should be tifffile.COMPRESSION.ADOBE_DEFLATE
+        # but that isn't supported by tifffile on python 3.7
+        assert file.pages[0].compression == 8
         print("")
 
     iio.imwrite(
@@ -323,4 +325,6 @@ def test_compression(tmp_path):
         img,
     )
     with tifffile.TiffFile(tmp_path / "test.tiff") as file:
-        assert file.pages[0].compression == tifffile.COMPRESSION.NONE
+        # this should be tifffile.COMPRESSION.NONE
+        # but that isn't supported by tifffile on python 3.7
+        assert file.pages[0].compression == 1

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -308,3 +308,19 @@ def test_multiple_ndimages(tmp_path):
     shapes = [(4, 255, 255, 3), (255, 255, 3), (120, 73, 3)]
     for image, shape in zip(iio3.imiter(tmp_path / "nightmare.tiff"), shapes):
         assert image.shape == shape
+
+
+def test_compression(tmp_path):
+    img = np.ones((128, 128))
+
+    iio.imwrite(tmp_path / "test.tiff", img, metadata={"compression": "zlib"})
+    with tifffile.TiffFile(tmp_path / "test.tiff") as file:
+        assert file.pages[0].compression == tifffile.COMPRESSION.ADOBE_DEFLATE
+        print("")
+
+    iio.imwrite(
+        tmp_path / "test.tiff",
+        img,
+    )
+    with tifffile.TiffFile(tmp_path / "test.tiff") as file:
+        assert file.pages[0].compression == tifffile.COMPRESSION.NONE


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/893

This PR adds a `metadata` kwarg to the LegacyPlugin, which allows passing metadata to a format's `append_data` function. It also adds support for the (not so) new kwargs `compression` and `compressionargs` which tifffile has introduced to manage compression. Among other things, these changes make it possible to use TIFF compression in the v3 API.