### PR TITLE
Support using offline test image cache w/ `-m "not needs_internet"`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def working_directory(path):
 
 
 @pytest.fixture(scope="session")
-def test_images(request):
+def test_images(request, pytestconfig):
     """A collection of test images.
 
     Note: The images are cached persistently (across test runs) in
@@ -81,6 +81,7 @@ def test_images(request):
     # downloaded once in the beginning
 
     checkout_dir = request.config.cache.get("imageio_test_binaries", None)
+    use_internet = "not needs_internet" not in pytestconfig.getoption("-m")
 
     if checkout_dir is not None and not Path(checkout_dir).exists():
         # cache value set, but cache is gone :( ... recreate
@@ -90,6 +91,8 @@ def test_images(request):
         # download test images and other binaries
         checkout_dir = Path(__file__).parents[1] / ".test_images"
 
+        if not checkout_dir.exists() and not use_internet:
+            pytest.skip("Internet use disabled and `.test_images` not found")
         try:
             checkout_dir.mkdir()
         except FileExistsError:
@@ -103,14 +106,15 @@ def test_images(request):
 
     checkout_dir = Path(checkout_dir)
 
-    with working_directory(checkout_dir):
-        result = os.system("git pull")
+    if use_internet:
+        with working_directory(checkout_dir):
+            result = os.system("git pull")
 
-    if result != 0:
-        request.config.cache.set("imageio_test_binaries", None)
-        raise RuntimeError(
-            "Cache directory is corrupt. Delete `.test_images` at project root."
-        )
+        if result != 0:
+            request.config.cache.set("imageio_test_binaries", None)
+            raise RuntimeError(
+                "Cache directory is corrupt. Delete `.test_images` at project root."
+            )
 
     return checkout_dir
 
@@ -173,12 +177,6 @@ def tmp_userdir(tmp_path):
         os.environ[user_dir_env] = old_user_dir
     else:
         del os.environ[user_dir_env]
-
-
-def pytest_collection_modifyitems(items):
-    for item in items:
-        if "test_images" in getattr(item, "fixturenames", ()):
-            item.add_marker("needs_internet")
 
 
 def deprecated_test(fn):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def test_images(request, pytestconfig):
         checkout_dir = Path(__file__).parents[1] / ".test_images"
 
         if not checkout_dir.exists() and not use_internet:
-            pytest.skip("Internet use disabled and `.test_images` not found")
+            pytest.skip("Internet use disabled and `.test_images` not found.")
         try:
             checkout_dir.mkdir()
         except FileExistsError:


### PR DESCRIPTION
Disable fetching/updating `.test_images` cache when `-m "not needs_internet"` is requested.  Instead, either reuse the existing cache if one is available, or skip the relevant tests.

This preserves the current behavior for the two scenarios: when `-m "not needs_internet"` is not passed, the cache is normally cloned and updated.  If it is passed and cache does not exist, the tests are skipped as before.  However, if one populates the cache first (either via running the tests or manually cloning it) and then passes `-m "not needs_internet"`, the tests run against the existing cache.

Fixes #1078