### PR TITLE
TEST: remove test from pypy

### DIFF
--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -1,5 +1,4 @@
 import io
-import platform
 import warnings
 from contextlib import ExitStack
 from pathlib import Path

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -17,7 +17,6 @@ from av.video.format import names as video_format_names  # type: ignore # noqa: 
 from imageio.plugins.pyav import _format_to_dtype  # noqa: E402
 
 IS_AV_10_0_0 = tuple(int(x) for x in av.__version__.split(".")) == (10, 0, 0)
-IS_MACOS = platform.system() == "Darwin"
 
 
 def test_mp4_read(test_images: Path):
@@ -580,8 +579,7 @@ def test_keyframe_intervals(test_images):
 # the maintainer of pyAV hasn't responded to my bug reports in over 4 months so
 # I am disabling this test on pypy to stay sane.
 @pytest.mark.skipif(
-    IS_PYPY and IS_MACOS,
-    reason="Using filters in pyAV sometimes causes segfaults when run on Pypy.",
+    IS_PYPY, reason="Using the trim filter in pyAV sometimes causes segfaults on Pypy."
 )
 def test_trim_filter(test_images):
     # this is a regression test for:


### PR DESCRIPTION
I previously removed a pyav test from pypy when run on iOS due to pyav causing segfaults and upstream not addressing these in a timely fashion. This problem doesn't seem to be limited to iOS only, so I am disabling it on pypy entirely to prevent our CI from breaking sproadically.

(xref: https://github.com/imageio/imageio/pull/981)
