### PR TITLE
Fix key error in tifffile improps

### DIFF
--- a/imageio/plugins/tifffile_v3.py
+++ b/imageio/plugins/tifffile_v3.py
@@ -373,7 +373,7 @@ class TifffilePlugin(PluginV3):
                 dtype=target_page.dtype,
                 n_images=n_series,
                 is_batch=True,
-                spacing=_get_resolution(target_page)["resolution"],
+                spacing=_get_resolution(target_page).get("resolution"),
             )
         elif index is Ellipsis and page is Ellipsis:
             n_pages = len(self._fh.pages)
@@ -382,14 +382,14 @@ class TifffilePlugin(PluginV3):
                 dtype=target_page.dtype,
                 n_images=n_pages,
                 is_batch=True,
-                spacing=_get_resolution(target_page)["resolution"],
+                spacing=_get_resolution(target_page).get("resolution"),
             )
         else:
             props = ImageProperties(
                 shape=target_page.shape,
                 dtype=target_page.dtype,
                 is_batch=False,
-                spacing=_get_resolution(target_page)["resolution"],
+                spacing=_get_resolution(target_page).get("resolution"),
             )
 
         return props


### PR DESCRIPTION
`_get_resolution` can return None, and `ImageProperties.spacing` is optional. If "resolution" is missing, we should not raise a KeyError, but just set it to None.