### PR TITLE
BUG: format hint test doesn't need to establish a connection

### DIFF
--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -214,7 +214,6 @@ class Request(object):
     """
 
     def __init__(self, uri, mode, *, extension=None, format_hint: str = None, **kwargs):
-
         # General
         self.raw_uri = uri
         self._uri_type = None
@@ -545,7 +544,6 @@ class Request(object):
         """
 
         if self.mode.io_mode == IOMode.write:
-
             # See if we "own" the data and must put it somewhere
             bytes = None
             if self._filename_local:
@@ -666,7 +664,6 @@ class SeekableFileObject:
         self.closed = False
 
     def read(self, n=None):
-
         # Fix up n
         if n is None:
             pass

--- a/imageio/plugins/_bsdf.py
+++ b/imageio/plugins/_bsdf.py
@@ -161,7 +161,6 @@ class BsdfSerializer(object):
         load_streaming=False,
         lazy_blob=False,
     ):
-
         # Validate compression
         if isinstance(compression, string_types):
             m = {"no": 0, "zlib": 1, "bz2": 2}
@@ -871,7 +870,6 @@ class Extension(object):
 
 
 class ComplexExtension(Extension):
-
     name = "c"
     cls = complex
 
@@ -883,7 +881,6 @@ class ComplexExtension(Extension):
 
 
 class NDArrayExtension(Extension):
-
     name = "ndarray"
 
     def __init__(self):

--- a/imageio/plugins/_freeimage.py
+++ b/imageio/plugins/_freeimage.py
@@ -408,7 +408,6 @@ class Freeimage(object):
     }
 
     def __init__(self):
-
         # Initialize freeimage lib as None
         self._lib = None
 
@@ -481,7 +480,6 @@ class Freeimage(object):
         self.lib_version = self.lib.FreeImage_GetVersion().decode("utf-8")
 
     def _load_freeimage(self):
