### PR TITLE
Avoid np.stack in pyav plugin.

### DIFF
--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -618,9 +618,7 @@ class PyAVPlugin(PluginV3):
         """
 
         if isinstance(ndimage, list):
-            # frames shapes must agree for video
-            if any(f.shape != ndimage[0].shape for f in ndimage):
-                raise ValueError("All frames should have the same shape")
+            pass
         elif not is_batch:
             ndimage = np.asarray(ndimage)[None, ...]
         else:
@@ -911,6 +909,18 @@ class PyAVPlugin(PluginV3):
 
         stream = self._video_stream
         av_frame.time_base = stream.codec_context.time_base
+
+        if stream.frames == 0:
+            stream.width = av_frame.width
+            stream.height = av_frame.height
+        elif stream.width != av_frame.width or stream.height != av_frame.height:
+            stream_shape = (stream.height, stream.width)
+            video_shape = (height, width)
+            raise ValueError(
+                f"Can't write a frame of shape `{video_shape}` to"
+                f" a video stream with shape `{stream_shape}`."
+            )
+
         av_frame.pts = self.frames_written
         self.frames_written += 1
 
@@ -919,9 +929,6 @@ class PyAVPlugin(PluginV3):
             if av_frame is None:
                 return
 
-        if stream.frames == 0:
-            stream.width = av_frame.width
-            stream.height = av_frame.height
         for packet in stream.encode(av_frame):
             self._container.mux(packet)
 

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -594,7 +594,8 @@ class PyAVPlugin(PluginV3):
 
         if isinstance(ndimage, list):
             # frames shapes must agree for video
-            ndimage = np.stack(ndimage)
+            if any(f.shape != ndimage[0].shape for f in ndimage):
+                raise ValueError("All frames should have the same shape")
         elif not is_batch:
             ndimage = np.asarray(ndimage)[None, ...]
         else:

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -265,8 +265,8 @@ def test_raises_exception_when_shapes_mismatch(test_images, tmp_path):
     )
 
     # touch the codepath that creates a video from a list of frames
-    frame_list = list(frames_expected)
-    frame_list[0].reshape(200, 150)
+    frame_list = list(frames_expected)    
+    frame_list[0] = frame_list[0].reshape(200, 150)
 
     with pytest.raises(ValueError, match="All frames should have the same shape"):
         iio.imwrite(

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -259,6 +259,24 @@ def test_gif_write(test_images, tmp_path):
     # with iio.v3.imopen("test2.gif", "w", plugin="pyav", container_format="gif", legacy_mode=False) as file:
     #     file.write(frames, codec="gif", out_pixel_format="gray", in_pixel_format="gray")
 
+def test_raises_exception_when_shapes_mismatch(test_images, tmp_path):
+    frames_expected = iio.imread(
+        test_images / "newtonscradle.gif", plugin="pyav", format="gray"
+    )
+
+    # touch the codepath that creates a video from a list of frames
+    frame_list = list(frames_expected)
+    frame_list[0].reshape(200, 150)
+
+    with pytest.raises(ValueError, match="All frames should have the same shape"):
+        iio.imwrite(
+            tmp_path / "test.gif",
+            frame_list,
+            plugin="pyav",
+            codec="gif",
+            out_pixel_format="gray",
+            in_pixel_format="gray",
+        )
 
 def test_gif_gen(test_images, tmp_path):
     frames = iio.imread(

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -260,16 +260,14 @@ def test_gif_write(test_images, tmp_path):
     # with iio.v3.imopen("test2.gif", "w", plugin="pyav", container_format="gif", legacy_mode=False) as file:
     #     file.write(frames, codec="gif", out_pixel_format="gray", in_pixel_format="gray")
 
+
 def test_raises_exception_when_shapes_mismatch(test_images, tmp_path):
-    frames_expected = iio.imread(
-        test_images / "newtonscradle.gif", plugin="pyav", format="gray"
-    )
+    frame_list = [
+        np.ones((200, 150), dtype=np.uint8),
+        np.ones((256, 256), dtype=np.uint8),
+    ]
 
-    # touch the codepath that creates a video from a list of frames
-    frame_list = list(frames_expected)    
-    frame_list[0] = frame_list[0].reshape(200, 150)
-
-    with pytest.raises(ValueError, match="All frames should have the same shape"):
+    with pytest.raises(ValueError):
         iio.imwrite(
             tmp_path / "test.gif",
             frame_list,
@@ -278,6 +276,7 @@ def test_raises_exception_when_shapes_mismatch(test_images, tmp_path):
             out_pixel_format="gray",
             in_pixel_format="gray",
         )
+
 
 def test_gif_gen(test_images, tmp_path):
     frames = iio.imread(


### PR DESCRIPTION
Closes #927.
Removed the call to np.stack and added a new test case, where I reshaped one frame, to validate new functionality.