### PR TITLE
DOC: don't build pdfs on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,11 +4,6 @@ sphinx:
    configuration: docs/conf.py
    fail_on_warning: true
 
-# Optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
-
-# Optionally set the version of Python and requirements required to build your docs
 python:
    install:
     - method: pip


### PR DESCRIPTION
I noticed that pdf builds started failing on RTD. I don't think this is a particularly used (or useful) feature, so I will disable it and see if we can get by without it.