-
         # Define names
         lib_names = ["freeimage", "libfreeimage"]
         exact_lib_names = [
@@ -572,7 +570,6 @@ class Freeimage(object):
         This function also tests whether the format supports reading/writing.
         """
         with self as lib:
-
             # Init
             ftype = -1
             if mode not in "rw":
@@ -652,7 +649,6 @@ class FIBaseBitmap(object):
             self._close_funcs.append(close_func)
 
     def get_meta_data(self):
-
         # todo: there is also FreeImage_TagToString, is that useful?
         # and would that work well when reading and then saving?
 
@@ -668,17 +664,14 @@ class FIBaseBitmap(object):
         tag = ctypes.c_void_p()
 
         with self._fi as lib:
-
             # Iterate over all FreeImage meta models
             for model_name, number in models:
-
                 # Find beginning, get search handle
                 mdhandle = lib.FreeImage_FindFirstMetadata(
                     number, self._bitmap, ctypes.byref(tag)
                 )
                 mdhandle = ctypes.c_void_p(mdhandle)
                 if mdhandle:
-
                     # Iterate over all tags in this model
                     more = True
                     while more:
@@ -723,7 +716,6 @@ class FIBaseBitmap(object):
             return metadata
 
     def set_meta_data(self, metadata):
-
         # Create a dict mapping model_name to number
         models = {}
         for name, number in METADATA_MODELS.__dict__.items():
@@ -739,16 +731,13 @@ class FIBaseBitmap(object):
                 return None
 
         with self._fi as lib:
-
             for model_name, subdict in metadata.items():
-
                 # Get model number
                 number = models.get(model_name, None)
                 if number is None:
                     continue  # Unknown model, silent ignore
 
                 for tag_name, tag_val in subdict.items():
-
                     # Create new tag
                     tag = lib.FreeImage_CreateTag()
                     tag = ctypes.c_void_p(tag)
@@ -801,7 +790,6 @@ class FIBitmap(FIBaseBitmap):
     """Wrapper for the FI bitmap object."""
 
     def allocate(self, array):
-
         # Prepare array
         assert isinstance(array, numpy.ndarray)
         shape = array.shape
@@ -973,7 +961,6 @@ class FIBitmap(FIBaseBitmap):
         return a
 
     def set_image_data(self, array):
-
         # Prepare array
         assert isinstance(array, numpy.ndarray)
         shape = array.shape
@@ -1219,7 +1206,6 @@ class FIMultipageBitmap(FIBaseBitmap):
 
         # Try opening
         with self._fi as lib:
-
             # Create bitmap
             multibitmap = lib.FreeImage_OpenMultiBitmap(
                 self._ftype,
@@ -1299,7 +1285,6 @@ class FIMultipageBitmap(FIBaseBitmap):
         Please close the returned bitmap when done.
         """
         with self._fi as lib:
-
             # Create low-level bitmap in freeimage
             bitmap = lib.FreeImage_LockPage(self._bitmap, index)
             bitmap = ctypes.c_void_p(bitmap)

--- a/imageio/plugins/_swf.py
+++ b/imageio/plugins/_swf.py
@@ -83,7 +83,6 @@ class BitArray:
         return self
 
     def append(self, bits):
-
         # check input
         if isinstance(bits, BitArray):
             bits = str(bits)
@@ -320,7 +319,6 @@ class Tag:
         return twits2bits([xmin, xmax, ymin, ymax])
 
     def make_matrix_record(self, scale_xy=None, rot_xy=None, trans_xy=None):
-
         # empty matrix?
         if scale_xy is None and rot_xy is None and trans_xy is None:
             return "0" * 8
@@ -466,7 +464,6 @@ class BitmapTag(DefinitionTag):
         self.imshape = im.shape
 
     def process_tag(self):
-
         # build tag
         bb = bytes()
         bb += int2uint16(self.id)  # CharacterID
@@ -567,7 +564,6 @@ class ShapeTag(DefinitionTag):
         # self.bytes = bb
 
     def make_style_change_record(self, lineStyle=None, fillStyle=None, moveTo=None):
-
         # first 6 flags
         # Note that we use FillStyle1. If we don't flash (at least 8) does not
         # recognize the frames properly when importing to library.

--- a/imageio/plugins/bsdf.py
+++ b/imageio/plugins/bsdf.py
@@ -71,12 +71,10 @@ def get_bsdf_serializer(options):
             return Image(v["array"], v["meta"])
 
     class Image2DExtension(ImageExtension):
-
         name = "image2d"
         cls = Image2D
 
     class Image3DExtension(ImageExtension):
-
         name = "image3d"
         cls = Image3D
 

--- a/imageio/plugins/dicom.py
+++ b/imageio/plugins/dicom.py
@@ -145,7 +145,6 @@ class DicomFormat(Format):
     # --
 
     class Reader(Format.Reader):
-
         _compressed_warning_dirs = set()
 
         def _open(self, progress=True):

--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -197,7 +197,6 @@ class FfmpegFormat(Format):
     # --
 
     class Reader(Format.Reader):
-
         _frame_catcher = None
         _read_gen = None
 
@@ -417,7 +416,6 @@ class FfmpegFormat(Format):
             return self._meta
 
         def _initialize(self, index=0):
-
             # Close the current generator, and thereby terminate its subprocess
             if self._read_gen is not None:
                 self._read_gen.close()
@@ -534,7 +532,6 @@ class FfmpegFormat(Format):
     # --
 
     class Writer(Format.Writer):
-
         _write_gen = None
 
         def _open(
@@ -564,7 +561,6 @@ class FfmpegFormat(Format):
                 self._write_gen = None
 
         def _append_data(self, im, meta):
-
             # Get props of image
             h, w = im.shape[:2]
             size = w, h
@@ -609,7 +605,6 @@ class FfmpegFormat(Format):
             )
 
         def _initialize(self):
-
             # Close existing generator
             if self._write_gen is not None:
                 self._write_gen.close()

--- a/imageio/plugins/freeimagemulti.py
+++ b/imageio/plugins/freeimagemulti.py
@@ -205,7 +205,6 @@ class GifFormat(FreeimageMulti):
     # -- writer
 
     class Writer(FreeimageMulti.Writer):
-
         # todo: subrectangles
         # todo: global palette
 

--- a/imageio/plugins/pillow_legacy.py
+++ b/imageio/plugins/pillow_legacy.py
@@ -225,7 +225,6 @@ class PillowFormat(Format):
     _description = ""
 
     def __init__(self, *args, plugin_id: str = None, **kwargs):
-
         super(PillowFormat, self).__init__(*args, **kwargs)
         # Used to synchronize _init_pillow(), see #244
         self._lock = threading.RLock()
@@ -412,7 +411,6 @@ class PNGFormat(PillowFormat):
 
     class Writer(PillowFormat.Writer):
         def _open(self, compression=None, quantize=None, interlaced=False, **kwargs):
-
             # Better default for compression
             kwargs["compress_level"] = kwargs.get("compress_level", 9)
 
@@ -518,7 +516,6 @@ class JPEGFormat(PillowFormat):
 
     class Writer(PillowFormat.Writer):
         def _open(self, quality=75, progressive=False, optimize=False, **kwargs):
-
             # The JPEG quality can be between 0 (worst) and 100 (best)
             quality = int(quality)
             if quality < 0 or quality > 100:
@@ -599,7 +596,6 @@ class JPEG2000Format(PillowFormat):
 
     class Writer(PillowFormat.Writer):
         def _open(self, quality_mode="rates", quality=5, **kwargs):
-
             # Check quality - in Pillow it should be no higher than 95
             if quality_mode not in {"rates", "dB"}:
                 raise ValueError("Quality mode should be either 'rates' or 'dB'")
@@ -784,7 +780,6 @@ def pil_get_frame(im, is_gray=None, as_gray=None, mode=None, dtype=None):
 
 
 def ndarray_to_pil(arr, format_str=None, prefer_uint8=True):
-
     from PIL import Image
 
     if arr.ndim == 3:

--- a/imageio/plugins/pillowmulti.py
+++ b/imageio/plugins/pillowmulti.py
@@ -37,7 +37,6 @@ class GIFFormat(PillowFormat):
             quantizer=0,
             subrectangles=False,
         ):
