### PR TITLE
FEAT: Decode gray 16-bit PNG as uint16 (not int32) if pillow allows

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -41,9 +41,6 @@ from ..core.v3_plugin_api import ImageProperties, PluginV3
 from ..typing import ArrayLike
 
 
-PILLOW_VERSION = tuple(int(x) for x in Image.__version__.split("."))
-
-
 def _exif_orientation_transform(orientation: int, mode: str) -> Callable:
     # get transformation that transforms an image from a
     # given EXIF orientation into the standard orientation

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -286,7 +286,7 @@ class PillowPlugin(PluginV3):
 
             if sys.byteorder == "little":
                 desired_mode = "I;16"
-            else: # pragma: no cover
+            else:  # pragma: no cover
                 # can't test big-endian in GH-Actions
                 desired_mode = "I;16B"
 
@@ -299,8 +299,8 @@ class PillowPlugin(PluginV3):
                     "version of pillow which will make this warning dissapear.",
                     UserWarning,
                 )
-            else: # pragma: no cover
-                # Let pillow know that it is okay to return 16-bit 
+            else:  # pragma: no cover
+                # Let pillow know that it is okay to return 16-bit
                 image.mode = desired_mode
 
         image = np.asarray(image)

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -275,6 +275,10 @@ class PillowPlugin(PluginV3):
             # adjust for pillow9 changes
             # see: https://github.com/python-pillow/Pillow/issues/5929
             image = image.convert(image.palette.mode)
+        elif image.format == "PNG" and image.mode == "I":
+            # grayscale PNG is big-endian 16-bit, not 32-bit we can unpack
+            # as 16 bit directly and save a copy.
+            image.mode = "I;16B"
         image = np.asarray(image)
 
         meta = self.metadata(index=self._image.tell(), exclude_applied=False)

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -286,22 +286,21 @@ class PillowPlugin(PluginV3):
 
             if sys.byteorder == "little":
                 desired_mode = "I;16"
-            else:
+            else: # pragma: no cover
+                # can't test big-endian in GH-Actions
                 desired_mode = "I;16B"
 
             try:
                 Image._getdecoder(desired_mode, "raw", "I;16B")
             except ValueError:
-                # pillow can't decode into 16-bit yet, use its 32-bit default
-                # instead and warn the user (has caused confusion in the past)
                 warnings.warn(
                     "Loading 16-bit (uint16) PNG as int32 due to limitations "
                     "in pillow's PNG decoder. This will be fixed in a future "
                     "version of pillow which will make this warning dissapear.",
                     UserWarning,
                 )
