### PR TITLE
BUG: allow incremental write in pillow

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -73,6 +73,7 @@ class PillowPlugin(PluginV3):
         super().__init__(request)
 
         self._image: Image = None
+        self.images_to_write = []
 
         if request.mode.io_mode == IOMode.read:
             try:
@@ -93,6 +94,8 @@ class PillowPlugin(PluginV3):
 
             self._image = Image.open(self._request.get_file())
         else:
+            self.save_args = {}
+
             extension = self.request.extension or self.request.format_hint
             if extension is None:
                 warnings.warn(
@@ -114,6 +117,9 @@ class PillowPlugin(PluginV3):
             ) from None
 
     def close(self) -> None:
+        if len(self.images_to_write) > 0:
+            self._flush_writer()       
+
         if self._image:
             self._image.close()
 
@@ -354,26 +360,34 @@ class PillowPlugin(PluginV3):
         if not is_batch:
             ndimage = ndimage[None, ...]
 
-        pil_frames = list()
         for frame in ndimage:
             pil_frame = Image.fromarray(frame, mode=mode)
             if "bits" in kwargs:
                 pil_frame = pil_frame.quantize(colors=2 ** kwargs["bits"])
-            pil_frames.append(pil_frame)
-        primary_image, other_images = pil_frames[0], pil_frames[1:]
+            self.images_to_write.append(pil_frame)
 
-        if is_batch:
-            save_args["save_all"] = True
-            save_args["append_images"] = other_images
-
-        save_args.update(kwargs)
-        primary_image.save(self._request.get_file(), **save_args)
+        self.save_args.update(kwargs)
 
         if self._request._uri_type == URI_BYTES:
+            self._flush_writer()
             file = cast(BytesIO, self._request.get_file())
             return file.getvalue()
 
         return None
+
+    def _flush_writer(self):
+        if len(self.images_to_write) == 0:
+            return
+        
+        primary_image = self.images_to_write.pop(0)
+
+        if len(self.images_to_write) > 0:
+            self.save_args["save_all"] = True
+            self.save_args["append_images"] = self.images_to_write
+
+        primary_image.save(self._request.get_file(), **self.save_args)
+        self.images_to_write.clear()
+        self.save_args = {}
 
     def get_meta(self, *, index=0) -> Dict[str, Any]:
         return self.metadata(index=index, exclude_applied=False)

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -327,11 +327,14 @@ class PillowPlugin(PluginV3):
                 "(in ms) instead, e.g. `fps=50` == `duration=20` (1000 * 1/50)."
             )
 
-        extension = self.request.extension or self.request.format_hint
+        if "format" not in self.save_args:
+            extension = self.request.extension or self.request.format_hint
+            self.save_args["format"] = format or Image.registered_extensions()[extension]
+        elif format is None or format == self.save_args["format"]:
+            pass
+        else:
+            raise ValueError("Can't change `format` after the first image was written.")
 
-        save_args = {
-            "format": format or Image.registered_extensions()[extension],
-        }
 
         if isinstance(ndimage, list):
             ndimage = np.stack(ndimage, axis=0)


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/974

This PR adds the ability to write multi-frame formats (mainly thinking about GIF) incrementally when using pillow. The old (v2) pillow plugin was capable of doing this by manually writing to the output stream. The v3 plugin lost that ability (pillow doesn't natively do incremental writing afaik) and this went unnoticed until now.

The way this works under the hood is that we aggregate the images (in `images_to_write`) and output settings (in `save_args`) and delay writing to the stream until the `imopen` context goes out of scope. This implementation _might_ cause memory issues when writing large images, but - to be honest - if you feel the need to write several GB to a single GIF you probably shouldn't use Python for this anyway 🤷‍♂️.