### PR TITLE
FEAT: Add `n_images` to `ImageProperties`

### DIFF
--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -305,7 +305,6 @@ class LegacyPlugin(PluginV3):
         return ImageProperties(
             shape=image.shape,
             dtype=image.dtype,
-            n_images=None,
             is_batch=False,
         )
 

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -296,7 +296,8 @@ class LegacyPlugin(PluginV3):
         return ImageProperties(
             shape=image.shape,
             dtype=image.dtype,
-            is_batch=True if index is None else False,
+            n_images=image.shape[0] if index is Ellipsis else None,
+            is_batch=index is Ellipsis,
         )
 
     def get_meta(self, *, index=None):

--- a/imageio/core/legacy_plugin_wrapper.py
+++ b/imageio/core/legacy_plugin_wrapper.py
@@ -291,13 +291,22 @@ class LegacyPlugin(PluginV3):
             index = _legacy_default_index(self._format)
 
         # for backwards compatibility ... actually reads pixel data :(
-        image = self.read(index=index)
+        if index is Ellipsis:
+            image = self.read(index=0)
+            n_images = self.legacy_get_reader().get_length()
+            return ImageProperties(
+                shape=(n_images, *image.shape),
+                dtype=image.dtype,
+                n_images=n_images,
+                is_batch=True,
+            )
 
+        image = self.read(index=index)
         return ImageProperties(
             shape=image.shape,
             dtype=image.dtype,
-            n_images=image.shape[0] if index is Ellipsis else None,
-            is_batch=index is Ellipsis,
+            n_images=None,
+            is_batch=False,
         )
 
     def get_meta(self, *, index=None):

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -20,6 +20,8 @@ class ImageProperties:
         The shape of the loaded ndimage.
     dtype : np.dtype
         The dtype of the loaded ndimage.
+    n_images : int or None
+        Number of images in the file if ``index=...``, `None` for single images
     is_batch : bool
         If True, the first dimension of the ndimage represents a batch dimension
         along which several images are stacked.
@@ -35,6 +37,7 @@ class ImageProperties:
 
     shape: Tuple[int, ...]
     dtype: np.dtype
+    n_images: Optional[int]
     is_batch: bool = False
     spacing: Optional[tuple] = None
 

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -21,7 +21,7 @@ class ImageProperties:
     dtype : np.dtype
         The dtype of the loaded ndimage.
     n_images : int
-        Number of images in the file if ``index=...``, `None` for single images
+        Number of images in the file if ``index=...``, `None` for single images.
     is_batch : bool
         If True, the first dimension of the ndimage represents a batch dimension
         along which several images are stacked.

--- a/imageio/core/v3_plugin_api.py
+++ b/imageio/core/v3_plugin_api.py
@@ -20,7 +20,7 @@ class ImageProperties:
         The shape of the loaded ndimage.
     dtype : np.dtype
         The dtype of the loaded ndimage.
-    n_images : int or None
+    n_images : int
         Number of images in the file if ``index=...``, `None` for single images
     is_batch : bool
         If True, the first dimension of the ndimage represents a batch dimension
@@ -37,7 +37,7 @@ class ImageProperties:
 
     shape: Tuple[int, ...]
     dtype: np.dtype
-    n_images: Optional[int]
+    n_images: Optional[int] = None
     is_batch: bool = False
     spacing: Optional[tuple] = None
 

--- a/imageio/plugins/opencv.py
+++ b/imageio/plugins/opencv.py
@@ -273,19 +273,28 @@ class OpenCVPlugin(PluginV3):
         if index is None:
             n_images = cv2.imcount(self.file_handle, flags)
             is_batch = n_images > 1
-        elif index is ...:
+        elif index is Ellipsis:
+            n_images = cv2.imcount(self.file_handle, flags)
             is_batch = True
         else:
             is_batch = False
 
         # unfortunately, OpenCV doesn't allow reading shape without reading pixel data