-            else:
-                # Let pillow know that it is okay to return 16-bit
+            else: # pragma: no cover
+                # Let pillow know that it is okay to return 16-bit 
                 image.mode = desired_mode
 
         image = np.asarray(image)

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -28,14 +28,20 @@ Methods
 
 """
 
-from io import BytesIO
-from typing import Callable, Optional, Dict, Any, Tuple, cast, Iterator, Union, List
-import numpy as np
-from PIL import Image, UnidentifiedImageError, ImageSequence, ExifTags  # type: ignore
-from ..core.request import Request, IOMode, InitializationError, URI_BYTES
-from ..core.v3_plugin_api import PluginV3, ImageProperties
+import sys
 import warnings
+from io import BytesIO
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, cast
+
+import numpy as np
+from PIL import ExifTags, Image, ImageSequence, UnidentifiedImageError  # type: ignore
+
+from ..core.request import URI_BYTES, InitializationError, IOMode, Request
+from ..core.v3_plugin_api import ImageProperties, PluginV3
 from ..typing import ArrayLike
+
+
+PILLOW_VERSION = tuple(int(x) for x in Image.__version__.split("."))
 
 
 def _exif_orientation_transform(orientation: int, mode: str) -> Callable:
@@ -276,9 +282,31 @@ class PillowPlugin(PluginV3):
             # see: https://github.com/python-pillow/Pillow/issues/5929
             image = image.convert(image.palette.mode)
         elif image.format == "PNG" and image.mode == "I":
-            # grayscale PNG is big-endian 16-bit, not 32-bit we can unpack
-            # as 16 bit directly and save a copy.
-            image.mode = "I;16B"
+            # By default, pillows unpacks 16-bit grayscale PNG into 32-bit
+            # integers due to limited 16-bit support in pillow itself. However,
+            # recent versions can directly unpack into a 16-bit buffer, which is
+            # more correct (and more efficient) in our scenario.
+
+            if sys.byteorder == "little":
+                desired_mode = "I;16"
+            else:
+                desired_mode = "I;16B"
+
+            try:
+                Image._getdecoder(desired_mode, "raw", "I;16B")
+            except ValueError:
+                # pillow can't decode into 16-bit yet, use its 32-bit default
+                # instead and warn the user (has caused confusion in the past)
+                warnings.warn(
+                    "Loading 16-bit (uint16) PNG as int32 due to limitations "
+                    "in pillow's PNG decoder. This will be fixed in a future "
+                    "version of pillow which will make this warning dissapear.",
+                    UserWarning,
+                )
+            else:
+                # Let pillow know that it is okay to return 16-bit
+                image.mode = desired_mode
+
         image = np.asarray(image)
 
         meta = self.metadata(index=self._image.tell(), exclude_applied=False)

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -115,7 +115,9 @@ def test_png_16bit(test_images, tmp_path):
     im2 = iio.imread(tmp_path / "2.png", plugin="pillow")
     assert im2.dtype == np.uint8
 
-    im3 = iio.imread(tmp_path / "1.png", plugin="pillow")
+    with pytest.warns(UserWarning):
+        im3 = iio.imread(tmp_path / "1.png", plugin="pillow")
+
     assert im3.dtype == np.int32
 
 

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -17,6 +17,11 @@ from imageio.plugins.pyav import _format_to_dtype  # noqa: E402
 
 IS_AV_10_0_0 = tuple(int(x) for x in av.__version__.split(".")) == (10, 0, 0)
 
+# the maintainer of pyAV hasn't responded to my bug reports in over 4 months so
+# I am disabling test on pypy to stay sane.
+if IS_PYPY:
+    pytest.skip("pyAV sometimes causes segfaults on Pypy.")
+
 
 def test_mp4_read(test_images: Path):
     with av.open(str(test_images / "cockatoo.mp4"), "r") as container:
@@ -575,11 +580,6 @@ def test_keyframe_intervals(test_images):
     assert np.max(np.diff(key_dist)) <= 5
 
 
-# the maintainer of pyAV hasn't responded to my bug reports in over 4 months so
-# I am disabling this test on pypy to stay sane.
-@pytest.mark.skipif(
-    IS_PYPY, reason="Using the trim filter in pyAV sometimes causes segfaults on Pypy."
-)
 def test_trim_filter(test_images):
     # this is a regression test for:
     # https://github.com/imageio/imageio/issues/951

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -20,7 +20,7 @@ IS_AV_10_0_0 = tuple(int(x) for x in av.__version__.split(".")) == (10, 0, 0)
 # the maintainer of pyAV hasn't responded to my bug reports in over 4 months so
 # I am disabling test on pypy to stay sane.
 if IS_PYPY:
-    pytest.skip("pyAV sometimes causes segfaults on Pypy.")
+    pytest.skip("pyAV sometimes causes segfaults on Pypy.", allow_module_level=True)
 
 
 def test_mp4_read(test_images: Path):


### PR DESCRIPTION
Closes: #982 

By default, pillow will decode 16-bit grayscale PNG as uint32 due to its limited support for transforming 16-bit integer buffers. However, I learned yesterday that it is also possible to directly decode these images into 16-bit big-endian integers (`">u2"`) and it will soon be possible to decode them into 16-bit little-endian (`"<u2"`) as well (xref: https://github.com/python-pillow/Pillow/pull/7125).

As a result, this PR adds the necessary plumbing to (by default) decode a 16-bit grayscale PNG directly into a 16-bit buffer with native endianness. This default change is warranted because `uint16` is the more desirable result so long as we can avoid the internal copy/conversion from `int32`.

This PR also adds a warning if it is not possible to unpack/decode directly into native uint16. I added this because I have now had several reports that users were surprised about this default behavior. The warning might make ImageIO chatty when reading several 16-bit PNGs, so I am happy to take feedback if you want the ability to silence it. In either case, it will automatically disappear if you use a pillow version that includes the aforementioned pillow PR.