-
             # Check palettesize
             palettesize = int(palettesize)
             if palettesize < 2 or palettesize > 256:
@@ -120,7 +119,6 @@ class GifWriter:
         self.getdata = getdata
 
     def add_image(self, im, duration, dispose):
-
         # Prepare image
         im_rect, rect = im, (0, 0)
         if self.opt_subrectangle:
@@ -158,7 +156,6 @@ class GifWriter:
         self.fp.write(";".encode("utf-8"))  # end gif
 
     def write_image(self, im, palette, rect, duration, dispose):
-
         fp = self.fp
 
         # Gather local image header and data, using PIL's getdata. That

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -536,7 +536,7 @@ class TiffFormat(Format):
         @staticmethod
         def _sanitize_meta(meta):
             ret = {}
-            for (key, value) in meta.items():
+            for key, value in meta.items():
                 if key in WRITE_METADATA_KEYS:
                     # Special case of previously read `predictor` int value
                     # 1(=NONE) translation to False expected by TiffWriter.save

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,6 @@ def image_files(test_images, tmp_path):
 
 @pytest.fixture()
 def clear_plugins():
-
     old_extensions = iio.config.known_extensions.copy()
     old_plugins = iio.config.known_plugins.copy()
 
@@ -154,7 +153,6 @@ def invalid_file(tmp_path, request):
 
 @pytest.fixture()
 def tmp_userdir(tmp_path):
