### PR TITLE
Support HEIF image file

### DIFF
--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -1856,10 +1856,8 @@ extension_list = [
         priority=["tifffile"],
     ),
     FileExtension(
-        name="High Efficiency Image File Format",
-        extension=".heic",
-        priority=["pillow"]
-    )
+        name="High Efficiency Image File Format", extension=".heic", priority=["pillow"]
+    ),
 ]
 extension_list.sort(key=lambda x: x.extension)
 

--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -1855,6 +1855,11 @@ extension_list = [
         extension=".btf",
         priority=["tifffile"],
     ),
+    FileExtension(
+        name="High Efficiency Image File Format",
+        extension=".heic",
+        priority=["pillow"]
+    )
 ]
 extension_list.sort(key=lambda x: x.extension)
 

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -35,7 +35,6 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, 
 
 import numpy as np
 from PIL import ExifTags, GifImagePlugin, Image, ImageSequence, UnidentifiedImageError  # type: ignore
-from pillow_heif import register_heif_opener
 
 from ..core.request import URI_BYTES, InitializationError, IOMode, Request
 from ..core.v3_plugin_api import ImageProperties, PluginV3
@@ -77,7 +76,12 @@ class PillowPlugin(PluginV3):
         super().__init__(request)
 
         # Register HEIF opener for Pillow
-        register_heif_opener()
+        try:
+            from pillow_heif import register_heif_opener
+        except ImportError:
+            pass
+        else:
+            register_heif_opener()
 
         self._image: Image = None
         self.images_to_write = []

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -35,6 +35,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, 
 
 import numpy as np
 from PIL import ExifTags, GifImagePlugin, Image, ImageSequence, UnidentifiedImageError  # type: ignore
+from pillow_heif import register_heif_opener
 
 from ..core.request import URI_BYTES, InitializationError, IOMode, Request
 from ..core.v3_plugin_api import ImageProperties, PluginV3
@@ -74,6 +75,9 @@ class PillowPlugin(PluginV3):
         """
 
         super().__init__(request)
+
+        # Register HEIF opener for Pillow
+        register_heif_opener()
 
         self._image: Image = None
         self.images_to_write = []

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ plugins = {
     "swf": [],
     "tifffile": ["tifffile"],
     "pyav": ["av"],
+    "heif": ["pillow-heif"],
 }
 
 cpython_only_plugins = {

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -709,6 +709,6 @@ def test_writable_output():
 
 @pytest.mark.needs_internet
 def test_heif_remote():
-    url = "https://nokiatech.github.io/heif/content/images/surfer_1440x960.heic"
+    url = "http://github.com/tigranbs/test-heic-images/raw/master/image4.heic"
     im = iio.imread(url, plugin="pillow")
-    assert im.shape == (960, 1440, 3)
+    assert im.shape == (476, 700, 4)

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -710,5 +710,5 @@ def test_writable_output():
 @pytest.mark.needs_internet
 def test_heif_remote():
     url = "https://nokiatech.github.io/heif/content/images/surfer_1440x960.heic"
-    im = iio.imread(url)
+    im = iio.imread(url, plugin="pillow")
     assert im.shape == (960, 1440, 3)

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -705,3 +705,9 @@ def test_writable_output():
 
     frame = iio.imread(buffer, writeable_output=False, plugin="pillow")
     assert not frame.flags["WRITEABLE"]
+
+@pytest.mark.needs_internet
+def test_heif_remote():
+    url = "https://nokiatech.github.io/heif/content/images/surfer_1440x960.heic"
+    im = iio.imread(url)
+    assert im.shape == (960, 1440, 3)

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -706,6 +706,7 @@ def test_writable_output():
     frame = iio.imread(buffer, writeable_output=False, plugin="pillow")
     assert not frame.flags["WRITEABLE"]
 
+
 @pytest.mark.needs_internet
 def test_heif_remote():
     url = "https://nokiatech.github.io/heif/content/images/surfer_1440x960.heic"


### PR DESCRIPTION
Resolves #1021.
The previous pull request #1040 is closed as the redundant commits.
And also, move `pillow-heif` to be a plugin rather than extra requirement of `Pillow` (thanks for the advice of @bigcat88).