### PR TITLE
TEST: handle changes in imageio-ffmpeg

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -26,8 +26,8 @@ webcams and USB cameras. It is based on ffmpeg and is inspired by/based `moviepy
 Parameters for reading
 ----------------------
 fps : scalar
-    The number of frames per second to read the data at. Default None (i.e.
-    read at the file's own fps). One can use this for files with a
+    The number of frames per second of the input stream. Default None (i.e.
+    read at the file's native fps). One can use this for files with a
     variable fps, or in cases where imageio is unable to correctly detect
     the fps. In case of trouble opening camera streams, it may help to set an
     explicit fps value matching a framerate supported by the camera.

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -57,14 +57,12 @@ def test_overload_fps(test_images):
 
     # Less
     r = imageio.get_reader(test_images / "cockatoo.mp4", fps=8)
-    # assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 112  # note the mismatch
     ims = [1 for _ in r]
     assert len(ims) == 114
 
     # More
     r = imageio.get_reader(test_images / "cockatoo.mp4", fps=24)
     ims = [1 for _ in r]
-    # assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 336
     assert len(ims) in (336, 337)
 
     # Do we calculate nframes correctly? To be fair, the reader wont try to
@@ -72,7 +70,7 @@ def test_overload_fps(test_images):
     # makes sure that this works.
     for fps in (8.0, 8.02, 8.04, 8.06, 8.08):
         r = imageio.get_reader(test_images / "cockatoo.mp4", fps=fps)
-        n = int(r._meta["fps"] * r._meta["duration"] + 0.5)
+        n = int(fps * r._meta["duration"] + 0.5)
         i = 0
         try:
             while True:

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -57,14 +57,14 @@ def test_overload_fps(test_images):
 
     # Less
     r = imageio.get_reader(test_images / "cockatoo.mp4", fps=8)
-    assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 112  # note the mismatch
+    # assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 112  # note the mismatch
     ims = [1 for _ in r]
     assert len(ims) == 114
 
     # More
     r = imageio.get_reader(test_images / "cockatoo.mp4", fps=24)
     ims = [1 for _ in r]
-    assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 336
+    # assert int(r._meta["fps"] * r._meta["duration"] + 0.5) == 336
     assert len(ims) in (336, 337)
 
     # Do we calculate nframes correctly? To be fair, the reader wont try to


### PR DESCRIPTION
This PR updates a test of our imageio-ffmpeg plugin to reflect changes in the backend. 

`imageio-ffmpeg` now get FPS metadata from ffmpeg's `fps` field instead of using the output's `tbr` field. As a result, our `reader._meta["fps"]` field now always shows the FPS of the input stream instead of showing the FPS of the "output" stream (which can be "controlled"/hinted by the plugin's `fps` kwarg).

To adapt to this change, we remove all places where we assert that our `fps` kwarg controls `reader._meta["fps"]`.