### PR TITLE
TEST: skip trim filter test on MacOS and pypy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,16 @@
-import os
-import sys
-import shutil
-from pathlib import Path
-from functools import wraps
 import contextlib
+import os
+import shutil
+import sys
 import warnings
+from functools import wraps
+from pathlib import Path
+
 import pytest
 
 import imageio as iio
+
+IS_PYPY = "__pypy__" in sys.builtin_module_names
 
 
 def pytest_configure(config):

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -580,7 +580,8 @@ def test_keyframe_intervals(test_images):
 # the maintainer of pyAV hasn't responded to my bug reports in over 4 months so
 # I am disabling this test on pypy to stay sane.
 @pytest.mark.skipif(
-    IS_PYPY and IS_MACOS, reason="Using filters in pyAV sometimes causes segfaults when run on Pypy."
+    IS_PYPY and IS_MACOS,
+    reason="Using filters in pyAV sometimes causes segfaults when run on Pypy.",
 )
 def test_trim_filter(test_images):
     # this is a regression test for:

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -1,18 +1,23 @@
-import pytest
-from pathlib import Path
-import imageio.v3 as iio
-import numpy as np
 import io
+import platform
 import warnings
 from contextlib import ExitStack
+from pathlib import Path
+
+import numpy as np
+import pytest
+from conftest import IS_PYPY
+
+import imageio.v3 as iio
 
 av = pytest.importorskip("av", reason="pyAV is not installed.")
 
 from av.video.format import names as video_format_names  # type: ignore # noqa: E402
+
 from imageio.plugins.pyav import _format_to_dtype  # noqa: E402
 
-
 IS_AV_10_0_0 = tuple(int(x) for x in av.__version__.split(".")) == (10, 0, 0)
+IS_MACOS = platform.system() == "Darwin"
 
 
 def test_mp4_read(test_images: Path):
@@ -572,6 +577,11 @@ def test_keyframe_intervals(test_images):
     assert np.max(np.diff(key_dist)) <= 5
 
 
+# the maintainer of pyAV hasn't responded to my bug reports in over 4 months so
+# I am disabling this test on pypy to stay sane.
+@pytest.mark.skipif(
+    IS_PYPY and IS_MACOS, reason="Using filters in pyAV sometimes causes segfaults when run on Pypy."
+)
 def test_trim_filter(test_images):
     # this is a regression test for:
     # https://github.com/imageio/imageio/issues/951


### PR DESCRIPTION
This PR excludes a test from the CI that I suspect to cause sporadic failures. It tests if FFMPEGs trim filter accessible via PyAV works correctly. On MacOS+Pypy it sometimes causes segfaults, which I suspect come from how pyAV hands data over to FFMPEG.

Nothing much we can do here to fix this, and I am still hoping to get a response on a more relevant pyAV bug so the hopes of getting a fix upstream soon are not great. Instead, I will disable this test for now especially considering that you have to have a really intense use-case to hit that particular combination and in that case probably know what you are doing anyway.