### PR TITLE
Fix bug of #1068 that `getattr` cannot get attribute with index directly

### DIFF
--- a/imageio/plugins/_dicom.py
+++ b/imageio/plugins/_dicom.py
@@ -706,7 +706,11 @@ class DicomSeries(object):
         self._entries.sort(
             key=lambda k: (
                 k.InstanceNumber,
-                getattr(k, "ImagePositionPatient[2]", None),
+                (
+                    k.ImagePositionPatient[2]
+                    if hasattr(k, "ImagePositionPatient")
+                    else None
+                ),
             )
         )
 

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -191,3 +191,15 @@ def test_v3_reading(test_images):
     actual = iio3.imread(test_images / "dicom_file01.dcm")
 
     assert np.allclose(actual, expected)
+
+
+def test_contiguous_dicom_series(test_images, tmp_path):
+    # this is a regression test for
+    # https://github.com/imageio/imageio/issues/1067
+    fname = test_images / "dicom_issue_1067.zip"
+    with ZipFile(fname) as zip_ref:
+        zip_ref.extractall(tmp_path)
+
+    dname = tmp_path / "modified_dicom_sample1"
+    ims = iio.volread(dname, "DICOM")
+    assert ims.shape == (25, 512, 512)


### PR DESCRIPTION
Small fix on PR #1068.
I think I should add the testcase to prove the PR works. Is that possible to expand the test image set?