### PR TITLE
BUG: Update FreeImage backend to v3.18.0 on Windows

### DIFF
--- a/imageio/plugins/_freeimage.py
+++ b/imageio/plugins/_freeimage.py
@@ -37,8 +37,8 @@ TEST_NUMPY_NO_STRIDES = False  # To test pypy fallback
 FNAME_PER_PLATFORM = {
     "osx32": "libfreeimage-3.16.0-osx10.6.dylib",  # universal library
     "osx64": "libfreeimage-3.16.0-osx10.6.dylib",
-    "win32": "FreeImage-3.15.4-win32.dll",
-    "win64": "FreeImage-3.15.1-win64.dll",
+    "win32": "FreeImage-3.18.0-win32.dll",
+    "win64": "FreeImage-3.18.0-win64.dll",
     "linux32": "libfreeimage-3.16.0-linux32.so",
     "linux64": "libfreeimage-3.16.0-linux64.so",
 }


### PR DESCRIPTION
fix https://github.com/imageio/imageio/issues/433 along with https://github.com/imageio/imageio-binaries/pull/21