### PR TITLE
DOC: Add migration instructions for as_gray in new pillow plugin.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -190,7 +190,9 @@ html_theme_options = {
         },
     ],
     "use_edit_page_button": True,
-    "google_analytics_id": "G-EFE74Z5D7E",
+    "analytics": {
+        "google_analytics_id": "G-EFE74Z5D7E",
+    },
 }
 html_context = {
     # "github_url": "https://github.com", # or your GitHub Enterprise interprise

--- a/docs/reference/userapi.rst
+++ b/docs/reference/userapi.rst
@@ -208,8 +208,11 @@ This section is a collection of notes and feedback that we got from other
 developers that were migrating to ImageIO V3, which might be useful to know
 while you are migrating your own code.
 
-- The old pillow plugin used to `np.squeeze` the image before writing it. This
+- The old pillow plugin used to ``np.squeeze`` the image before writing it. This
   has been removed in V3 to match pillows native behavior. A trailing axis with
   dimension 1, e.g., ``(256, 256, 1)`` will now raise an exception. (see `#842
   <https://github.com/imageio/imageio/issues/842>`_)
-
+- The old pillow plugin featured a kwarg called ``as_gray`` which would convert
+  images to grayscale before returning them. This is redundant and has been
+  deprecated in favor of using ``mode="L"``, which matches pillow's native
+  kwarg.

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -120,14 +120,14 @@ class PillowPlugin(PluginV3):
         self._request.finish()
 
     def read(
-        self, *, index=None, mode=None, rotate=False, apply_gamma=False
+        self, *, index=None, mode=None, rotate=False, apply_gamma=False, as_gray=None
     ) -> np.ndarray:
         """
         Parses the given URI and creates a ndarray from it.
 
         Parameters
         ----------
-        index : {integer}
+        index : int
             If the ImageResource contains multiple ndimages, and index is an
             integer, select the index-th ndimage from among them and return it.
             If index is an ellipsis (...), read all ndimages in the file and
@@ -135,16 +135,18 @@ class PillowPlugin(PluginV3):
             None, this plugin reads the first image of the file (index=0) unless
             the image is a GIF or APNG, in which case all images are read
             (index=...).
-        mode : {str, None}
+        mode : str
             Convert the image to the given mode before returning it. If None,
             the mode will be left unchanged. Possible modes can be found at:
             https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
-        rotate : {bool}
+        rotate : bool
             If set to ``True`` and the image contains an EXIF orientation tag,
             apply the orientation before returning the ndimage.
-        apply_gamma : {bool}
+        apply_gamma : bool
             If ``True`` and the image contains metadata about gamma, apply gamma
             correction to the image.
+        as_gray : bool
+            Deprecated. Exists to raise a constructive error message.
 
         Returns
         -------
@@ -159,6 +161,12 @@ class PillowPlugin(PluginV3):
         is discarded during conversion to ndarray.
 
         """
+
+        if as_gray is not None:
+            raise TypeError(
+                "The keyword `as_gray` is no longer supported."
+                "Use `mode='L'` instead."
+            )
 
         if index is None:
             if self._image.format == "GIF":

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -612,7 +612,7 @@ def test_8bit_with_16bit_depth():
 
 def test_deprecated_as_gray(test_images):
     with pytest.raises(TypeError):
-        iio.v3.imread(test_images / "chelsea.png", plugin="pillow", as_gray=True)
+        iio.imread(test_images / "chelsea.png", plugin="pillow", as_gray=True)
 
 
 def test_png_batch_fail():

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -608,3 +608,8 @@ def test_8bit_with_16bit_depth():
 
     assert img16_read.dtype != np.uint8
     assert np.allclose(img16_read, img16)
+
+
+def test_deprecated_as_gray(test_images):
+    with pytest.raises(TypeError):
+        iio.v3.imread(test_images / "chelsea.png", plugin="pillow", as_gray=True)


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/909

This PR adds some documentation around migrating from `as_gray` to `mode="L"` when using pillow to read images as grayscale. It also adds a constructive error message that informs users about this change.