### PR TITLE
DEV: remove pypy 3.7 testing and improve CI/CD scripts

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,19 @@
+name: Documentation
+
+on:
+  workflow_call:
+
+jobs:
+  docs-GH:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install Dependencies
+      run: |
+        pip install -e .[docs]
+    - name: Build Docs
+      run: sphinx-build -W ./docs ./build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,17 +54,7 @@ jobs:
     name: Build Docs
     needs: initial_check
     if: needs.initial_check.outputs.should_release == 'true'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - name: Install Dependencies
-      run: |
-        pip install -e .[docs]
-    - name: Build Docs
-      run: sphinx-build -W ./docs ./build
+    uses: ./.github/workflows/build_docs.yml
   
   cpython_tests:
     needs: initial_check

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,77 +67,16 @@ jobs:
       run: sphinx-build -W ./docs ./build
   
   cpython_tests:
-    name: "${{ matrix.os }} / CPython ${{ matrix.pyversion }}"
     needs: initial_check
     if: needs.initial_check.outputs.should_release == 'true'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        include:
-          - name: Linux py37 full
-            os: ubuntu-latest
-            pyversion: '3.7'
-            TEST_UNIT: 1
-            TEST_FULL: 1
-          - name: Use PyAV 10.0.0
-            pyversion: '3.11'
-            PYAV_10_0_0: 1
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Set up Python ${{ matrix.pyversion }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.pyversion }}
-      - name: Install dependencies for tests
-        shell: bash
-        run: |
-            pip install .[test,ffmpeg,tifffile]
-      - name: Install optional dependencies for tests
-        if: matrix.TEST_FULL == 1
-        run: |
-            pip install -q -U simpleitk astropy
-      - name: Downgrade PyAV
-        # PyAV 10.0.0 is needed on py3.11 but has issues, so we only use it on
-        # py3.11 for now
-        if: matrix.PYAV_10_0_0 != 1
-        run: |
-            pip install --upgrade av!=10.0.0
-      - name: Run All Unit tests
-        run: pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}
+    name: CPython Test Suite
+    uses: ./.github/workflows/cpython_tests.yml
 
   pypy_tests:
-    name: "${{ matrix.os }} / ${{ matrix.pyversion }}"
+    name: PyPy Test Suite
     needs: initial_check
     if: needs.initial_check.outputs.should_release == 'true'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.8", "pypy-3.9"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up pypy
-        uses: actions/setup-python@v4
-        with:
-          python-version: "${{ matrix.pyversion }}"
-      - name: MacOS Numpy Fix
-        if: runner.os == 'macOS'
-        run: |
-            brew install openblas
-            OPENBLAS="$(brew --prefix openblas)" pypy3 -m pip install numpy
-      - name: Install dependencies
-        shell: bash
-        run: |
-            pypy3 -m pip install .[test,all-plugins-pypy]
-      - name: Run Unit tests
-        run: |
-            pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/pypy_tests.yml
   
   build_test:
     name: Wheel Building Test

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -119,7 +119,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.7", "pypy-3.8", "pypy-3.9"]
+        pyversion: ["pypy-3.8", "pypy-3.9"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up pypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.7", "pypy-3.8", "pypy-3.9"]
+        pyversion: ["pypy-3.8", "pypy-3.9"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up pypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,31 +76,9 @@ jobs:
             invoke test --installed
 
   cpython:
-    uses: FirefoxMetzger/imageio/.github/workflows/cpython_tests.yml@fix_ci_fail
+    name: CPython Test Suite
+    uses: ./.github/workflows/cpython_tests.yml
 
   pypy:
-    name: "${{ matrix.os }} / ${{ matrix.pyversion }}"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.8", "pypy-3.9"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up pypy
-        uses: actions/setup-python@v4
-        with:
-          python-version: "${{ matrix.pyversion }}"
-      - name: MacOS Numpy Fix
-        if: runner.os == 'macOS'
-        run: |
-            brew install openblas
-            OPENBLAS="$(brew --prefix openblas)" pypy3 -m pip install numpy
-      - name: Install dependencies
-        shell: bash
-        run: |
-            pypy3 -m pip install .[test,all-plugins-pypy]
-      - name: Run Unit tests
-        run: |
-            pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}
+    name: PyPy Test Suite
+    uses: ./.github/workflows/pypy_tests.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             invoke test --installed
 
   cpython:
-    uses: imageio/imageio/.github/workflows/cpython_tests.yml@fix_ci_fail
+    uses: FirefoxMetzger/imageio/.github/workflows/cpython_tests.yml@fix_ci_fail
 
   pypy:
     name: "${{ matrix.os }} / ${{ matrix.pyversion }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,60 +76,7 @@ jobs:
             invoke test --installed
 
   cpython:
-    name: "${{ matrix.os }} / CPython ${{ matrix.pyversion }}"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        include:
-          - name: Linux py37 full
-            os: ubuntu-latest
-            pyversion: '3.7'
-            TEST_UNIT: 1
-            TEST_FULL: 1
-          - name: Use PyAV 10.0.0
-            pyversion: '3.11'
-            PYAV_10_0_0: 1
-        exclude:
-          # exclude 3.11 on windows until we can replicate the
-          # access violation found in CI
-          - os: windows-latest
-            pyversion: '3.11'
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Set up Python ${{ matrix.pyversion }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.pyversion }}
-      - name: Install dependencies for tests
-        shell: bash
-        run: |
-            pip install .[test,all-plugins]
-      - name: Install OpenCV on non-MacOS
-        if: matrix.os != 'macos-latest'
-        run: |
-            pip install opencv-python
-      - name: Install optional dependencies for tests
-        if: matrix.TEST_FULL == 1
-        run: |
-            pip install -q --upgrade simpleitk astropy
-      - name: Downgrade PyAV
-        # PyAV 10.0.0 is needed on py3.11 but has issues, so we only use it on
-        # py3.11 for now
-        if: matrix.PYAV_10_0_0 != 1
-        run: |
-            pip install --upgrade av!=10.0.0
-      - name: Run All Unit tests
-        run: |
-            coverage run -m pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload coverage to Codecov
-        run: |
-          curl -s https://codecov.io/bash | bash
-        shell: bash
+    uses: imageio/imageio/.github/workflows/cpython_tests.yml@master
 
   pypy:
     name: "${{ matrix.os }} / ${{ matrix.pyversion }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,7 @@ concurrency:
 jobs:
   docs-GH:
     name: Build Docs
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - name: Install Dependencies
-      run: |
-        pip install -e .[docs]
-    - name: Build Docs
-      run: sphinx-build -W ./docs ./build
+    uses: ./.github/workflows/build_docs.yml
 
   style:
     name: "Linting"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             invoke test --installed
 
   cpython:
-    uses: imageio/imageio/.github/workflows/cpython_tests.yml@master
+    uses: imageio/imageio/.github/workflows/cpython_tests.yml@fix_ci_fail
 
   pypy:
     name: "${{ matrix.os }} / ${{ matrix.pyversion }}"

--- a/.github/workflows/cpython_tests.yml
+++ b/.github/workflows/cpython_tests.yml
@@ -1,6 +1,7 @@
 name: CPython Test Suite
 
-on: workflow_call
+on: 
+  workflow_call:
 
 jobs:
   cpython:

--- a/.github/workflows/cpython_tests.yml
+++ b/.github/workflows/cpython_tests.yml
@@ -1,0 +1,60 @@
+name: CPython Test Suite
+
+on: workflow_call
+
+jobs:
+  cpython:
+    name: "${{ matrix.os }} / CPython ${{ matrix.pyversion }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        pyversion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        include:
+          - name: Linux py37 full
+            os: ubuntu-latest
+            pyversion: '3.7'
+            TEST_UNIT: 1
+            TEST_FULL: 1
+          - name: Use PyAV 10.0.0
+            pyversion: '3.11'
+            PYAV_10_0_0: 1
+        exclude:
+          # exclude 3.11 on windows until we can replicate the
+          # access violation found in CI
+          - os: windows-latest
+            pyversion: '3.11'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Set up Python ${{ matrix.pyversion }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.pyversion }}
+      - name: Install dependencies for tests
+        shell: bash
+        run: |
+            pip install .[test,all-plugins]
+      - name: Install OpenCV on non-MacOS
+        if: matrix.os != 'macos-latest'
+        run: |
+            pip install opencv-python
+      - name: Install optional dependencies for tests
+        if: matrix.TEST_FULL == 1
+        run: |
+            pip install -q --upgrade simpleitk astropy
+      - name: Downgrade PyAV
+        # PyAV 10.0.0 is needed on py3.11 but has issues, so we only use it on
+        # py3.11 for now
+        if: matrix.PYAV_10_0_0 != 1
+        run: |
+            pip install --upgrade av!=10.0.0
+      - name: Run All Unit tests
+        run: |
+            coverage run -m pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage to Codecov
+        run: |
+          curl -s https://codecov.io/bash | bash
+        shell: bash

--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# This action runs through ImageIO's continous integration pipeline. It
+# performs the following checks:
+# 
+# - Linting/Style (Black)
+# - Invokes the unit tests in no-internet mode on python 3.8
+# - runs unit test on cypthon in matrix mode (python 3.X) x (3 major OS)
+# - runs unit tests on pypy in matrix mode (pypy 3.X) x (3 major OS)
+
+
+on:
+  workflow_call:
+
+jobs:
+  pypy:
+    name: "${{ matrix.os }} / ${{ matrix.pyversion }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        pyversion: ["pypy-3.8", "pypy-3.9"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up pypy
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ matrix.pyversion }}"
+      - name: MacOS Numpy Fix
+        if: runner.os == 'macOS'
+        run: |
+            brew install openblas
+            OPENBLAS="$(brew --prefix openblas)" pypy3 -m pip install numpy
+      - name: Install dependencies
+        shell: bash
+        run: |
+            pypy3 -m pip install .[test,all-plugins-pypy]
+      - name: Run Unit tests
+        run: |
+            pytest -v --github-username "anything" --github-token ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -1,13 +1,4 @@
-name: CI
-
-# This action runs through ImageIO's continous integration pipeline. It
-# performs the following checks:
-# 
-# - Linting/Style (Black)
-# - Invokes the unit tests in no-internet mode on python 3.8
-# - runs unit test on cypthon in matrix mode (python 3.X) x (3 major OS)
-# - runs unit tests on pypy in matrix mode (pypy 3.X) x (3 major OS)
-
+name: PyPy Test Suite
 
 on:
   workflow_call:

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -529,7 +529,7 @@ def test_write_float_fps(test_images):
     fps = 3.5
     frames = iio.imread(test_images / "cockatoo.mp4", plugin="pyav")
     buffer = iio.imwrite(
-        "<bytes>", frames, extension=".mp4", codec="h264", plugin="pyav", fps=3.5
+        "<bytes>", frames, extension=".mp4", codec="h264", plugin="pyav", fps=fps
     )
 
     assert iio.immeta(buffer, plugin="pyav")["fps"] == fps


### PR DESCRIPTION
This PR cleans up our CI and CD scripts. It removes pypy 3.7 from the test matrix (no longer downloadable) and combines the config that both the CI and the CD use when running the test suite and building the docs. This way, we can be more confident that what we test on the PR is the same as what is tested when releasing.