### PR TITLE
Update pyav.py

### DIFF
--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -808,7 +808,7 @@ class PyAVPlugin(PluginV3):
         Parameters
         ----------
         codec : str
-            The codec to use, e.g. ``"x264"`` or ``"vp9"``.
+            The codec to use, e.g. ``"libx264"`` or ``"vp9"``.
         fps : float
             The desired framerate of the video stream (frames per second).
         pixel_format : str


### PR DESCRIPTION
The documentation for init_video_stream suggests using "x264" but this results in in a no codec error. Replacing that with "libx264" works, so I think the documentation should be updated.