### PR TITLE
DEV: pin sphinx<6

### DIFF
--- a/imageio/plugins/opencv.py
+++ b/imageio/plugins/opencv.py
@@ -162,7 +162,7 @@ class OpenCVPlugin(PluginV3):
             for details.
 
         Yields
-        -------
+        ------
         ndimage : np.ndarray
             The decoded image as a numpy array.
 

--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,7 @@ extras_require = {
     "build": ["wheel"],
     "linting": ["black", "flake8"],
     "test": ["invoke", "pytest", "pytest-cov", "fsspec[github]"],
-    "docs": ["sphinx", "numpydoc", "pydata-sphinx-theme"],
+    "docs": ["sphinx<6", "numpydoc", "pydata-sphinx-theme"],
     **plugins,
     **cpython_only_plugins,
     "gdal": ["gdal"],  # gdal currently fails to install :(


### PR DESCRIPTION
This PR pins sphinx below v6.0, because using v6.0+ breaks the doc building with the following error:

```
Theme error:
An error happened in rendering the page _autosummary/_plugins/pillow/imageio.plugins.pillow.PillowPlugin.get_meta.
Reason: UndefinedError("'logo' is undefined")
```