### PR TITLE
BUG: add `writeable_output=True` to pillow plugin to ensure data is writable by default

### DIFF
--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -49,10 +49,10 @@ def imopen(
             ``I`` for multiple images,
             ``v`` for a single volume,
             ``V`` for multiple volumes,
-            ``?`` for don't care (default)
+            ``?`` for don't care
 
     plugin : str, Plugin, or None
-        The plugin to use. If set to None (default) imopen will perform a
+        The plugin to use. If set to None imopen will perform a
         search for a matching plugin. If not None, this takes priority over
         the provided format hint.
     extension : str
@@ -62,7 +62,7 @@ def imopen(
     format_hint : str
         Deprecated. Use `extension` instead.
     legacy_mode : bool
-        If true (default) use the v2 behavior when searching for a suitable
+        If true use the v2 behavior when searching for a suitable
         plugin. This will ignore v3 plugins and will check ``plugin``
         against known extensions if no plugin with the given name can be found.
     **kwargs : Any

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -630,3 +630,15 @@ def test_png_batch_fail():
 
     with pytest.raises(ValueError):
         iio.imwrite("<bytes>", img, extension=".png", plugin="pillow")
+
+
+def test_writable_output():
+    rng = np.random.default_rng()
+    img = rng.integers(0, 255, (128, 128), dtype=np.uint8)
+    buffer = iio.imwrite("<bytes>", img, extension=".png")
+
+    frame = iio.imread(buffer)
+    assert frame.flags["WRITEABLE"]
+
+    frame = iio.imread(buffer, writeable_output=False)
+    assert not frame.flags["WRITEABLE"]


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/877, https://github.com/imageio/imageio/issues/972

This PR adds the `writeable_output` kwarg to pillow's `read` and `iter` functions. If set to True (default) the plugin will ensure that the returned numpy array is writable, i.e., it will copy the data into a new buffer in cases where pillow would have otherwise returned a read-only array. This has the advantage of allowing in-place modifications of the returned array which makes the plugin backward compatible with v2 and is supposedly less surprising behavior.

It does come with a performance penalty though because we may have to copy the pixel data of a (potentially large) image. If, however, read-only is sufficient, e.g., when we copy the decoded data straight into an image batch (aka. image tensor) this extra copy is unnecessary. In such cases, users can set `writeable_output=False`. The plugin is then allowed to return read-only arrays if this is faster and users can enjoy improved performance.