-        img = self.read(index=index, flags=flags, colorspace=colorspace)
+        if is_batch:
+            img = self.read(index=0, flags=flags, colorspace=colorspace)
+            return ImageProperties(
+                shape=(n_images, *img.shape),
+                dtype=img.dtype,
+                n_images=n_images,
+                is_batch=True
+            )
 
+        img = self.read(index=index, flags=flags, colorspace=colorspace)
         return ImageProperties(
             shape=img.shape,
             dtype=img.dtype,
-            n_images = img.shape[0] if is_batch else None,
-            is_batch=is_batch,
+            n_images=None,
+            is_batch=False
         )
 
     def metadata(

--- a/imageio/plugins/opencv.py
+++ b/imageio/plugins/opencv.py
@@ -270,13 +270,22 @@ class OpenCVPlugin(PluginV3):
 
         """
 
+        if index is None:
+            n_images = cv2.imcount(self.file_handle, flags)
+            is_batch = n_images > 1
+        elif index is ...:
+            is_batch = True
+        else:
+            is_batch = False
+
         # unfortunately, OpenCV doesn't allow reading shape without reading pixel data
         img = self.read(index=index, flags=flags, colorspace=colorspace)
 
         return ImageProperties(
             shape=img.shape,
             dtype=img.dtype,
-            is_batch=(index is ...),
+            n_images = img.shape[0] if is_batch else None,
+            is_batch=is_batch,
         )
 
     def metadata(

--- a/imageio/plugins/opencv.py
+++ b/imageio/plugins/opencv.py
@@ -290,9 +290,7 @@ class OpenCVPlugin(PluginV3):
             )
 
         img = self.read(index=index, flags=flags, colorspace=colorspace)
-        return ImageProperties(
-            shape=img.shape, dtype=img.dtype, n_images=None, is_batch=False
-        )
+        return ImageProperties(shape=img.shape, dtype=img.dtype, is_batch=False)
 
     def metadata(
         self, index: int = None, exclude_applied: bool = True

--- a/imageio/plugins/opencv.py
+++ b/imageio/plugins/opencv.py
@@ -230,7 +230,7 @@ class OpenCVPlugin(PluginV3):
 
     def properties(
         self,
-        index: int = 0,
+        index: int = None,
         colorspace: Union[int, str] = None,
         flags: int = cv2.IMREAD_COLOR,
     ) -> ImageProperties:

--- a/imageio/plugins/opencv.py
+++ b/imageio/plugins/opencv.py
@@ -286,15 +286,12 @@ class OpenCVPlugin(PluginV3):
                 shape=(n_images, *img.shape),
                 dtype=img.dtype,
                 n_images=n_images,
-                is_batch=True
+                is_batch=True,
             )
 
         img = self.read(index=index, flags=flags, colorspace=colorspace)
         return ImageProperties(
-            shape=img.shape,
-            dtype=img.dtype,
-            n_images=None,
-            is_batch=False
+            shape=img.shape, dtype=img.dtype, n_images=None, is_batch=False
         )
 
     def metadata(

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -473,5 +473,5 @@ class PillowPlugin(PluginV3):
             shape=shape,
             dtype=dummy.dtype,
             n_images=n_frames if index is Ellipsis else None,
-            is_batch=index is Ellipsis
+            is_batch=index is Ellipsis,
         )

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -433,7 +433,7 @@ class PillowPlugin(PluginV3):
 
         Notes
         -----
-        This does not decode pixel data and is 394fast for large images.
+        This does not decode pixel data and is fast for large images.
 
         """
 
@@ -472,5 +472,6 @@ class PillowPlugin(PluginV3):
         return ImageProperties(
             shape=shape,
             dtype=dummy.dtype,
-            is_batch=True if index is Ellipsis else False,
+            n_images=n_frames if index is Ellipsis else None,
+            is_batch=index is Ellipsis
         )

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -688,7 +688,8 @@ class PyAVPlugin(PluginV3):
         return ImageProperties(
             shape=tuple(shape),
             dtype=_format_to_dtype(frame_template.format),
-            is_batch=True if index is ... else False,
+            n_images=shape[0] if index is ... else None,
+            is_batch=index is ...,
         )
 
     def metadata(

--- a/imageio/plugins/tifffile_v3.py
+++ b/imageio/plugins/tifffile_v3.py
@@ -335,7 +335,9 @@ class TifffilePlugin(PluginV3):
         single page from the selected series. If ``index=Ellipsis``, ``page`` is
         understood as a flat index, i.e., the selection ignores individual
         series inside the file. If ``index=Ellipsis`` and ``page=None`` then
-        global (file-level) properties is returned.
+        global (file-level) properties are returned. If ``index=Ellipsis``
+        and ``page=...``, file-level properties for the flattened index are
+        returned.
 
         Parameters
         ----------
@@ -346,7 +348,8 @@ class TifffilePlugin(PluginV3):
             If ``Ellipsis`` and ``page=None``, return the properties for the
             batch of all ndimages in the file.
         page : int
-            If ``None`` return the properties of the full ndimage. If ``int``,
+            If ``None`` return the properties of the full ndimage. If ``...``
+            return the properties of the flattened index. If ``int``,
             return the properties of the page at the selected index only.
 
         Returns
@@ -368,6 +371,16 @@ class TifffilePlugin(PluginV3):
             props = ImageProperties(
                 shape=(n_series, *target_page.shape),
                 dtype=target_page.dtype,
+                n_images=n_series,
+                is_batch=True,
+                spacing=_get_resolution(target_page)["resolution"],
+            )
+        elif index is Ellipsis and page is Ellipsis:
+            n_pages = len(self._fh.pages)
+            props = ImageProperties(
+                shape=(n_pages, *target_page.shape),
+                dtype=target_page.dtype,
+                n_images=n_pages,
                 is_batch=True,
                 spacing=_get_resolution(target_page)["resolution"],
             )
@@ -375,6 +388,7 @@ class TifffilePlugin(PluginV3):
             props = ImageProperties(
                 shape=target_page.shape,
                 dtype=target_page.dtype,
+                n_images=None,
                 is_batch=False,
                 spacing=_get_resolution(target_page)["resolution"],
             )

--- a/imageio/plugins/tifffile_v3.py
+++ b/imageio/plugins/tifffile_v3.py
@@ -359,7 +359,7 @@ class TifffilePlugin(PluginV3):
 
         """
         index = index or 0
-        page_idx = page or 0
+        page_idx = 0 if page in (None, Ellipsis) else page
 
         if index is Ellipsis:
             target_page = self._fh.pages[page_idx]

--- a/imageio/plugins/tifffile_v3.py
+++ b/imageio/plugins/tifffile_v3.py
@@ -388,7 +388,6 @@ class TifffilePlugin(PluginV3):
             props = ImageProperties(
                 shape=target_page.shape,
                 dtype=target_page.dtype,
-                n_images=None,
                 is_batch=False,
                 spacing=_get_resolution(target_page)["resolution"],
             )

--- a/tests/test_legacy_plugin_wrapper.py
+++ b/tests/test_legacy_plugin_wrapper.py
@@ -50,3 +50,15 @@ def test_list_writing(test_images, tmp_path):
     actual = iio.v3.imread(tmp_path / "test.gif", index=...)
 
     assert np.allclose(actual, expected)
+
+
+def test_properties(test_images):
+    p = iio.v3.improps(test_images / "newtonscradle.gif", plugin="GIF-PIL", index=...)
+    assert p.shape == (36, 150, 200, 4)
+    assert p.n_images == 36
+    assert p.is_batch
+
+    p = iio.v3.improps(test_images / "newtonscradle.gif", plugin="GIF-PIL", index=0)
+    assert p.shape == (150, 200, 4)
+    assert p.n_images is None
+    assert not p.is_batch

--- a/tests/test_opencv.py
+++ b/tests/test_opencv.py
@@ -124,6 +124,7 @@ def test_props(test_images, tmp_path):
     props = iio.improps(test_images / "astronaut.png", plugin="opencv")
     assert props.shape == (512, 512, 3)
     assert props.dtype == np.uint8
+    assert props.n_images is None
     assert props.is_batch is False
 
     img_expected = iio.imread(test_images / "newtonscradle.gif")
@@ -132,7 +133,14 @@ def test_props(test_images, tmp_path):
     props = iio.improps(tmp_path / "test.tiff", plugin="opencv", index=...)
     assert props.shape == (36, 150, 200, 3)
     assert props.dtype == np.uint8
+    assert props.n_images == 36
     assert props.is_batch is True
+
+    props = iio.improps(tmp_path / "test.tiff", plugin="opencv", index=0)
+    assert props.shape == (150, 200, 3)
+    assert props.dtype == np.uint8
+    assert props.n_images is None
+    assert props.is_batch is False
 
 
 def test_metadata(test_images):

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -522,11 +522,13 @@ def test_properties(image_files: Path):
 
     assert properties.shape == (300, 451, 3)
     assert properties.dtype == np.uint8
+    assert properties.n_images is None
 
     # test a ndimage (GIF)
     properties = iio.improps(image_files / "newtonscradle.gif", plugin="pillow")
     assert properties.shape == (36, 150, 200, 3)
     assert properties.dtype == np.uint8
+    assert properties.n_images == 36
     assert properties.is_batch is True
 
     # test a flat gray image
@@ -534,6 +536,7 @@ def test_properties(image_files: Path):
 
     assert properties.shape == (172, 448)
     assert properties.dtype == np.uint8
+    assert properties.n_images is None
 
 
 def test_metadata(test_images):

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -101,16 +101,19 @@ def test_properties(test_images: Path):
         props = plugin.properties()
         assert props.shape == (280, 720, 1280, 3)
         assert props.dtype == np.uint8
+        assert props.n_images == 280
         assert props.is_batch is True
 
         props = plugin.properties(index=4, format="rgb48")
         assert props.shape == (720, 1280, 3)
         assert props.dtype == np.uint16
+        assert props.n_images is None
         assert props.is_batch is False
 
         props = plugin.properties(index=5)
         assert props.shape == (720, 1280, 3)
         assert props.dtype == np.uint8
+        assert props.n_images is None
         assert props.is_batch is False
 
 

--- a/tests/test_tifffile_v3.py
+++ b/tests/test_tifffile_v3.py
@@ -338,7 +338,7 @@ def test_properties(tmp_path):
     assert props.n_images is None
 
     props = iio.improps(filename, index=...)
-    assert props.shape == (1, 6, 255, 255, 3)
+    assert props.shape == (1, 255, 255, 3)
     assert props.n_images == 1
 
     props = iio.improps(filename, index=..., page=...)

--- a/tests/test_tifffile_v3.py
+++ b/tests/test_tifffile_v3.py
@@ -324,15 +324,26 @@ def test_properties(tmp_path):
 
     props = iio.improps(filename)
     assert props.shape == (255, 255, 3)
+    assert props.n_images is None
 
     props = iio.improps(filename, index=...)
     assert props.shape == (1, 255, 255, 3)
+    assert props.n_images == 1
 
     data = np.full((6, 255, 255, 3), 42, dtype=np.uint8)
     iio.imwrite(filename, data)
 
     props = iio.improps(filename, page=3)
     assert props.shape == (255, 255, 3)
+    assert props.n_images is None
+
+    props = iio.improps(filename, index=...)
+    assert props.shape == (1, 6, 255, 255, 3)
+    assert props.n_images == 1
+
+    props = iio.improps(filename, index=..., page=...)
+    assert props.shape == (6, 255, 255, 3)
+    assert props.n_images == 6
 
 
 def test_contigous_writing(tmp_path):


### PR DESCRIPTION
This exposes the number of frames/images in a file via `improps()`.

See also #915.