### PR TITLE
FEAT: optimize pyav

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
             pip install .[test,all-plugins]
       - name: OpenCV on python 3.7
-        if: matrix.os != "macos-latest"
+        if: matrix.os != 'macos-latest'
         run: |
             pip install opencv-python
       - name: Install optional dependencies for tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: psf/black@latest
+      - uses: psf/black
         with:
           args: ". --check"
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
           # access violation found in CI
           - os: windows-latest
             pyversion: '3.11'
+          - os: macos-latest
+            pyversion: '3.11'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: psf/black@stable
+      - uses: psf/black@latest
         with:
           args: ". --check"
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,6 @@ jobs:
           # access violation found in CI
           - os: windows-latest
             pyversion: '3.11'
-          - os: macos-latest
-            pyversion: '3.11'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -111,6 +109,10 @@ jobs:
         shell: bash
         run: |
             pip install .[test,all-plugins]
+      - name: OpenCV on python 3.7
+        if: matrix.os != "macos-latest"
+        run: |
+            pip install opencv-python
       - name: Install optional dependencies for tests
         if: matrix.TEST_FULL == 1
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: psf/black
+      - uses: psf/black@22.12.0
         with:
           args: ". --check"
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ci-${{ github.ref }}-1
+  cancel-in-progress: true
 
 jobs:
   docs-GH:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: psf/black@22.8.0
+      - uses: psf/black@stable
         with:
           args: ". --check"
       - name: Install Dependencies

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -761,7 +761,7 @@ class PyAVPlugin(PluginV3):
         self,
         codec: str,
         *,
-        fps: int = 24,
+        fps: float = 24,
         pixel_format: str = None,
     ) -> None:
         """Initialize a new video stream.
@@ -773,7 +773,7 @@ class PyAVPlugin(PluginV3):
         ----------
         codec : str
             The codec to use, e.g. ``"x264"`` or ``"vp9"``.
-        fps : str
+        fps : float
             The desired framerate of the video stream (frames per second).
         pixel_format : str
             The pixel format to use while encoding frames. If None (default) use
@@ -782,7 +782,7 @@ class PyAVPlugin(PluginV3):
         """
 
         stream = self._container.add_stream(codec, fps)
-        stream.time_base = Fraction(1, int(fps))
+        stream.time_base = Fraction(1/fps).limit_denominator(int(2**16-1))
         if pixel_format is not None:
             stream.pix_fmt = pixel_format
 

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -421,6 +421,7 @@ class PyAVPlugin(PluginV3):
 
         if index is ...:
             self._container.seek(0)
+            # self.metadata(constant_framerate=constant_framerate)
 
             frames = np.stack(
                 [
@@ -665,7 +666,7 @@ class PyAVPlugin(PluginV3):
         self,
         index: int = ...,
         exclude_applied: bool = True,
-        constant_framerate: bool = True,
+        constant_framerate: bool = None,
     ) -> Dict[str, Any]:
         """Format-specific metadata.
 
@@ -721,6 +722,9 @@ class PyAVPlugin(PluginV3):
             metadata.update(self.container_metadata)
             metadata.update(self.video_stream_metadata)
             return metadata
+
+        if constant_framerate is None:
+            constant_framerate = self._container.format.variable_fps
 
         decoder = self._seek(index, constant_framerate=constant_framerate)
         desired_frame = next(decoder)
@@ -782,7 +786,7 @@ class PyAVPlugin(PluginV3):
         """
 
         stream = self._container.add_stream(codec, fps)
-        stream.time_base = Fraction(1/fps).limit_denominator(int(2**16-1))
+        stream.time_base = Fraction(1 / fps).limit_denominator(int(2**16 - 1))
         if pixel_format is not None:
             stream.pix_fmt = pixel_format
 

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -766,7 +766,9 @@ class PyAVPlugin(PluginV3):
         )
 
         # side data
