### PR TITLE
BUG: add bytes to ImageResource typehints

### DIFF
--- a/imageio/typing.py
+++ b/imageio/typing.py
@@ -8,7 +8,7 @@ except ImportError:
     # numpy<1.20 fall back to using ndarray
     from numpy import ndarray as ArrayLike
 
-ImageResource = Union[str, BytesIO, Path, BinaryIO]
+ImageResource = Union[str, bytes, BytesIO, Path, BinaryIO]
 
 
 __all__ = [


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/1024

This PR adds `bytes` as an allowed `ImageResource` input to our type hints. This means that `iio.imopen(b"some bytes")` or `iio.imread(b"some bytes")` should be correctly annotated and/or validated by mypy.