### PR TITLE
BUG: Consistently apply color palettes by default

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -388,8 +388,10 @@ class PillowPlugin(PluginV3):
         metadata["mode"] = self._image.mode
         metadata["shape"] = self._image.size
 
-        if self._image.mode == "P":
-            metadata["palette"] = self._image.palette
+        if self._image.mode == "P" and not exclude_applied:
+            metadata["palette"] = np.asarray(
+                [list(x) for x in self._image.palette.colors.keys()]
+            )
 
         if self._image.getexif():
             exif_data = {

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -212,7 +212,7 @@ class PillowPlugin(PluginV3):
     def _apply_transforms(self, image, mode, rotate, apply_gamma) -> np.ndarray:
         if mode is not None:
             image = image.convert(mode)
-        elif image.format == "GIF":
+        elif image.mode == "P":
             # adjust for pillow9 changes
             # see: https://github.com/python-pillow/Pillow/issues/5929
             image = image.convert(image.palette.mode)
@@ -442,8 +442,8 @@ class PillowPlugin(PluginV3):
         else:
             self._image.seek(index)
 
-        if self._image.format == "GIF":
-            # GIF mode is determined by pallette
+        if self._image.mode == "P":
+            # mode of palette images is determined by their palette
             mode = self._image.palette.mode
         else:
             mode = self._image.mode

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -389,9 +389,7 @@ class PillowPlugin(PluginV3):
         metadata["shape"] = self._image.size
 
         if self._image.mode == "P" and not exclude_applied:
-            metadata["palette"] = np.asarray(
-                [list(x) for x in self._image.palette.colors.keys()]
-            )
+            metadata["palette"] = np.asarray(tuple(self._image.palette.colors.keys()))
 
         if self._image.getexif():
             exif_data = {

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -155,10 +155,13 @@ class PillowPlugin(PluginV3):
 
         Notes
         -----
-        If you open a GIF - or any other format using color pallets - you may
-        wish to manually set the `mode` parameter. Otherwise, the numbers in
-        the returned image will refer to the entries in the color pallet, which
-        is discarded during conversion to ndarray.
+        If you read a paletted image (e.g. GIF) then the plugin will apply the
+        palette by default. Should you wish to read the palette indices of each
+        pixel use ``mode="P"``. The coresponding color pallete can be found in
+        the image's metadata using the ``palette`` key when metadata is
+        extracted using the ``exclude_applied=False`` kwarg. The latter is
+        needed, as palettes are applied by default and hence excluded by default
+        to keep metadata and pixel data consistent.
 
         """
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -551,6 +551,7 @@ def test_metadata(test_images):
     meta_all = iio.immeta(test_images / "newtonscradle.gif", exclude_applied=False)
     palette = meta_all["palette"]
     assert palette.shape == (102, 3)
+    assert palette.dtype == np.int32
 
 
 def test_apng_reading(tmp_path, test_images):

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -546,6 +546,11 @@ def test_metadata(test_images):
         image_file.read(index=5)
         meta = image_file.metadata(index=0)
         assert "version" in meta and meta["version"] == b"GIF89a"
+        assert "palette" not in meta
+
+    meta_all = iio.immeta(test_images / "newtonscradle.gif", exclude_applied=False)
+    palette = meta_all["palette"]
+    assert palette.shape == (102, 3)
 
 
 def test_apng_reading(tmp_path, test_images):


### PR DESCRIPTION
xref: https://github.com/scikit-image/scikit-image/pull/6764 revealed that ImageIO is not behaving consistently when decoding images that use a color palette. GIFs have their palette applied by default; however, other formats (like PNG) don't. 

This is a regression from the old pillow plugin, and while paletted images that aren't GIF are fairly rare in practice, we should still behave consistently and avoid surprising behavior. Hence, this PR updates the pillow plugin to apply palettes by default. The (raw) index data can still be read by passing `mode="P"`.

This PR also updates how the color palette is exposed as part of the metadata. (1) Since we apply a color palette by default, we should (by default) exclude it from the metadata. This PR changes that behavior and aligns the plugin to the documented API. (2) It changes the returned value from a `PIL.ImagePalette.ImagePalette` to a `np.ndarray`. This should make interacting with and inspecting the palette much easier in the future.