-        metadata.update({item.type.name:item.to_bytes() for item in desired_frame.side_data})
+        metadata.update(
+            {item.type.name: item.to_bytes() for item in desired_frame.side_data}
+        )
 
         return metadata
 
@@ -795,7 +797,7 @@ class PyAVPlugin(PluginV3):
         fps: float = 24,
         pixel_format: str = None,
         max_keyframe_interval: int = None,
-        force_keyframes:bool = None,
+        force_keyframes: bool = None,
     ) -> None:
         """Initialize a new video stream.
 

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -1124,10 +1124,8 @@ class PyAVPlugin(PluginV3):
         #     frames_to_yield = index - self._next_idx
         if not constant_framerate and index > self._next_idx:
             frames_to_yield = index - self._next_idx
-        # in all other cases we have to seek or can optimize by seeking
         elif not constant_framerate:
-            # can't link idx and pts, hence we can't find the idx of
-            # a keyframe
+            # seek backwards and can't link idx and pts
             self._container.seek(0)
             self._decoder = self._container.decode(video=0)
             self._next_idx = 0

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -472,7 +472,7 @@ class PyAVPlugin(PluginV3):
             self._video_stream.codec_context.thread_count = thread_count
 
         if constant_framerate is None:
-            constant_framerate = self._container.format.variable_fps
+            constant_framerate = not self._container.format.variable_fps
         decoder = self._seek(index, constant_framerate=constant_framerate)
         desired_frame = next(decoder)
 
@@ -742,7 +742,7 @@ class PyAVPlugin(PluginV3):
             return metadata
 
         if constant_framerate is None:
-            constant_framerate = self._container.format.variable_fps
+            constant_framerate = not self._container.format.variable_fps
 
         decoder = self._seek(index, constant_framerate=constant_framerate)
         desired_frame = next(decoder)

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -421,20 +421,38 @@ class PyAVPlugin(PluginV3):
 
         if index is ...:
             self._container.seek(0)
-            # self.metadata(constant_framerate=constant_framerate)
+            props = self.properties(format=format)
+            uses_filter = (
+                self._video_filter is not None
+                or filter_graph is not None
+                or filter_sequence is not None
+            )
 
-            frames = np.stack(
-                [
-                    x
-                    for x in self.iter(
+            if not uses_filter and props.shape[0] not in [0, -1]:
+                frames = np.empty(props.shape, dtype=props.dtype)
+                for idx, frame in enumerate(
+                    self.iter(
                         format=format,
                         filter_sequence=filter_sequence,
                         filter_graph=filter_graph,
                         thread_count=thread_count,
                         thread_type=thread_type or "FRAME",
                     )
-                ]
-            )
+                ):
+                    frames[idx] = frame
+            else:
+                frames = np.stack(
+                    [
+                        x
+                        for x in self.iter(
+                            format=format,
+                            filter_sequence=filter_sequence,
+                            filter_graph=filter_graph,
+                            thread_count=thread_count,
+                            thread_type=thread_type or "FRAME",
+                        )
+                    ]
+                )
 
             # reset stream container, because threading model can't change after
             # first access

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -861,7 +861,6 @@ class PyAVPlugin(PluginV3):
             if av_frame is None:
                 return
 
-        av_frame = av_frame.reformat(format=stream.codec_context.pix_fmt)
         if stream.frames == 0:
             stream.width = av_frame.width
             stream.height = av_frame.height

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -428,7 +428,7 @@ class PyAVPlugin(PluginV3):
                 or filter_sequence is not None
             )
 
-            if not uses_filter and props.shape[0] not in [0, -1]:
+            if not uses_filter and props.shape[0] != 0:
                 frames = np.empty(props.shape, dtype=props.dtype)
                 for idx, frame in enumerate(
                     self.iter(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E203, W503, E501
+exclude = .venv
 
 [semantic_release]
 branch = master

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,6 @@ plugins = {
 }
 
 cpython_only_plugins = {
-    "opencv": ["opencv-python"],
     "fits": ["astropy"],
 }
 

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -434,7 +434,7 @@ def test_seek_vs_iter(test_images):
 
             actual = file.read(index=idx, thread_type="FRAME")
             assert np.allclose(actual, expected)
-            
+
             actual = iio.imread(img_path, plugin="pyav", index=idx)
             assert np.allclose(actual, expected)
 

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -303,6 +303,11 @@ def test_variable_fps_seek(test_images):
 
     assert np.allclose(actual, expected)
 
+    meta = iio.immeta(
+        test_images / "cockatoo.mp4", index=3, plugin="pyav", constant_framerate=False
+    )
+    assert meta["interlaced_frame"] is False
+
 
 def test_multiple_writes(test_images):
     # Note: when opening videos via imopen prefer using the additional API for
@@ -488,6 +493,8 @@ def test_read_filter(test_images):
 def test_write_float_fps(test_images):
     fps = 3.5
     frames = iio.imread(test_images / "cockatoo.mp4", plugin="pyav")
-    buffer = iio.imwrite("<bytes>", frames, extension=".mp4", codec="h264", plugin="pyav", fps=3.5)
+    buffer = iio.imwrite(
+        "<bytes>", frames, extension=".mp4", codec="h264", plugin="pyav", fps=3.5
+    )
 
     assert iio.immeta(buffer, plugin="pyav")["fps"] == fps

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -421,6 +421,7 @@ def test_uri_reading(test_images):
 
 
 def test_seek_last(test_images):
+    frame = iio.imread(test_images / "cockatoo.mp4", plugin="pyav", index=145)
     frame = iio.imread(test_images / "cockatoo.mp4", plugin="pyav", index=279)
     assert frame.shape == (720, 1280, 3)
 

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -483,3 +483,11 @@ def test_read_filter(test_images):
     )
 
     assert image.shape == (480, 640, 3)
+
+
+def test_write_float_fps(test_images):
+    fps = 3.5
+    frames = iio.imread(test_images / "cockatoo.mp4", plugin="pyav")
+    buffer = iio.imwrite("<bytes>", frames, extension=".mp4", codec="h264", plugin="pyav", fps=3.5)
+
+    assert iio.immeta(buffer, plugin="pyav")["fps"] == fps

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -421,9 +421,15 @@ def test_uri_reading(test_images):
 
 
 def test_seek_last(test_images):
-    frame = iio.imread(test_images / "cockatoo.mp4", plugin="pyav", index=145)
-    frame = iio.imread(test_images / "cockatoo.mp4", plugin="pyav", index=279)
-    assert frame.shape == (720, 1280, 3)
+    with iio.imopen(test_images / "cockatoo.mp4", "r", plugin="pyav") as file:
+        for idx, expected in enumerate(
+            iio.imiter(test_images / "cockatoo.mp4", plugin="pyav", thread_type="FRAME")
+        ):
+            if idx == 264:
+                print("")
+            frame = file.read(index=idx, thread_type="FRAME")
+            if not np.allclose(frame, expected):
+                assert False, f"Missmatch at {idx}"
 
 
 def test_procedual_writing(test_images):


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/926, https://github.com/imageio/imageio/issues/929, https://github.com/imageio/imageio/issues/932, https://github.com/imageio/imageio/issues/933

This PR is a collection of optimizations and tweaks to improve the performance of our pyav plugin. It adds the following improvements:

- It removes an explicit (and redundant) colorspace conversion that ffmpeg can handle more efficiently internally (#926)
- It allows floats to be used for `fps`, which allows non-integer framerates (#929).
- It checks the container's `variable_fps` flag when reading metadata to automatically set `constant_framerate` if not manually specified
- It preallocates the output array when bulk reading (`index=...`) if the output shape is known in advance. (#932)
- It optimizes sequential calls to `read` so that they reuse the current decoder state if possible. (#933)
- It exposes the frame type as metadata
- It allows setting `max_keyframe_interval` and `force_keyframes` (open/closed GOP) when writing to control intra frame behavior.