### PR TITLE
MAINT: generate images in temporary folders

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -651,8 +651,7 @@ def test_functions(test_images, tmp_path):
         return  # no support for npz format :(
 
     # Test mimsave()
-    fname5 = str(fname3.with_suffix(""))
-    fname5 += "2.npz"
+    fname5 = tmp_path / "newtonscradle2.npz"
     if os.path.isfile(fname5):
         os.remove(fname5)
     assert not os.path.isfile(fname5)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -336,7 +336,6 @@ def test_reader_more(test_images, tmp_path):
 
 
 def test_writer_more(test_images, tmp_path):
-    fname1 = test_images / "cockatoo.mp4"
     fname2 = tmp_path / "cockatoo.out.mp4"
 
     W = iio.save(fname2, "ffmpeg")

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -106,13 +106,13 @@ def test_integer_reader_length(test_images):
     assert True if r else False
 
 
-def test_read_and_write(test_images):
+def test_read_and_write(test_images, tmp_path):
     fname1 = test_images / "cockatoo.mp4"
 
     R = iio.read(fname1, "ffmpeg")
     assert isinstance(R, imageio.plugins.ffmpeg.FfmpegFormat.Reader)
 
-    fname2 = fname1.with_suffix(".out.mp4")
+    fname2 = tmp_path / "cockatoo.out.mp4"
 
     frame1, frame2, frame3 = 41, 131, 227
 
@@ -182,13 +182,13 @@ def test_v3_read(test_images):
     assert frames.shape == (280, 720, 1280, 3)
 
 
-def test_write_not_contiguous(test_images):
+def test_write_not_contiguous(test_images, tmp_path):
     fname1 = test_images / "cockatoo.mp4"
 
     R = iio.read(fname1, "ffmpeg")
     assert isinstance(R, imageio.plugins.ffmpeg.FfmpegFormat.Reader)
 
-    fname2 = fname1.with_suffix(".out.mp4")
+    fname2 = tmp_path / "cockatoo.out.mp4"
 
     # Read
     ims1 = []
@@ -256,10 +256,10 @@ def test_write_audio_default_codec(test_images, tmp_path):
     assert "audio_codec" in meta
 
 
-def test_reader_more(test_images):
+def test_reader_more(test_images, tmp_path):
     fname1 = test_images / "cockatoo.mp4"
 
-    fname3 = fname1.with_suffix(".stub.mp4")
+    fname3 = tmp_path / "cockatoo.stub.mp4"
 
     # Get meta data
     R = iio.read(fname1, "ffmpeg", loop=True)
@@ -335,9 +335,9 @@ def test_reader_more(test_images):
     iio.read(fname1, "ffmpeg", print_info=True)
 
 
-def test_writer_more(test_images):
+def test_writer_more(test_images, tmp_path):
     fname1 = test_images / "cockatoo.mp4"
-    fname2 = fname1.with_suffix(".out.mp4")
+    fname2 = tmp_path / "cockatoo.out.mp4"
 
     W = iio.save(fname2, "ffmpeg")
     with pytest.raises(ValueError):  # Invalid shape

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -243,7 +243,7 @@ def test_default_can_read_and_can_write(tmp_path):
 
 
 @deprecated_test
-def test_format_manager(test_images):
+def test_format_manager(test_images, tmp_path):
     """Test working of the format manager"""
 
     formats = imageio.formats
@@ -266,7 +266,7 @@ def test_format_manager(test_images):
         # assert format.name in fulldocs
 
     fname = test_images / "chelsea.png"
-    fname2 = fname.with_suffix(".noext")
+    fname2 = tmp_path / "chelsea.noext"
     shutil.copy(fname, fname2)
 
     # Check getting

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -17,9 +17,9 @@ def mean(x):
 
 
 @deprecated_test
-def test_format_selection(test_images):
+def test_format_selection(test_images, tmp_path):
     fname1 = test_images / "stent.swf"
-    fname2 = fname1.with_suffix(".out.swf")
+    fname2 = tmp_path / "stent.out.swf"
 
     F = iio.formats["swf"]
     assert F.name == "SWF"
@@ -31,9 +31,9 @@ def test_format_selection(test_images):
 
 def test_reading_saving(test_images, tmp_path):
     fname1 = test_images / "stent.swf"
-    fname2 = fname1.with_suffix(".out.swf")
-    fname3 = fname1.with_suffix(".compressed.swf")
-    fname4 = fname1.with_suffix(".out2.swf")
+    fname2 = tmp_path / "stent.out.swf"
+    fname3 = tmp_path / "stent.compressed.swf"
+    fname4 = tmp_path / "stent.out2.swf"
 
     # Read
     R = iio.read(fname1)
@@ -136,9 +136,9 @@ def test_read_from_url():
 
 
 @deprecated_test
-def test_invalid(test_images):
+def test_invalid(test_images, tmp_path):
     fname1 = test_images / "stent.swf"
-    fname2 = fname1.with_suffix(".invalid.swf")
+    fname2 = tmp_path / "stent.invalid.swf"
 
     # Empty file
     with open(fname2, "wb"):
@@ -180,9 +180,9 @@ def test_lowlevel():
     )
 
 
-def test_types(test_images):
+def test_types(test_images, tmp_path):
     fname1 = test_images / "stent.swf"
-    fname2 = fname1.with_suffix(".out3.swf")
+    fname2 = tmp_path / "stent.out3.swf"
 
     for dtype in [
         np.uint8,

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -137,7 +137,6 @@ def test_read_from_url():
 
 @deprecated_test
 def test_invalid(test_images, tmp_path):
-    fname1 = test_images / "stent.swf"
     fname2 = tmp_path / "stent.invalid.swf"
 
     # Empty file
@@ -181,7 +180,6 @@ def test_lowlevel():
 
 
 def test_types(test_images, tmp_path):
-    fname1 = test_images / "stent.swf"
     fname2 = tmp_path / "stent.out3.swf"
 
     for dtype in [


### PR DESCRIPTION
I found some images that were generated in the test images folder during unit tests instead of being generated in their own temporary folders. This PR moves fixes that and generates them in temporary folders instead.