### PR TITLE
BUG: ffmpeg supports .h264 extension

### DIFF
--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -1584,7 +1584,7 @@ extension_list = [
     FileExtension(
         name="raw H.264 video",
         extension=".h264",
-        priority=["pyav"],
+        priority=["pyav", "ffmpeg"],
     ),
     FileExtension(
         name="raw H.264 video",

--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -1584,7 +1584,7 @@ extension_list = [
     FileExtension(
         name="raw H.264 video",
         extension=".h264",
-        priority=["pyav", "ffmpeg"],
+        priority=["pyav", "FFMPEG"],
     ),
     FileExtension(
         name="raw H.264 video",

--- a/imageio/config/plugins.py
+++ b/imageio/config/plugins.py
@@ -224,7 +224,7 @@ known_plugins["FFMPEG"] = PluginConfig(
     install_name="ffmpeg",
     legacy_args={
         "description": "Many video formats and cameras (via ffmpeg)",
-        "extensions": ".mov .avi .mpg .mpeg .mp4 .mkv .webm .wmv",
+        "extensions": ".mov .avi .mpg .mpeg .mp4 .mkv .webm .wmv .h264",
         "modes": "I",
     },
 )

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -665,9 +665,9 @@ def test_write_stream(test_images, tmp_path):
 
 
 def test_h264_reading(test_images, tmp_path):
-    # regression test for 
+    # regression test for
     # https://github.com/imageio/imageio/issues/900
     frames = iio3.imread(test_images / "cockatoo.mp4")
     iio3.imwrite(tmp_path / "cockatoo.h264", frames, plugin="FFMPEG")
 
-    imageio.get_reader(tmp_path / "cockatoo.h264", 'ffmpeg')
+    imageio.get_reader(tmp_path / "cockatoo.h264", "ffmpeg")

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -662,3 +662,12 @@ def test_write_stream(test_images, tmp_path):
     # Note: No assertions here, because video compression is lossy and
     # imageio-python changes the shape of the array. Our PyAV plugin (which
     # should be preferred) does not have the latter limitaiton :)
+
+
+def test_h264_reading(test_images, tmp_path):
+    # regression test for 
+    # https://github.com/imageio/imageio/issues/900
+    frames = iio3.imread(test_images / "cockatoo.mp4")
+    iio3.imwrite(tmp_path / "cockatoo.h264", frames, plugin="FFMPEG")
+
+    imageio.get_reader(tmp_path / "cockatoo.h264", 'ffmpeg')


### PR DESCRIPTION
Closes: #900

This PR adds the .h264 extension to the list of supported extensions for FFMPEG.