### PR TITLE
Fixes #992 - Turns the error raising into a conversion

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -387,10 +387,11 @@ class PillowPlugin(PluginV3):
 
         """
         if "fps" in kwargs:
-            raise TypeError(
+            warnings.warn(
                 "The keyword `fps` is no longer supported. Use `duration`"
                 "(in ms) instead, e.g. `fps=50` == `duration=20` (1000 * 1/50)."
             )
+            kwargs['duration'] = 1000 * 1/kwargs.get('fps')
 
         if isinstance(ndimage, list):
             ndimage = np.stack(ndimage, axis=0)

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -391,7 +391,7 @@ class PillowPlugin(PluginV3):
                 "The keyword `fps` is no longer supported. Use `duration`"
                 "(in ms) instead, e.g. `fps=50` == `duration=20` (1000 * 1/50)."
             )
-            kwargs['duration'] = 1000 * 1/kwargs.get('fps')
+            kwargs["duration"] = 1000 * 1 / kwargs.get("fps")
 
         if isinstance(ndimage, list):
             ndimage = np.stack(ndimage, axis=0)

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -389,7 +389,8 @@ class PillowPlugin(PluginV3):
         if "fps" in kwargs:
             warnings.warn(
                 "The keyword `fps` is no longer supported. Use `duration`"
-                "(in ms) instead, e.g. `fps=50` == `duration=20` (1000 * 1/50)."
+                "(in ms) instead, e.g. `fps=50` == `duration=20` (1000 * 1/50).",
+                DeprecationWarning,
             )
             kwargs["duration"] = 1000 * 1 / kwargs.get("fps")
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -260,23 +260,6 @@ def test_gif_gray(test_images, tmp_path):
     )
 
 
-def test_gif_fps_error(test_images, tmp_path):
-    im = iio.imread(
-        test_images / "newtonscradle.gif",
-        plugin="pillow",
-        mode="L",
-    )
-
-    with pytest.raises(TypeError):
-        iio.imwrite(
-            tmp_path / "test.gif",
-            im[..., 0],
-            plugin="pillow",
-            fps=60,
-            mode="L",
-        )
-
-
 def test_gif_irregular_duration(test_images, tmp_path):
     im = iio.imread(
         test_images / "newtonscradle.gif",

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -260,6 +260,23 @@ def test_gif_gray(test_images, tmp_path):
     )
 
 
+def test_gif_fps_warning(test_images, tmp_path):
+    im = iio.imread(
+        test_images / "newtonscradle.gif",
+        plugin="pillow",
+        mode="L",
+    )
+
+    with pytest.warns(DeprecationWarning):
+        iio.imwrite(
+            tmp_path / "test.gif",
+            im[..., 0],
+            plugin="pillow",
+            fps=60,
+            mode="L",
+        )
+
+
 def test_gif_irregular_duration(test_images, tmp_path):
     im = iio.imread(
         test_images / "newtonscradle.gif",


### PR DESCRIPTION
Closes: #992 

So this error raising broke a PyVista function, also any other package that depends on imageio for writing GIFs/MP4s is broken.
The conversion to the new parameter is known, So just demoting it to an warning and doing what is suggested in the message itself automatically solves the issue.

It may be easier than PR every package that depends on this one to update a single parameter...