### PR TITLE
DOC: Fix typo in PyPI link tooltip

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,7 +184,7 @@ html_theme_options = {
             "icon": "fab fa-github-square",
         },
         {
-            "name": "Pipy",
+            "name": "PyPI",
             "url": "https://pypi.org/project/imageio/",
             "icon": "fas fa-box",
         },


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/969

Fixes a typo in the docs.