### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,6 +82,9 @@ jobs:
             pyversion: '3.7'
             TEST_UNIT: 1
             TEST_FULL: 1
+          - name: Use PyAV 10.0.0
+            pyversion: '3.11'
+            PYAV_10_0_0: 1
     steps:
       - uses: actions/checkout@v3
         with:
@@ -98,6 +101,12 @@ jobs:
         if: matrix.TEST_FULL == 1
         run: |
             pip install -q -U simpleitk astropy
+      - name: Downgrade PyAV
+        # PyAV 10.0.0 is needed on py3.11 but has issues, so we only use it on
+        # py3.11 for now
+        if: matrix.PYAV_10_0_0 != 1
+        run: |
+            pip install --upgrade av!=10.0.0
       - name: Run All Unit tests
         run: pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: '3.x'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.7", "3.8", "3.9", "3.10"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - name: Linux py37 full
             os: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,10 +29,10 @@ jobs:
     outputs:
       should_release: ${{ steps.skippy.outputs.release }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install Dependencies
@@ -56,8 +56,8 @@ jobs:
     if: needs.initial_check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install Dependencies
@@ -83,11 +83,11 @@ jobs:
             TEST_UNIT: 1
             TEST_FULL: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Set up Python ${{ matrix.pyversion }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyversion }}
       - name: Install dependencies for tests
@@ -112,9 +112,9 @@ jobs:
         os: ["ubuntu-latest", "macos-latest"]
         pyversion: ["pypy-3.7", "pypy-3.8", "pypy-3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up pypy
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.pyversion }}"
       - name: MacOS Numpy Fix
@@ -136,8 +136,8 @@ jobs:
     if: needs.initial_check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install dependencies for tests
@@ -152,7 +152,7 @@ jobs:
     needs: [cpython_tests, pypy_tests, build_test, docs]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Python Semantic Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.x'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: psf/black@20.8b1
+      - uses: psf/black@22.8.0
         with:
           args: ". --check"
       - name: Install Dependencies
@@ -47,7 +47,7 @@ jobs:
         run: |
             pip install .[linting]
       - name: Flake8
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v2
         with:
           linters: flake8
           run: flake8 .

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ MANIFEST
 .pytest_cache/
 .test_images/
 coverage.xml
+.venv/
 
 # Specific folders
 imageio/lib

--- a/setup.py
+++ b/setup.py
@@ -265,5 +265,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)