### PR TITLE
TEST: Update tests for pillow10

### DIFF
--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -670,6 +670,7 @@ def test_gamma_correction(setup_library, test_images):
         assert im.shape == (512, 768, 3) and im.dtype == "uint8"
 
 
+@pytest.mark.needs_internet
 def test_improps(setup_library, test_images):
     props = iio3.improps(test_images / "kodim03.png", plugin="PNG-FI")
 
@@ -678,6 +679,7 @@ def test_improps(setup_library, test_images):
     assert props.is_batch is False
 
 
+@pytest.mark.needs_internet
 def test_exr_write(setup_library):
     expected = np.full((128, 128, 3), 0.42, dtype=np.float32)
     buffer = iio3.imwrite("<bytes>", expected, extension=".exr")

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -670,7 +670,7 @@ def test_gamma_correction(setup_library, test_images):
         assert im.shape == (512, 768, 3) and im.dtype == "uint8"
 
 
-def test_improps(test_images):
+def test_improps(setup_library, test_images):
     props = iio3.improps(test_images / "kodim03.png", plugin="PNG-FI")
 
     assert props.shape == (512, 768, 3)
@@ -678,7 +678,7 @@ def test_improps(test_images):
     assert props.is_batch is False
 
 
-def test_exr_write():
+def test_exr_write(setup_library):
     expected = np.full((128, 128, 3), 0.42, dtype=np.float32)
     buffer = iio3.imwrite("<bytes>", expected, extension=".exr")
 

--- a/tests/test_legacy_plugin_wrapper.py
+++ b/tests/test_legacy_plugin_wrapper.py
@@ -26,20 +26,20 @@ def test_exception_message_bytes():
 
 
 def test_ellipsis_index(test_images):
-    img = iio.v3.imread(test_images / "chelsea.png", plugin="PNG-FI", index=...)
+    img = iio.v3.imread(test_images / "chelsea.png", plugin="pillow", index=...)
     assert img.shape == (1, 300, 451, 3)
 
     props = iio.v3.improps(
         test_images / "chelsea.png",
-        plugin="PNG-FI",
+        plugin="pillow",
         index=...,
     )
     assert props.shape == (1, 300, 451, 3)
 
     metadata = iio.v3.immeta(
-        test_images / "chelsea.png", plugin="PNG-FI", index=0, exclude_applied=False
+        test_images / "chelsea.png", plugin="pillow", index=0, exclude_applied=False
     )
-    assert metadata == {}
+    assert metadata == {'mode': 'RGB', 'shape': (451, 300)}
 
 
 def test_list_writing(test_images, tmp_path):

--- a/tests/test_legacy_plugin_wrapper.py
+++ b/tests/test_legacy_plugin_wrapper.py
@@ -26,20 +26,20 @@ def test_exception_message_bytes():
 
 
 def test_ellipsis_index(test_images):
-    img = iio.v3.imread(test_images / "chelsea.png", plugin="pillow", index=...)
+    img = iio.v3.imread(test_images / "chelsea.png", plugin="PNG-PIL", index=...)
     assert img.shape == (1, 300, 451, 3)
 
     props = iio.v3.improps(
         test_images / "chelsea.png",
-        plugin="pillow",
+        plugin="PNG-PIL",
         index=...,
     )
     assert props.shape == (1, 300, 451, 3)
 
     metadata = iio.v3.immeta(
-        test_images / "chelsea.png", plugin="pillow", index=0, exclude_applied=False
+        test_images / "chelsea.png", plugin="PNG-PIL", index=0, exclude_applied=False
     )
-    assert metadata == {"mode": "RGB", "shape": (451, 300)}
+    assert metadata == {}
 
 
 def test_list_writing(test_images, tmp_path):

--- a/tests/test_legacy_plugin_wrapper.py
+++ b/tests/test_legacy_plugin_wrapper.py
@@ -39,7 +39,7 @@ def test_ellipsis_index(test_images):
     metadata = iio.v3.immeta(
         test_images / "chelsea.png", plugin="pillow", index=0, exclude_applied=False
     )
-    assert metadata == {'mode': 'RGB', 'shape': (451, 300)}
+    assert metadata == {"mode": "RGB", "shape": (451, 300)}
 
 
 def test_list_writing(test_images, tmp_path):

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -16,6 +16,7 @@ from PIL import Image, ImageSequence, ImageOps, __version__  # type: ignore
 
 PILLOW_VERSION = tuple(int(x) for x in __version__.split("."))
 
+
 @pytest.mark.parametrize(
     "im_npy,im_out,im_comp",
     [


### PR DESCRIPTION
This PR updates one of our unit tests to not break under pillow 10. Pillow10 allows us to read 16-bit grayscale PNGs directly into 16-bit buffers instead of using 32-bit buffers like before.