### PR TITLE
DOC: add code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,7 @@ We welcome contributions of any kind. Here are some suggestions on how you are a
 - report/fix any bugs you encounter while using ImageIO
 
 To assist you in getting started with contributing code, take a look at the [development section](https://imageio.readthedocs.io/en/stable/development/index.html) of the docs. You will find instructions on setting up the dev environment as well as examples on how to contribute code.
+
+<h2>Code of Conduct</h2>
+
+ImageIO is a community-driven open-source project developed by a diverse group of contributors. We want to create an open, inclusive, and positive community. Please read the Code of Conduct for guidance on how to interact with others in a way that makes this community thrive.

--- a/docs/code_of_conduct.rst
+++ b/docs/code_of_conduct.rst
@@ -1,0 +1,116 @@
+Code of Conduct
+===============
+
+TL:DR
+------
+
+- Be professional, kind, and don't insult others.
+- Strive to create an environment of learning and healthy discussion. 
+- Don't bully people.
+
+Introduction
+------------
+
+This Code of Conduct applies to all spaces managed by the ImageIO project,
+including all public and private mailing lists, issue trackers, wikis, blogs,
+Twitter, and any other communication channel used by our community. 
+
+This Code of Conduct should be honored by everyone who participates in the
+ImageIO community formally or informally, or claims any affiliation with the
+project, in any project-related activities and especially when representing the
+project, in any role.
+
+This code is not exhaustive or complete. It serves to distil our common
+understanding of a collaborative, shared environment and goals. Please try to
+follow this code in spirit as much as in letter, to create a friendly and
+productive environment that enriches the surrounding community.
+
+Specific Guidelines
+-------------------
+
+We strive to:
+
+1.	Be open. We invite anyone to participate in our community. We prefer to use
+  	public methods of communication for project-related messages, unless
+  	discussing something sensitive. This applies to messages for help or
+  	project-related support, too; not only is a public support request much more
+  	likely to result in an answer to a question, but it also ensures that any
+  	inadvertent mistakes in answering are more easily detected and corrected.
+2.	Be empathetic, welcoming, friendly, and patient. We work together to resolve
+  	conflict and assume good intentions. A community where people feel
+  	uncomfortable or threatened is not a productive one.
+3.	Be collaborative. Our work will be used by other people, and in turn we will
+  	depend on the work of others. When we make something for the benefit of the
+  	project, we are willing to explain to others how it works, so that they can
+  	build on the work to make it even better. Any decision we make will affect
+  	users and colleagues, and we take those consequences seriously when making
+  	decisions.
+4.	Be inquisitive. Nobody knows everything! Asking questions early avoids many
+  	problems later, so we encourage questions, although we may direct them to
+  	the appropriate forum. We will try hard to be responsive and helpful.
+5.	Be careful in the words that we choose. We are careful and respectful in our
+  	communication, and we take responsibility for our own speech. Be kind to
+  	others. Do not insult or put down other participants. We will not accept
+  	harassment or other exclusionary behaviour, such as
+
+        - Violent threats or language directed against another person.
+        - Posting sexually explicit or violent material.
+        - Personal insults, especially those using racist or sexist terms.
+        - Unwelcome sexual attention.
+        - Excessive profanity.
+        - Repeated harassment of others. In general, if someone asks you to stop,
+          then stop.
+        - Advocating for, or encouraging, any of the above behaviour.
+
+Diversity Statement
+-------------------
+
+The ImageIO project welcomes and encourages participation by everyone. We are
+committed to being a community that everyone enjoys being part of. Although we
+may not always be able to accommodate each individual's preferences, we try our
+best to treat everyone kindly.
+
+Though we welcome people fluent in all languages, ImageIO development is
+conducted in English.
+
+Standards for behaviour in the ImageIO community are detailed in the Code of
+Conduct above. Participants in our community should uphold these standards in
+all their interactions.
+
+Reporting Guidelines
+--------------------
+
+We know that it is possible for internet communication to devolve into obvious
+and flagrant abuse. We also recognize that sometimes people may have a bad day
+or be unaware of some of the guidelines in this Code of Conduct. Please keep
+this in mind when deciding on how to respond to a breach of this Code.
+
+For clearly intentional breaches, report those to the Code of Conduct Committee
+(see below). For possibly unintentional breaches, you may reply to the person
+and point out this code of conduct (either in public or in private, whatever is
+most appropriate). If you would prefer not to do that, please feel free to
+report to the Code of Conduct Committee directly, or ask the Committee for
+advice, in confidence.
+
+Currently, the Committee consists of:
+
+- Sebastian Wallkötter
+
+If your report involves any members of the Committee, or if they feel they have
+a conflict of interest in handling it, then they will recuse themselves from
+considering your report.
+
+Incident reporting resolution & Code of Conduct enforcement
+-----------------------------------------------------------
+
+We will investigate and respond to all complaints. The ImageIO Code of Conduct
+Committee will protect the identity of the reporter and treat the content of
+complaints as confidential (unless the reporter agrees otherwise). Please see
+:doc:`Code of Conduct Reporting Guidelines <code_of_conduct_reporting>` for
+details on this procedure.
+
+Endnotes
+--------
+
+This Code of Conduct took inspiration from the NumFOCUS Code of Conduct and the
+NumPy Code of Conduct.

--- a/docs/code_of_conduct_reporting.rst
+++ b/docs/code_of_conduct_reporting.rst
@@ -1,0 +1,214 @@
+Code of Conduct Reporting Guidelines
+====================================
+
+This is the manual followed by ImageIO's Code of Conduct Committee. It's used
+when we respond to an issue to make sure we're consistent and fair.
+
+When the Committee (or a committee member) receives a report, they will proceed
+as follows, while keeping the guiding principles in mind:
+
+1.	Acknowledge report was received.
+2.	Immediately respond to a :ref:`clear and severe breach <clear_breach>`.
+3.	:ref:`Process the report <Processing>`.
+4.	Make a :ref:`transparent decision <Resolutions>` on how to resolve the
+  	report.
+5.	:ref:`Mediate<Mediation>` (if both reporter and reported agree).
+6.	Enforce the transparent decision if necessary.
+
+Guiding Principles
+------------------
+
+Enforcing the Code of Conduct impacts our community today and for the future. It
+is an action that we do not take lightly. When reviewing enforcement measures,
+the Code of Conduct Committee will keep the following values and guidelines in
+mind:
+
+- Act in a personal manner rather than impersonal. The Committee can engage
+  the parties to understand the situation while respecting the privacy and any
+  necessary confidentiality of reporters. However, sometimes it is necessary
+  to communicate with one or more individuals directly: the Committee's goal
+  is to improve the health of our community rather than only produce a formal
+  decision.
+- Emphasize empathy for individuals rather than judging behavior, avoiding
+  binary labels of “good” and “bad/evil”. Overt, clear-cut aggression and
+  harassment exist, and we will address them firmly. But many scenarios that
+  can prove challenging to resolve are those where normal disagreements
+  devolve into unhelpful or harmful behavior from multiple parties.
+  Understanding the full context and finding a path that re-engages all is
+  hard, but ultimately the most productive for our community.
+- Help increase engagement in good discussion practice: try to identify where
+  discussion may have broken down, and provide actionable information,
+  pointers, and resources that can lead to positive change on these points.
+- Be mindful of the needs of new members: provide them with explicit support
+  and consideration, with the aim of increasing participation.
+- Individuals come from different cultural backgrounds and native languages.
+  Try to identify any honest misunderstandings caused by a non-native speaker
+  and help them understand the issue and what they can change to avoid causing
+  offence. Complex discussion in a foreign language can be very intimidating,
+  and we want to grow our diversity also across nationalities and cultures.
+
+.. _clear_breach:
+
+Clear and severe breach actions
+-------------------------------
+
+We know that it is possible for internet communication to start at or devolve
+into obvious and flagrant abuse. We will deal quickly with clear and severe
+breaches like personal threats, violent, sexist or racist language.
+
+When a member of the Code of Conduct Committee becomes aware of a clear and
+severe breach, they will do the following:
+
+- Immediately disconnect the originator from all ImageIO communication
+  channels.
+- Reply to the reporter that their report has been received and that the
+  originator has been disconnected.
+- In every case, the moderator should make a reasonable effort to contact the
+  originator, and tell them specifically how their language or actions qualify
+  as a “clear and severe breach”. The moderator should also say that, if the
+  originator believes this is unfair or they want to be reconnected to
+  ImageIO, they have the right to ask for a review, as below, by the Code of
+  Conduct Committee. The moderator should copy this explanation to the Code of
+  Conduct Committee.
+- The Code of Conduct Committee will formally review and sign off on all cases
+  where this mechanism has been applied to make sure it is not being used to
+  control ordinary heated disagreement.
+
+.. _Processing:
+
+Processing of a report
+----------------------
+
+When a report is sent to the Committee, they will immediately reply to the
+reporter to confirm receipt. This reply must be sent within 72 hours, and the
+group should strive to respond much quicker than that.
+
+If a report doesn't contain enough information, the Committee will obtain all
+relevant data before acting. The Committee is empowered to act on the Steering
+Council's behalf in contacting any individuals involved to get a more complete
+account of events.
+
+The Committee will then review the incident and determine, to the best of their
+ability:
+
+- What happened.
+- Whether this event constitutes a Code of Conduct violation.
+- Who are the responsible party(ies).
+- Whether this is an ongoing situation, and there is a threat to anyone's
+  physical safety.
+
+This information will be collected in writing, and whenever possible the group's
+deliberations will be recorded and retained (i.e., chat transcripts, email
+discussions, recorded conference calls, summaries of voice conversations, etc).
+
+It is important to retain an archive of all activities of this Committee to
+ensure consistency in behavior and provide institutional memory for the project.
+To assist in this, the default channel of discussion for this Committee will be
+a private mailing list accessible to current and future members of the Committee
+as well as members of the Steering Council upon justified request. If the
+Committee finds the need to use off-list communications (e.g., phone calls for
+early/rapid response), it should in all cases summarize these back to the list
+so there's a good record of the process.
+
+The Code of Conduct Committee should aim to have a resolution agreed upon within
+two weeks. If a resolution can't be determined in that time, the Committee will
+respond to the reporter(s) with an update and projected timeline for resolution.
+
+.. _Resolutions:
+
+Resolutions
+-----------
+
+The Committee must agree on a resolution by consensus. If the group cannot reach
+consensus and deadlocks for over a week, the group will turn the matter over to
+the Steering Council for resolution.
+
+Possible responses may include:
+
+- Taking no further action:
+
+  - if we determine no violations have occurred. 
+  - if the matter has been resolved publicly while the Committee was
+    considering responses.
+
+- Coordinating voluntary mediation: if all involved parties agree, the
+  Committee may facilitate a mediation process as detailed below.
+- Remind publicly, and point out that some behavior/actions/language have been
+  judged inappropriate and why in the current context, or can be hurtful to
+  some people, requesting the community to self-adjust.
+- A private reprimand from the Committee to the individual(s) involved. In
+  this case, the group chair will deliver that reprimand to the individual(s)
+  over email, cc'ing the group.
+- A public reprimand. In this case, the Committee chair will deliver that
+  reprimand in the same venue that the violation occurred, within the limits
+  of practicality. E.g., the original mailing list for an email violation, but
+  for a chat room discussion where the person/context may be gone, they can be
+  reached by other means. The group may choose to publish this message
+  elsewhere for documentation purposes.
+- A request for a public or private apology, assuming the reporter agrees to
+  this idea: they may at their discretion refuse further contact with the
+  violator. The chair will deliver this request. The Committee may, if it
+  chooses, attach “strings” to this request: for example, the group may ask a
+  violator to apologize in order to retain one's membership on a mailing list.
+- A “mutually agreed upon hiatus” where the Committee asks the individual to
+  temporarily refrain from community participation. If the individual chooses
+  not to take a temporary break voluntarily, the Committee may issue a
+  “mandatory cooling off period”.
+- A permanent or temporary ban from some or all ImageIO spaces (mailing lists,
+  gitter.im, etc.). The group will maintain records of all such bans so that
+  they may be reviewed in the future or otherwise maintained.
+
+Once a resolution is agreed upon, but before it is enacted, the Committee will
+contact the original reporter and any other affected parties and explain the
+proposed resolution. The Committee will ask if this resolution is acceptable,
+and must note feedback for the record.
+
+Finally, the committee will make a report to the ImageIO Steering Council (as
+well as the ImageIO core team in the event of an ongoing resolution, such as a
+ban).
+
+The committee will never publicly discuss the issue; all public statements will
+be made by the chair of the Code of Conduct Committee or the ImageIO Steering
+Council.
+
+.. _Mediation:
+
+Mediation
+---------
+
+Voluntary informal mediation is a tool at our disposal. In contexts such as when
+two or more parties have all escalated to the point of inappropriate behavior
+(something sadly common in human conflict), it may be useful to facilitate a
+mediation process. This is only an example: the Committee can consider mediation
+in any case, mindful that the process is meant to be strictly voluntary and no
+party can be pressured to participate. If the Committee suggests mediation, it
+should:
+
+- Find a candidate who can serve as a mediator.
+- Obtain the agreement of the reporter(s). The reporter(s) have complete
+  freedom to decline the mediation idea or to propose an alternate mediator.
+- Obtain the agreement of the reported person(s).
+- Settle on the mediator: while parties can propose a different mediator than
+  the suggested candidate, only if a common agreement is reached on all terms
+  can the process move forward.
+- Establish a timeline for mediation to complete, ideally within two weeks.
+
+The mediator will engage with all the parties and seek a resolution that is
+satisfactory to all. Upon completion, the mediator will provide a report (vetted
+by all parties to the process) to the Committee, with recommendations on further
+steps. The Committee will then evaluate these results (whether a satisfactory
+resolution was achieved or not) and decide on any additional action deemed
+necessary.
+
+Conflicts of Interest
+---------------------
+
+In the event of any conflict of interest, a committee member must immediately
+notify the other members, and recuse themselves if necessary.
+
+Endnotes
+--------
+
+This Code of Conduct took inspiration from the NumFOCUS Code of Conduct and the
+NumPy Code of Conduct.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,3 +14,5 @@ Contents:
   Supported Formats <formats/index>
   API Reference <reference/index>
   Contributing <development/index>
+  Code of Conduct <code_of_conduct>
+  Code of Conduct Reporting Guidelines <code_of_conduct_reporting>


### PR DESCRIPTION
This PR adds an explicit code of conduct to ImageIO. 

While we didn't have any incidents during the time I have been here, it is required to have an explicit code to apply for affiliation with NumFOCUS. I would like to apply and eventually attract and grow a community around ImageIO; hence this PR.

@almarklein @jni Could I trouble both of you to have a look at this draft and tell me what you think? I'm especially hoping for insights from @jni since scikit-image is fiscally sponsored by NumFOCUS and have thus I assume you have gone through this process at some point :)

Of course, feedback from others is also highly appreciated 🚀 