### PR TITLE
BUG: Pin pillow below 10.1 to avoid breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ package_data = [
 
 # pinned to > 8.3.2 due to security vulnerability
 # See: https://github.com/advisories/GHSA-98vv-pw6r-q6q4
-install_requires = ["numpy", "pillow>= 8.3.2,<=10.0.0"]
+install_requires = ["numpy", "pillow>= 8.3.2,<10.1.0"]
 
 plugins = {
     "bsdf": [],

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ package_data = [
 
 # pinned to > 8.3.2 due to security vulnerability
 # See: https://github.com/advisories/GHSA-98vv-pw6r-q6q4
-install_requires = ["numpy", "pillow >= 8.3.2"]
+install_requires = ["numpy", "pillow>= 8.3.2,<=10.0.0"]
 
 plugins = {
     "bsdf": [],


### PR DESCRIPTION
Since https://github.com/imageio/imageio/pull/1045 discovered problems beyond `Image.mode` becoming read-only, I am pinning Pillow until we can resolve all the issues that v10.1 introduces.