### PR TITLE
BUG: Avoid exception when n_frames is not set by Pillow

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -538,8 +538,9 @@ class PillowPlugin(PluginV3):
         height: int = self._image.height
         shape: Tuple[int, ...] = (height, width)
 
-        n_frames: int = self._image.n_frames
+        n_frames: Optional[int] = None
         if index is ...:
+            n_frames = getattr(self._image, "n_frames", 1)
             shape = (n_frames, *shape)
 
         dummy = np.asarray(Image.new(mode, (1, 1)))
@@ -550,6 +551,6 @@ class PillowPlugin(PluginV3):
         return ImageProperties(
             shape=shape,
             dtype=dummy.dtype,
-            n_images=n_frames if index is Ellipsis else None,
+            n_images=n_frames,
             is_batch=index is Ellipsis,
         )

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -538,6 +538,13 @@ def test_properties(image_files: Path):
     assert properties.dtype == np.uint8
     assert properties.n_images is None
 
+    # test an image format that doesn't have n_frames
+    properties = iio.improps(image_files / "rommel.jpg", plugin="pillow")
+    assert properties.n_images is None
+
+    properties = iio.improps(image_files / "rommel.jpg", plugin="pillow", index=...)
+    assert properties.n_images == 1
+
 
 def test_metadata(test_images):
     meta = iio.immeta(test_images / "newtonscradle.gif")


### PR DESCRIPTION
Resolves #958

Not all Pillow image formats have `n_frames` defined. See https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.n_frames
> The number of frames in this image.
>
> This attribute is only defined by image plugins that support animated images. Plugins may leave this attribute undefined if they don’t support loading animated images, even if the given format supports animated images.
>
> Given that this attribute is not present for all images use `getattr(image, "n_frames", 1)` to check the number of frames that Pillow is aware of in an image regardless of its format.