### PR TITLE
Update tested pypy versions

### DIFF
--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.9", "pypy-3.10"]
+        os: ["ubuntu-latest", "macos-12"]
+        pyversion: ["pypy-3.8", "pypy-3.9", "pypy-3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up pypy

--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -8,7 +8,7 @@ jobs:
     name: "${{ matrix.os }} / ${{ matrix.pyversion }}"
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
         pyversion: ["pypy-3.9", "pypy-3.10"]

--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -8,7 +8,7 @@ jobs:
     name: "${{ matrix.os }} / ${{ matrix.pyversion }}"
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-12"]
         pyversion: ["pypy-3.8", "pypy-3.9", "pypy-3.10"]

--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        pyversion: ["pypy-3.8", "pypy-3.9"]
+        pyversion: ["pypy-3.9", "pypy-3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up pypy


### PR DESCRIPTION
This PR starts testing pypy-3.10 and switches MacOS testing for pypy to `macos-12` from `macos-latest`.

Turns out that GH runners for mac (`macos-latest`) now use an M1 chip. This breaks our tests since not all of our optional dependencies serve precompiled libraries for M1 (in particular FreeImage and PyAV). Until that happens we are "stuck" on x64 for Mac testing and I've switched the runner version.

Also, pypy-3.10 has been out long enough now that all dependencies should support it. Let's see if our tests agree :)