### PR TITLE
DOC: document deprecated format_hint

### DIFF
--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -60,12 +60,7 @@ def imopen(
         extension. This affects the order in which backends are considered, and
         when writing this may also influence the format used when encoding.
     format_hint : str
-        A format hint to help optimize plugin selection given as the format's
-        extension, e.g. ".png". This can speed up the selection process for
-        ImageResources that don't have an explicit extension, e.g. streams, or
-        for ImageResources where the extension does not match the resource's
-        content. If the ImageResource lacks an explicit extension, it will be
-        set to this format.
+        Deprecated. Use `extension` instead.
     legacy_mode : bool
         If true (default) use the v2 behavior when searching for a suitable
         plugin. This will ignore v3 plugins and will check ``plugin``

--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -265,8 +265,9 @@ class Request(object):
 
         if format_hint is not None:
             warnings.warn(
-                "The usage of `format_hint` is deprecated and will be removed in ImageIO v3."
-                " Use `extension` instead."
+                "The usage of `format_hint` is deprecated and will be removed "
+                "in ImageIO v3. Use `extension` instead.",
+                DeprecationWarning,
             )
 
         if format_hint is not None and format_hint[0] != ".":

--- a/imageio/v3.py
+++ b/imageio/v3.py
@@ -29,11 +29,7 @@ def imread(uri, *, index=None, plugin=None, extension=None, format_hint=None, **
         If not None, treat the provided ImageResource as if it had the given
         extension. This affects the order in which backends are considered.
     format_hint : str
-        A format hint to help optimize plugin selection given as the format's
-        extension, e.g. ".png". This can speed up the selection process for
-        ImageResources that don't have an explicit extension, e.g. streams, or
-        for ImageResources where the extension does not match the resource's
-        content.
+        Deprecated. Use `extension` instead.
     **kwargs :
         Additional keyword arguments will be passed to the plugin's read call.
 
@@ -79,12 +75,7 @@ def imiter(uri, *, plugin=None, extension=None, format_hint=None, **kwargs):
         If not None, treat the provided ImageResource as if it had the given
         extension. This affects the order in which backends are considered.
     format_hint : str
-        A format hint to help optimize plugin selection given as the format's
-        extension, e.g. ".png". This can speed up the selection process for
-        ImageResources that don't have an explicit extension, e.g. streams, or
-        for ImageResources where the extension does not match the resource's
-        content. If the ImageResource lacks an explicit extension, it will be
-        set to this format.
+        Deprecated. Use `extension` instead.
     **kwargs :
         Additional keyword arguments will be passed to the plugin's ``iter``
         call.
@@ -132,12 +123,7 @@ def imwrite(uri, image, *, plugin=None, extension=None, format_hint=None, **kwar
         extension. This affects the order in which backends are considered, and
         may also influence the format used when encoding.
     format_hint : str
-        A format hint to help optimize plugin selection given as the format's
-        extension, e.g. ".png". This can speed up the selection process for
-        ImageResources that don't have an explicit extension, e.g. streams, or
-        for ImageResources where the extension does not match the resource's
-        content. If the ImageResource lacks an explicit extension, it will be
-        set to this format.
+        Deprecated. Use `extension` instead.
     **kwargs :
         Additional keyword arguments will be passed to the plugin's ``write``
         call.


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/879

This PR changes the docstring of `format_hint` to say that it is deprecated in favor of `extension`. There has been a programmatic deprecation notice for a while, but we have never documented it ... until now :)