### PR TITLE
Use `TiffPage` properties in TiffFile v3 plugin

### DIFF
--- a/imageio/plugins/tifffile_v3.py
+++ b/imageio/plugins/tifffile_v3.py
@@ -45,8 +45,6 @@ context:
 
 from io import BytesIO
 from typing import Any, Dict, Optional, cast
-import warnings
-import datetime
 
 import numpy as np
 import tifffile
@@ -54,55 +52,6 @@ import tifffile
 from ..core.request import URI_BYTES, InitializationError, Request
 from ..core.v3_plugin_api import ImageProperties, PluginV3
 from ..typing import ArrayLike
-
-
-def _get_resolution(page):
-    """Get the resolution in a py3.7 compatible way"""
-
-    metadata = {
-        # uncomment once py 3.7 reached EoL - in fact, refactor this
-        # function :)
-        # "resolution_unit": page.resolutionunit,
-        # "resolution": page.resolution,
-    }
-
-    if 296 in page.tags:
-        metadata["resolution_unit"] = page.tags[296].value.value
-
-    if 282 in page.tags and 283 in page.tags and 296 in page.tags:
-        resolution_x = page.tags[282].value
-        resolution_y = page.tags[283].value
-        if resolution_x[1] == 0 or resolution_y[1] == 0:
-            warnings.warn(
-                "Ignoring resolution metadata, "
-                "because at least one direction has a 0 denominator.",
-                RuntimeWarning,
-            )
-        else:
-            metadata["resolution"] = (
-                resolution_x[0] / resolution_x[1],
-                resolution_y[0] / resolution_y[1],
-            )
-
-    return metadata
-
-
-def _get_datatime(page):
-    """Get the datetime in a python 3.7 compatible way"""
-
-    metadata = {
-        # uncomment once python 3.7 is EoL
-        # "datetime": page.datetime,
-    }
-
-    try:
-        metadata["datetime"] = datetime.datetime.strptime(
-            page.tags[306].value, "%Y:%m:%d %H:%M:%S"
-        )
-    except KeyError:
-        pass
-
-    return metadata
 
 
 class TifffilePlugin(PluginV3):
@@ -319,9 +268,9 @@ class TifffilePlugin(PluginV3):
                     "description1": target.description1,
                     "description": target.description,
                     "software": target.software,
-                    # update once python 3.7 reached EoL
-                    **_get_resolution(target),
-                    **_get_datatime(target),
+                    "resolution": target.resolution,
+                    "resolution_unit": target.resolutionunit,
+                    "datetime": target.datetime,
                 }
             )
 
@@ -373,7 +322,7 @@ class TifffilePlugin(PluginV3):
                 dtype=target_page.dtype,
                 n_images=n_series,
                 is_batch=True,
-                spacing=_get_resolution(target_page)["resolution"],
+                spacing=target_page.resolution,
             )
         elif index is Ellipsis and page is Ellipsis:
             n_pages = len(self._fh.pages)
@@ -382,14 +331,14 @@ class TifffilePlugin(PluginV3):
                 dtype=target_page.dtype,
                 n_images=n_pages,
                 is_batch=True,
-                spacing=_get_resolution(target_page)["resolution"],
+                spacing=target_page.resolution,
             )
         else:
             props = ImageProperties(
                 shape=target_page.shape,
                 dtype=target_page.dtype,
                 is_batch=False,
-                spacing=_get_resolution(target_page)["resolution"],
+                spacing=target_page.resolution,
             )
 
         return props

--- a/tests/test_tifffile_v3.py
+++ b/tests/test_tifffile_v3.py
@@ -317,7 +317,7 @@ def test_compression(tmp_path):
     assert page_meta["compression"] == 1
 
 
-def test_properties(tmp_path):
+def test_properties(tmp_path, test_images):
     filename = tmp_path / "test.tiff"
     data = np.full((255, 255, 3), 42, dtype=np.uint8)
     iio.imwrite(filename, data)
@@ -344,6 +344,10 @@ def test_properties(tmp_path):
     props = iio.improps(filename, index=..., page=...)
     assert props.shape == (6, 255, 255, 3)
     assert props.n_images == 6
+
+    # read file without resolution tags
+    props = iio.improps(test_images / "multipage_rgb.tif")
+    assert props.spacing == (1.0, 1.0)
 
 
 def test_contigous_writing(tmp_path):

--- a/tests/test_tifffile_v3.py
+++ b/tests/test_tifffile_v3.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 import io
 from copy import deepcopy
+import struct
 
 import imageio.v3 as iio
 from imageio.config import known_plugins, known_extensions
@@ -179,9 +180,51 @@ def test_invalid_resolution_metadata(tmp_path, resolution):
         tags["XResolution"].overwrite(resolution)
         tags["YResolution"].overwrite(resolution)
 
-    read_image = iio.immeta(tmp_path / "test.tif", index=0)
+    with pytest.warns(RuntimeWarning):
+        read_image = iio.immeta(tmp_path / "test.tif", index=0)
     assert read_image["XResolution"] == resolution
     assert read_image["YResolution"] == resolution
+    assert "resolution" not in read_image
+
+
+def test_missing_resolution_metadata(tmp_path):
+    tif_path = tmp_path / "test.tif"
+    data = np.zeros((200, 100), dtype=np.uint8)
+    iio.imwrite(tif_path, data)
+
+    with tifffile.TiffFile(tif_path, mode="r+b") as tif:
+        tags = tif.pages[0].tags
+        xres = tags["XResolution"]
+        tags["YResolution"].overwrite((10, 11))
+
+    with tif_path.open("r+b") as f:
+        # give XResolution tag another ID so it won't be recognized
+        f.seek(xres.offset)
+        f.write(struct.pack("<H", 65000))
+
+    read_image = iio.immeta(tif_path, index=0)
+    assert "XResolution" not in read_image
+    assert read_image["YResolution"] == (10, 11)
+    assert "resolution" not in read_image
+    assert read_image["resolution_unit"] == 1
+
+    tif_path2 = tmp_path / "test2.tif"
+    data2 = np.zeros((200, 100), dtype=np.uint8)
+    iio.imwrite(tif_path2, data2)
+
+    with tifffile.TiffFile(tif_path2, mode="r+b") as tif:
+        tags = tif.pages[0].tags
+        res_u = tags["ResolutionUnit"]
+
+    with tif_path2.open("r+b") as f:
+        # give ResolutionUnit tag another ID so it won't be recognized
+        f.seek(res_u.offset)
+        f.write(struct.pack("<H", 65000))
+
+    read_image2 = iio.immeta(tif_path2, index=0)
+    assert "ResolutionUnit" not in read_image2
+    assert "resolution" not in read_image2
+    assert "resolution_unit" not in read_image2
 
 
 def test_read_bytes():
@@ -347,7 +390,7 @@ def test_properties(tmp_path, test_images):
 
     # read file without resolution tags
     props = iio.improps(test_images / "multipage_rgb.tif")
-    assert props.spacing == (1.0, 1.0)
+    assert props.spacing is None
 
 
 def test_contigous_writing(tmp_path):


### PR DESCRIPTION
According to comments in the source, this was previously not possible due to supporting Python 3.7, which is now EOLed.

Fixes #970 (`properties()` fails for TIFF files without resolution tags).