### PR TITLE
Fix incorrect DICOMSeries order

### DIFF
--- a/imageio/plugins/_dicom.py
+++ b/imageio/plugins/_dicom.py
@@ -703,7 +703,10 @@ class DicomSeries(object):
         self._entries.append(dcm)
 
     def _sort(self):
-        self._entries.sort(key=lambda k: (k.InstanceNumber, k.ImagePositionPatient[2]))
+        self._entries.sort(key=lambda k: (
+            k.InstanceNumber, 
+            getattr(k, 'ImagePositionPatient[2]', None)
+        ))
 
     def _finish(self):
         """

--- a/imageio/plugins/_dicom.py
+++ b/imageio/plugins/_dicom.py
@@ -703,7 +703,7 @@ class DicomSeries(object):
         self._entries.append(dcm)
 
     def _sort(self):
-        self._entries.sort(key=lambda k: k.InstanceNumber)
+        self._entries.sort(key=lambda k: (k.InstanceNumber, k.ImagePositionPatient[2]))
 
     def _finish(self):
         """

--- a/imageio/plugins/_dicom.py
+++ b/imageio/plugins/_dicom.py
@@ -703,10 +703,12 @@ class DicomSeries(object):
         self._entries.append(dcm)
 
     def _sort(self):
-        self._entries.sort(key=lambda k: (
-            k.InstanceNumber, 
-            getattr(k, 'ImagePositionPatient[2]', None)
-        ))
+        self._entries.sort(
+            key=lambda k: (
+                k.InstanceNumber,
+                getattr(k, "ImagePositionPatient[2]", None),
+            )
+        )
 
     def _finish(self):
         """


### PR DESCRIPTION
Fixes #1067.
The root cause is the series order in `DicomSeries`.
The whole series shares the identical `InstanceNumber`. When `DicomSeries._sort` is invoked, the sorting is no longer sorted by `InstanceNumber`, but the **filename**:
```python
# File order in local
[
  './DICOM/DICOM/ST000000/SE000001/MR000000',
  './DICOM/DICOM/ST000000/SE000001/MR000001',
  './DICOM/DICOM/ST000000/SE000001/MR000002',
  './DICOM/DICOM/ST000000/SE000001/MR000003',
  './DICOM/DICOM/ST000000/SE000001/MR000004',
  './DICOM/DICOM/ST000000/SE000001/MR000005',
  ...
]
# File order in Google Colab
[
  '/content/DICOM/DICOM/ST000000/SE000001/MR000020',
  '/content/DICOM/DICOM/ST000000/SE000001/MR000014',
  '/content/DICOM/DICOM/ST000000/SE000001/MR000015',
  '/content/DICOM/DICOM/ST000000/SE000001/MR000001',
  '/content/DICOM/DICOM/ST000000/SE000001/MR000011',
  ...
]
```
This makes function `splitSerieIfRequired` splits into 1 series in **local** while 8 series in **Google Colab**.
In summary, the series should not be sorted by **filename**, it should be sorted by the attribute `ImagePositionPatient[2]` (The z-index of the image?) in the DICOM file.