### PR TITLE
DEV: refactor invoke in no-internet CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             rm -rf ./imageio ./build ./egg-info
       - name: Unit tests
         run: |
-            pytest -v -m not needs_internet --cov imageio --cov-config .coveragerc --cov-report
+            pytest -v -m not needs_internet
         env:
           IMAGEIO_NO_INTERNET: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             rm -rf ./imageio ./build ./egg-info
       - name: Unit tests
         run: |
-            pytest -v -m not needs_internet
+            pytest -v -m "not needs_internet"
         env:
           IMAGEIO_NO_INTERNET: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
             rm -rf ./imageio ./build ./egg-info
       - name: Unit tests
         run: |
-            invoke test --installed
+            pytest -v -m not needs_internet --cov imageio --cov-config .coveragerc --cov-report
+        env:
+          IMAGEIO_NO_INTERNET: 1
 
   cpython:
     name: CPython Test Suite

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ cpython_only_plugins = {
 extras_require = {
     "build": ["wheel"],
     "linting": ["black", "flake8"],
-    "test": ["invoke", "pytest", "pytest-cov", "fsspec[github]"],
+    "test": ["pytest", "pytest-cov", "fsspec[github]"],
     "docs": ["sphinx<6", "numpydoc", "pydata-sphinx-theme"],
     **plugins,
     **cpython_only_plugins,

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -6,6 +6,16 @@ one can simply add tasks by adding files.
 import os
 
 from invoke import Collection, Task
+import warnings
+
+
+warnings.warn(
+    "Invoke scripts are deprecated and will be removed in ImageIO v3. They"
+    " have been superseeded by CI scripts and there is currently no plan to"
+    " keep invoke. If you want to keep them, please open a new issue so"
+    " that we can discuss.",
+    DeprecationWarning
+)
 
 # Get root directory of the package
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -14,7 +14,7 @@ warnings.warn(
     " have been superseeded by CI scripts and there is currently no plan to"
     " keep invoke. If you want to keep them, please open a new issue so"
     " that we can discuss.",
-    DeprecationWarning
+    DeprecationWarning,
 )
 
 # Get root directory of the package

--- a/tasks/__main__.py
+++ b/tasks/__main__.py
@@ -12,7 +12,7 @@ warnings.warn(
     " have been superseeded by CI scripts and there is currently no plan to"
     " keep invoke. If you want to keep them, please open a new issue so"
     " that we can discuss.",
-    DeprecationWarning
+    DeprecationWarning,
 )
 
 cmd = ["invoke"]

--- a/tasks/__main__.py
+++ b/tasks/__main__.py
@@ -4,6 +4,16 @@ Make this module itself executable as an alias for invoke.
 
 import sys
 import subprocess
+import warnings
+
+
+warnings.warn(
+    "Invoke scripts are deprecated and will be removed in ImageIO v3. They"
+    " have been superseeded by CI scripts and there is currently no plan to"
+    " keep invoke. If you want to keep them, please open a new issue so"
+    " that we can discuss.",
+    DeprecationWarning
+)
 
 cmd = ["invoke"]
 if len(sys.argv) == 1:


### PR DESCRIPTION
Invoke's latest release broke our CI that simulates running ImageIO without internet. It is the only place where we still rely on invoke so I decided to refactor. Now we call pytest directly (still one line) and have one element less in CI that can break.