### PR TITLE
DEV: exclude py3.11 on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
           - name: Use PyAV 10.0.0
             pyversion: '3.11'
             PYAV_10_0_0: 1
+        exclude:
+          # exclude 3.11 on windows until we can replicate the
+          # access violation found in CI
+          - os: windows-latest
+            pyversion: '3.11'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
For now, let's exclude the flaky CI until I can come around to debug it properly.