-
     ud = tmp_path / "userdir"
     ud.mkdir(exist_ok=True)
 

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -21,7 +21,6 @@ xfail_big_endian = pytest.mark.xfail(
 
 @deprecated_test
 def test_select(test_images):
-
     F = iio.formats["BSDF"]
     assert F.name == "BSDF"
 
@@ -40,7 +39,6 @@ def test_select(test_images):
 
 
 def test_not_an_image(tmp_path):
-
     fname = str(tmp_path / "notanimage.bsdf")
 
     # Not an image not a list
@@ -62,7 +60,6 @@ def test_not_an_image(tmp_path):
 
 @xfail_big_endian
 def test_singleton(test_images, tmp_path):
-
     im1 = iio.imread(test_images / "chelsea.png")
 
     fname = str(tmp_path / "chelsea.bsdf")
@@ -93,7 +90,6 @@ def test_singleton(test_images, tmp_path):
 
 @xfail_big_endian
 def test_series(test_images, tmp_path):
-
     im1 = iio.imread(test_images / "chelsea.png")
 
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
@@ -157,7 +153,6 @@ def test_series_unclosed(test_images, tmp_path):
 
 @xfail_big_endian
 def test_random_access(test_images, tmp_path):
-
     im1 = iio.imread(test_images / "chelsea.png")
     ims1 = [im1, im1 * 0.8, im1 * 0.5]
 
@@ -174,7 +169,6 @@ def test_random_access(test_images, tmp_path):
 
 @xfail_big_endian
 def test_volume(test_images, tmp_path):
-
     fname1 = test_images / "stent.npz"
     vol1 = iio.volread(fname1)
     assert vol1.shape == (256, 128, 128)
@@ -189,7 +183,6 @@ def test_volume(test_images, tmp_path):
 
 @pytest.mark.needs_internet
 def test_from_url(test_images):
-
     im = iio.imread(
         "https://raw.githubusercontent.com/imageio/"
         + "imageio-binaries/master/images/chelsea.bsdf"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1044,7 +1044,7 @@ def test_format_hint(test_images):
 
     assert np.allclose(im_new, im_old)
 
-    req = iio.core.Request("https://sample.com/my/resource", "r", format_hint=".jpg")
+    req = iio.core.Request(test_images / "bricks.jpg", "r", format_hint=".jpg")
     filename = req.get_local_filename()
 
     assert Path(filename).suffix == ".jpg"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -111,7 +111,6 @@ def test_fetching(tmp_path):
 
 
 def test_findlib2():
-
     if not sys.platform.startswith("linux"):
         skip("test on linux only")
 
@@ -216,7 +215,6 @@ def test_request(test_images, tmp_userdir):
 
 @pytest.mark.needs_internet
 def test_request_read_sources(test_images, tmp_userdir):
-
     # Make an image available in many ways
     fname = "chelsea.png"
     filename = test_images / fname
@@ -231,7 +229,6 @@ def test_request_read_sources(test_images, tmp_userdir):
     # and from local file (the two main plugin-facing functions)
     for file_or_filename in range(2):
         for check_first_bytes in range(2):
-
             # Define uris to test. Define inside loop, since we need fresh files
             uris = [
                 filename,
@@ -259,7 +256,6 @@ def test_request_read_sources(test_images, tmp_userdir):
 
 
 def test_request_save_sources(test_images, tmp_path):
-
     # Get test data
     filename = test_images / "chelsea.png"
     with open(filename, "rb") as f:
@@ -581,7 +577,6 @@ def test_util_image_as_uint():
 
 
 def test_util_has_has_module():
-
     assert not core.has_module("this_module_does_not_exist")
     assert core.has_module("sys")
 

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -56,7 +56,6 @@ def test_dcmtk():
 
 @deprecated_test
 def test_selection(test_images, tmp_path, examples):
-
     dname1, dname2, fname1, fname2 = examples
 
     # Test that DICOM can examine file
@@ -100,7 +99,6 @@ def test_selection(test_images, tmp_path, examples):
 
 
 def test_progress(examples):
-
     dname1, dname2, fname1, fname2 = examples
 
     iio.imread(fname1, progress=True)
@@ -111,11 +109,9 @@ def test_progress(examples):
 
 
 def test_different_read_modes(examples):
-
     dname1, dname2, fname1, fname2 = examples
 
     for fname, dname, n in [(fname1, dname1, 1), (fname2, dname2, 2)]:
-
         # Test imread()
         im = iio.imread(fname)
         assert isinstance(im, np.ndarray)
@@ -148,11 +144,9 @@ def test_different_read_modes(examples):
 
 
 def test_different_read_modes_with_readers(examples):
-
     dname1, dname2, fname1, fname2 = examples
 
     for fname, dname, n in [(fname1, dname1, 1), (fname2, dname2, 2)]:
-
         # Test imread()
         R = iio.read(fname, "DICOM", "i")
         assert len(R) == 1

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -82,7 +82,6 @@ def test_get_exe_env():
 
 @deprecated_test
 def test_select(test_images):
-
     fname1 = test_images / "cockatoo.mp4"
 
     F = iio.formats["ffmpeg"]
@@ -108,7 +107,6 @@ def test_integer_reader_length(test_images):
 
 
 def test_read_and_write(test_images):
-
     fname1 = test_images / "cockatoo.mp4"
 
     R = iio.read(fname1, "ffmpeg")
@@ -185,7 +183,6 @@ def test_v3_read(test_images):
 
 
 def test_write_not_contiguous(test_images):
-
     fname1 = test_images / "cockatoo.mp4"
 
     R = iio.read(fname1, "ffmpeg")
@@ -260,7 +257,6 @@ def test_write_audio_default_codec(test_images, tmp_path):
 
 
 def test_reader_more(test_images):
-
     fname1 = test_images / "cockatoo.mp4"
 
     fname3 = fname1.with_suffix(".stub.mp4")
@@ -340,7 +336,6 @@ def test_reader_more(test_images):
 
 
 def test_writer_more(test_images):
-
     fname1 = test_images / "cockatoo.mp4"
     fname2 = fname1.with_suffix(".out.mp4")
 
@@ -561,7 +556,6 @@ def test_webcam_get_next_data():
 
 
 def test_process_termination(test_images):
-
     pids0 = get_ffmpeg_pids()
 
     r1 = iio.get_reader(test_images / "cockatoo.mp4")

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -48,7 +48,6 @@ def test_webcam_parse_device_names():
 
 @pytest.mark.skipif("__pypy__" in sys.builtin_module_names, reason="Skipping on PYPI")
 def test_overload_fps(test_images):
-
     # Native
     r = imageio.get_reader(test_images / "cockatoo.mp4")
     assert r.count_frames() == 280  # native

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -34,7 +34,6 @@ def normal_plugin_order():
 
 @deprecated_test
 def test_fits_format(test_images):
-
     # Test selection
     for name in ["fits", ".fits"]:
         format = iio.formats["fits"]

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -154,7 +154,6 @@ def test_format(test_images, tmp_path):
 
 @deprecated_test
 def test_reader_and_writer(test_images, tmp_path):
-
     # Prepare
     filename1 = test_images / "chelsea.png"
     filename2 = tmp_path / "chelsea.out"
@@ -224,7 +223,6 @@ def test_reader_and_writer(test_images, tmp_path):
 
 @deprecated_test
 def test_default_can_read_and_can_write(tmp_path):
-
     F = imageio.plugins.example.DummyFormat("test", "", "foo bar", "v")
 
     # Prepare files
@@ -246,7 +244,6 @@ def test_default_can_read_and_can_write(tmp_path):
 
 @deprecated_test
 def test_format_selection(test_images, tmp_path):
-
     formats = imageio.formats
     fname1 = test_images / "chelsea.png"
     fname2 = tmp_path / "test.selectext1"
@@ -354,7 +351,6 @@ def test_format_manager(test_images):
 
 @deprecated_test
 def test_sorting_errors():
-
     with raises(TypeError):
         imageio.formats.sort(3)
     with raises(ValueError):
@@ -365,7 +361,6 @@ def test_sorting_errors():
 
 @deprecated_test
 def test_default_order():
-
     assert imageio.formats[".tiff"].name == "TIFF"
     assert imageio.formats[".png"].name == "PNG-PIL"
     assert imageio.formats[".pfm"].name == "PFM-FI"
@@ -373,7 +368,6 @@ def test_default_order():
 
 @deprecated_test
 def test_preferring_fi():
-
     # Prefer FI all the way
     imageio.formats.sort("-FI")
 
@@ -390,7 +384,6 @@ def test_preferring_fi():
 
 @deprecated_test
 def test_preferring_arbitrary():
-
     # Normally, these exotic formats are somewhere in the back
     imageio.formats.sort()
     names = [f.name for f in imageio.formats]

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -48,7 +48,6 @@ def vendored_lib(request, tmp_path_factory):
 # TODD: update fixture once we transition into v3
 @pytest.fixture(scope="module")
 def setup_library(tmp_path_factory, vendored_lib):
-
     # Checks if freeimage is installed by the system
     from imageio.plugins.freeimage import fi
 
@@ -59,7 +58,6 @@ def setup_library(tmp_path_factory, vendored_lib):
         iio.formats.sort("-FI")
 
     if use_imageio_binary:
-
         if sys.platform.startswith("win"):
             user_dir_env = "LOCALAPPDATA"
         else:
@@ -80,7 +78,6 @@ def setup_library(tmp_path_factory, vendored_lib):
     yield
 
     if use_imageio_binary:
-
         if old_user_dir is not None:
             os.environ[user_dir_env] = old_user_dir
         else:
@@ -179,7 +176,6 @@ def test_get_ref_im():
 
 
 def test_get_fi_lib(vendored_lib, tmp_userdir):
-
     from imageio.plugins._freeimage import get_freeimage_lib
 
     add = core.appdata_dir("imageio")
@@ -192,7 +188,6 @@ def test_get_fi_lib(vendored_lib, tmp_userdir):
 
 @deprecated_test
 def test_freeimage_format(setup_library, test_images, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     # Format
@@ -215,7 +210,6 @@ def test_freeimage_format(setup_library, test_images, tmp_path):
 
 
 def test_freeimage_lib(setup_library):
-
     fi = imageio.plugins.freeimage.fi
 
     # Error messages
@@ -231,7 +225,6 @@ def test_freeimage_lib(setup_library):
 
 
 def test_png(setup_library, test_images, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
@@ -298,7 +291,6 @@ def test_png(setup_library, test_images, tmp_path):
 
 
 def test_png_dtypes(setup_library, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     # See issue #44
@@ -337,7 +329,6 @@ def test_png_dtypes(setup_library, tmp_path):
 
 
 def test_jpg(setup_library, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
@@ -383,7 +374,6 @@ def test_jpg(setup_library, tmp_path):
 
 
 def test_jpg_more(setup_library, test_images, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     # Test broken JPEG
@@ -416,7 +406,6 @@ def test_jpg_more(setup_library, test_images, tmp_path):
 
 
 def test_bmp(setup_library, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
@@ -455,7 +444,6 @@ def test_bmp(setup_library, tmp_path):
 
 
 def test_gif(setup_library, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     # The not-animated gif
@@ -490,7 +478,6 @@ def test_gif(setup_library, tmp_path):
 
 
 def test_animated_gif(setup_library, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     if sys.platform.startswith("darwin"):
@@ -570,7 +557,6 @@ def test_animated_gif(setup_library, tmp_path):
 
 
 def test_ico(setup_library, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
@@ -615,7 +601,6 @@ def test_ico(setup_library, tmp_path):
     reason="Windows has a known issue with multi-icon files",
 )
 def test_multi_icon_ico(setup_library, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     im = get_ref_im(4, 0, 0)[:32, :32]
@@ -633,7 +618,6 @@ def test_mng(setup_library, test_images):
 
 
 def test_pnm(setup_library, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     for useAscii in (True, False):
@@ -674,7 +658,6 @@ def test_other(setup_library, tmp_path):
 
 
 def test_gamma_correction(setup_library, test_images):
-
     fname = test_images / "kodim03.png"
 
     # Load image three times

--- a/tests/test_grab.py
+++ b/tests/test_grab.py
@@ -15,7 +15,6 @@ def test_grab_plugin_load():
     sys.platform = "win32"
 
     try:
-
         reader = iio.get_reader("<screen>")
         assert reader.format.name == "SCREENGRAB"
 
@@ -34,7 +33,6 @@ def test_grab_plugin_load():
 
 
 class FakeImageGrab:
-
     has_clipboard = True
 
     @classmethod
@@ -59,7 +57,6 @@ def test_grab_simulated():
     sys.platform = "win32"
 
     try:
-
         im = iio.imread("<screen>")
         assert im.shape == (8, 8, 3)
 

--- a/tests/test_npz.py
+++ b/tests/test_npz.py
@@ -12,7 +12,6 @@ from conftest import deprecated_test
 
 @deprecated_test
 def test_npz_format(test_images):
-
     # Test selection
     for name in ["npz", ".npz"]:
         format = iio.formats["npz"]

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -24,7 +24,6 @@ from PIL import Image, ImageSequence  # type: ignore
     ],
 )
 def test_write_single_frame(test_images, tmp_path, im_npy, im_out, im_comp):
-
     # the base image as numpy array
     im = np.load(test_images / im_npy)
     # written with imageio
@@ -53,7 +52,6 @@ def test_write_single_frame(test_images, tmp_path, im_npy, im_out, im_comp):
 )
 @pytest.mark.needs_internet
 def test_write_multiframe(test_images, tmp_path, im_npy, im_out, im_comp):
-
     # the base image as numpy array
     im = np.load(test_images / im_npy)
     # written with imageio

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -74,7 +74,6 @@ def assert_close(im1, im2, tol=0.0):
 
 @deprecated_test
 def test_pillow_format(test_images, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     # Format - Pillow is the default!
@@ -103,7 +102,6 @@ def test_pillow_format(test_images, tmp_path):
 
 @deprecated_test
 def test_png(test_images, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
@@ -188,7 +186,6 @@ def test_png_remote():
 
 @deprecated_test
 def test_jpg(tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     for isfloat in (False, True):
@@ -227,7 +224,6 @@ def test_jpg(tmp_path):
 
 @deprecated_test
 def test_jpg_more(test_images, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     # Test broken JPEG
@@ -292,7 +288,6 @@ def test_gif(tmp_path):
 
 @deprecated_test
 def test_animated_gif(test_images, tmp_path):
-
     fnamebase = str(tmp_path / "test")
 
     # Read newton's cradle
@@ -394,7 +389,6 @@ def test_images_with_transparency(test_images):
 
 @deprecated_test
 def test_gamma_correction(test_images):
-
     fname = test_images / "kodim03.png"
 
     # Load image three times
@@ -417,7 +411,6 @@ def test_gamma_correction(test_images):
 
 @deprecated_test
 def test_inside_zipfile(test_images, tmp_path):
-
     fname = str(tmp_path / "pillowtest.zip")
     with ZipFile(fname, "w") as z:
         z.writestr(

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -18,7 +18,6 @@ def mean(x):
 
 @deprecated_test
 def test_format_selection(test_images):
-
     fname1 = test_images / "stent.swf"
     fname2 = fname1.with_suffix(".out.swf")
 
@@ -31,7 +30,6 @@ def test_format_selection(test_images):
 
 
 def test_reading_saving(test_images, tmp_path):
-
     fname1 = test_images / "stent.swf"
     fname2 = fname1.with_suffix(".out.swf")
     fname3 = fname1.with_suffix(".compressed.swf")
@@ -130,7 +128,6 @@ def test_reading_saving(test_images, tmp_path):
 
 @pytest.mark.needs_internet
 def test_read_from_url():
-
     burl = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/"
     url = burl + "images/stent.swf"
 
@@ -140,7 +137,6 @@ def test_read_from_url():
 
 @deprecated_test
 def test_invalid(test_images):
-
     fname1 = test_images / "stent.swf"
     fname2 = fname1.with_suffix(".invalid.swf")
 
@@ -161,7 +157,6 @@ def test_invalid(test_images):
 
 @pytest.mark.needs_internet
 def test_lowlevel():
-
     # Some tests from low level implementation that is not covered
     # by using the plugin itself.
     _swf = imageio.plugins.swf.load_lib()
@@ -186,7 +181,6 @@ def test_lowlevel():
 
 
 def test_types(test_images):
-
     fname1 = test_images / "stent.swf"
     fname2 = fname1.with_suffix(".out3.swf")
 


### PR DESCRIPTION
I recently learned that one of our tests tries to establish a connection to `sample.com` to make sure that the `format_hint` kwarg of our unit-test suite works. This is a bad idea for many reasons, so this PR makes it use a test image instead.