### PR TITLE
FEAT: Forward constructor kwargs to PyAV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: psf/black@22.12.0
+      - uses: psf/black@24.1.1
         with:
           args: ". --check"
       - name: Install Dependencies

--- a/imageio/plugins/_tifffile.py
+++ b/imageio/plugins/_tifffile.py
@@ -460,9 +460,7 @@ def imread(files, **kwargs):
             return imseq.asarray(**kwargs)
 
 
-def imsave(
-    file, data=None, shape=None, dtype=None, bigsize=2**32 - 2**25, **kwargs
-):
+def imsave(file, data=None, shape=None, dtype=None, bigsize=2**32 - 2**25, **kwargs):
     """Write numpy array to TIFF file.
 
     Refer to the TiffWriter class and member functions for documentation.
@@ -3765,10 +3763,7 @@ class TiffPage(object):
 
         if photometric == PHOTOMETRIC.PALETTE:
             colormap = self.colormap
-            if (
-                colormap.shape[1] < 2**self.bitspersample
-                or self.dtype.char not in "BH"
-            ):
+            if colormap.shape[1] < 2**self.bitspersample or self.dtype.char not in "BH":
                 raise ValueError("cannot apply colormap")
             if uint8:
                 if colormap.max() > 255:

--- a/imageio/plugins/opencv.py
+++ b/imageio/plugins/opencv.py
@@ -30,7 +30,6 @@ images are converted to RGB, RGBA, or grayscale (where applicable) by default.
 
 """
 
-
 import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -276,13 +276,7 @@ class PyAVPlugin(PluginV3):
 
     """
 
-    def __init__(
-        self,
-        request: Request,
-        *,
-        container: str = None,
-        **kwargs
-    ) -> None:
+    def __init__(self, request: Request, *, container: str = None, **kwargs) -> None:
         """Initialize a new Plugin Instance.
 
         See Plugin's docstring for detailed documentation.
@@ -336,7 +330,9 @@ class PyAVPlugin(PluginV3):
                 pass  # read-only, nothing we can do
 
             try:
-                self._container = av.open(file_handle, mode="w", format=container, **kwargs)
+                self._container = av.open(
+                    file_handle, mode="w", format=container, **kwargs
+                )
             except ValueError:
                 raise InitializationError(
                     f"PyAV can not write to `{self.request.raw_uri}`"

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -270,6 +270,11 @@ class PyAVPlugin(PluginV3):
         standard interface to access various the various ImageResources and
         serves them to the plugin as a file object (or file). Check the docs for
         details.
+    container : str
+        Only used during `iio_mode="w"`! If not None, overwrite the default container
+        format chosen by pyav.
+    kwargs : Any
+        Additional kwargs are forwarded to PyAV's constructor.
 
     """
 
@@ -278,6 +283,7 @@ class PyAVPlugin(PluginV3):
         request: Request,
         *,
         container: str = None,
+        **kwargs
     ) -> None:
         """Initialize a new Plugin Instance.
 
@@ -305,9 +311,9 @@ class PyAVPlugin(PluginV3):
                     # HTTP-based streams like DASH. Note that solving streams
                     # like this is temporary until the new request object gets
                     # implemented.
-                    self._container = av.open(request.raw_uri)
+                    self._container = av.open(request.raw_uri, **kwargs)
                 else:
-                    self._container = av.open(request.get_file())
+                    self._container = av.open(request.get_file(), **kwargs)
                 self._video_stream = self._container.streams.video[0]
                 self._decoder = self._container.decode(video=0)
             except av.AVError:
@@ -332,7 +338,7 @@ class PyAVPlugin(PluginV3):
                 pass  # read-only, nothing we can do
 
             try:
-                self._container = av.open(file_handle, mode="w", format=container)
+                self._container = av.open(file_handle, mode="w", format=container, **kwargs)
             except ValueError:
                 raise InitializationError(
                     f"PyAV can not write to `{self.request.raw_uri}`"

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -1,7 +1,6 @@
 """ Test BSDF plugin.
 """
 
-
 import numpy as np
 
 from pytest import raises

--- a/tests/test_fei_tiff.py
+++ b/tests/test_fei_tiff.py
@@ -2,6 +2,7 @@
 
 FEI TIFFs contain metadata as ASCII plaintext at the end of the file.
 """
+
 from __future__ import unicode_literals
 
 import pytest

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -1,5 +1,6 @@
 """ Test fits plugin functionality.
 """
+
 import pytest
 
 import imageio.v2 as iio
@@ -87,9 +88,7 @@ def test_fits_get_reader(normal_plugin_order, tmp_path):
 
     sigma = 10
     xx, yy = np.meshgrid(np.arange(512), np.arange(512))
-    z = (1 / (2 * np.pi * (sigma**2))) * np.exp(
-        -((xx**2) + (yy**2)) / (2 * (sigma**2))
-    )
+    z = (1 / (2 * np.pi * (sigma**2))) * np.exp(-((xx**2) + (yy**2)) / (2 * (sigma**2)))
     img = np.log(z, where=z != 0, out=np.zeros_like(z))
     phdu = fits.PrimaryHDU()
     ihdu = fits.ImageHDU(img)

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -1,5 +1,6 @@
 """ Test gdal plugin functionality.
 """
+
 import pytest
 import imageio
 

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -1,5 +1,6 @@
 """ Test npz plugin functionality.
 """
+
 from __future__ import division
 import numpy as np
 import json

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -519,6 +519,7 @@ def test_rotation_flag_metadata(test_images, tmp_path):
     else:
         pytest.xfail("PyAV v10.0.0+ doesn't extract the rotation flag.")
 
+
 def test_read_filter(test_images):
     image = iio.imread(
         test_images / "cockatoo.mp4",


### PR DESCRIPTION
Closes: https://github.com/imageio/imageio/issues/1059

This PR adds plumbing to forward additional kwargs from `iio.imopen` to `av.open` if the PyAV plugin is used to read the image. Among other things, this allows using `metadata_errors="ignore"` when reading files that could contain non-unicode characters in their metadata.

Since constructor kwargs are only forwarded by `imopen`, using this feature requires using the context manager when reading files. Example:

```python
import imageio.v3 as iio

with iio.imopen("imageio:cockatoo.mp4", "r", plugin="pyav", metadata_errors="ignore") as file:
    frames = file.read()
```