### PR TITLE
BUG: Handle unknown video duration in pyav metadata

### DIFF
--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -742,7 +742,9 @@ class PyAVPlugin(PluginV3):
                 }
             )
             if self._video_stream.duration is not None:
-                duration = float(self._video_stream.duration * self._video_stream.time_base)
+                duration = float(
+                    self._video_stream.duration * self._video_stream.time_base
+                )
                 metadata.update({"duration": duration})
 
             metadata.update(self.container_metadata)

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -706,17 +706,18 @@ class PyAVPlugin(PluginV3):
 
         if index is ...:
             # useful flags defined on the container and/or video stream
-            duration = float(self._video_stream.duration * self._video_stream.time_base)
             metadata.update(
                 {
                     "video_format": self._video_stream.codec_context.pix_fmt,
                     "codec": self._video_stream.codec.name,
                     "long_codec": self._video_stream.codec.long_name,
                     "profile": self._video_stream.profile,
-                    "duration": duration,
                     "fps": float(self._video_stream.guessed_rate),
                 }
             )
+            if self._video_stream.duration is not None:
+                duration = float(self._video_stream.duration * self._video_stream.time_base)
+                metadata.update({"duration": duration})
 
             metadata.update(self.container_metadata)
             metadata.update(self.video_stream_metadata)


### PR DESCRIPTION
Implement a check if video container has value in duration field before populate it's value in metadata

only apply to plugin pyav