### PR TITLE
BUG: allow ffmpeg filters to terminate iter

### DIFF
--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -545,7 +545,10 @@ class PyAVPlugin(PluginV3):
             self._next_idx += 1
 
             if self._video_filter is not None:
-                frame = self._video_filter.send(frame)
+                try:
+                    frame = self._video_filter.send(frame)
+                except StopIteration:
+                    break
 
             if frame is None:
                 continue
@@ -1008,6 +1011,8 @@ class PyAVPlugin(PluginV3):
                 except av.error.BlockingIOError:
                     # filter has lag and needs more frames
                     frame = yield None
+                except av.error.EOFError:
+                    break
 
             try:
                 # send EOF in av>=9.0

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -550,3 +550,15 @@ def test_keyframe_intervals(test_images):
 
     assert np.max(np.diff(i_dist)) <= 5
     assert np.max(np.diff(key_dist)) <= 5
+
+
+def test_trim_filter(test_images):
+    # this is a regression test for:
+    # https://github.com/imageio/imageio/issues/951
+    frames = iio.imread(
+        "imageio:cockatoo.mp4",
+        plugin="pyav",
+        filter_sequence=[("trim", {"start": "00:00:01", "end": "00:00:02"})],
+    )
+
+    assert frames.shape == (20, 720, 1280, 3)


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/951

Among the countless filters in FFMPEG there exists `trim` (and friends) who may terminate a video stream early. This was not handled gracefully by pyav's `iter` function. This PR fixes that by first converting pyav's EoF exception into a `StopIteration` exception at the level of the filter's generator. It then handles said `StopIteration` inside `iter` to stop iterating frames as soon as the filter indicates that the file has ended.
