### PR TITLE
Fix CI failures for CPython

### DIFF
--- a/.github/workflows/cpython_tests.yml
+++ b/.github/workflows/cpython_tests.yml
@@ -8,7 +8,7 @@ jobs:
     name: "${{ matrix.os }} / CPython ${{ matrix.pyversion }}"
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         pyversion: ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/cpython_tests.yml
+++ b/.github/workflows/cpython_tests.yml
@@ -8,10 +8,10 @@ jobs:
     name: "${{ matrix.os }} / CPython ${{ matrix.pyversion }}"
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.8", "3.9", "3.10", "3.11"]
+        pyversion: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - name: Linux py310 full
             os: ubuntu-latest

--- a/.github/workflows/cpython_tests.yml
+++ b/.github/workflows/cpython_tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyversion: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        pyversion: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - name: Linux py310 full
             os: ubuntu-latest

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -30,6 +30,9 @@ imageio_ffmpeg = pytest.importorskip(
     "imageio_ffmpeg", reason="imageio-ffmpeg is not installed"
 )
 
+if platform.system() == "darwin" and platform.machine() == "arm64":
+    pytest.skip("M1 is not yet supported by imageio-ffmpeg")
+
 
 def get_ffmpeg_pids():
     pids = set()

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -30,7 +30,7 @@ imageio_ffmpeg = pytest.importorskip(
     "imageio_ffmpeg", reason="imageio-ffmpeg is not installed"
 )
 
-if platform.system() == "darwin" and platform.machine() == "arm64":
+if platform.system() == "darwin" and platform.machine() == "arm":
     pytest.skip("M1 is not yet supported by imageio-ffmpeg")
 
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -30,8 +30,10 @@ imageio_ffmpeg = pytest.importorskip(
     "imageio_ffmpeg", reason="imageio-ffmpeg is not installed"
 )
 
-if platform.system() == "darwin" and platform.machine() == "arm":
-    pytest.skip("M1 is not yet supported by imageio-ffmpeg")
+try:
+    imageio_ffmpeg.get_ffmpeg_version()
+except RuntimeError:
+    pytest.skip("No compatible FFMPEG binary could be found.")
 
 
 def get_ffmpeg_pids():

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -33,7 +33,7 @@ imageio_ffmpeg = pytest.importorskip(
 try:
     imageio_ffmpeg.get_ffmpeg_version()
 except RuntimeError:
-    pytest.skip("No compatible FFMPEG binary could be found.")
+    pytest.skip("No compatible FFMPEG binary could be found.", allow_module_level=True)
 
 
 def get_ffmpeg_pids():

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -5,9 +5,13 @@
 import pytest
 import imageio
 import sys
+import platform
 
 
 pytest.importorskip("imageio_ffmpeg", reason="imageio-ffmpeg is not installed")
+
+if platform.system() == "darwin" and platform.machine() == "arm64":
+    pytest.skip("M1 is not yet supported by imageio-ffmpeg")
 
 
 def dedent(text, dedent=8):

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -6,7 +6,9 @@ import pytest
 import imageio
 import sys
 
-imageio_ffmpeg = pytest.importorskip("imageio_ffmpeg", reason="imageio-ffmpeg is not installed")
+imageio_ffmpeg = pytest.importorskip(
+    "imageio_ffmpeg", reason="imageio-ffmpeg is not installed"
+)
 
 try:
     imageio_ffmpeg.get_ffmpeg_version()

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -10,7 +10,7 @@ import platform
 
 pytest.importorskip("imageio_ffmpeg", reason="imageio-ffmpeg is not installed")
 
-if platform.system() == "darwin" and platform.machine() == "arm64":
+if platform.system() == "darwin" and platform.machine() == "arm":
     pytest.skip("M1 is not yet supported by imageio-ffmpeg")
 
 

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -13,7 +13,7 @@ imageio_ffmpeg = pytest.importorskip(
 try:
     imageio_ffmpeg.get_ffmpeg_version()
 except RuntimeError:
-    pytest.skip("No compatible FFMPEG binary could be found.")
+    pytest.skip("No compatible FFMPEG binary could be found.", allow_module_level=True)
 
 
 def dedent(text, dedent=8):

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -5,13 +5,13 @@
 import pytest
 import imageio
 import sys
-import platform
 
+imageio_ffmpeg = pytest.importorskip("imageio_ffmpeg", reason="imageio-ffmpeg is not installed")
 
-pytest.importorskip("imageio_ffmpeg", reason="imageio-ffmpeg is not installed")
-
-if platform.system() == "darwin" and platform.machine() == "arm":
-    pytest.skip("M1 is not yet supported by imageio-ffmpeg")
+try:
+    imageio_ffmpeg.get_ffmpeg_version()
+except RuntimeError:
+    pytest.skip("No compatible FFMPEG binary could be found.")
 
 
 def dedent(text, dedent=8):

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -73,7 +73,9 @@ def setup_library(tmp_path_factory, vendored_lib):
         os.makedirs(add, exist_ok=True)
         shutil.copytree(vendored_lib, os.path.join(add, "freeimage"))
         fi.load_freeimage()
-        assert fi.has_lib(), "imageio-binaries' version of libfreeimage was not found"
+    
+        if not fi.has_lib():
+            pytest.skip("Could not find a compatible FreeImage version for this OS.")
 
     yield
 

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -73,10 +73,10 @@ def setup_library(tmp_path_factory, vendored_lib):
         os.makedirs(add, exist_ok=True)
         shutil.copytree(vendored_lib, os.path.join(add, "freeimage"))
 
-        try:
-            fi.load_freeimage()
-        except OSError:
-            pytest.skip("Could not find a compatible FreeImage version for this OS.")
+    try:
+        fi.load_freeimage()
+    except OSError:
+        pytest.skip("Could not find a compatible FreeImage version for this OS.")
 
     yield
 

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -72,9 +72,10 @@ def setup_library(tmp_path_factory, vendored_lib):
         add = core.appdata_dir("imageio")
         os.makedirs(add, exist_ok=True)
         shutil.copytree(vendored_lib, os.path.join(add, "freeimage"))
-        fi.load_freeimage()
-    
-        if not fi.has_lib():
+
+        try:
+            fi.load_freeimage()
+        except OSError:
             pytest.skip("Could not find a compatible FreeImage version for this OS.")
 
     yield

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -424,8 +424,8 @@ def test_bayer_write():
 
 def test_sequential_reading(test_images):
     expected_imgs = [
-        iio.imread(test_images / "cockatoo.mp4", index=1),
-        iio.imread(test_images / "cockatoo.mp4", index=5),
+        iio.imread(test_images / "cockatoo.mp4", plugin="pyav", index=1),
+        iio.imread(test_images / "cockatoo.mp4", plugin="pyav", index=5),
     ]
 
     with iio.imopen(test_images / "cockatoo.mp4", "r", plugin="pyav") as img_file:


### PR DESCRIPTION
This PR makes a couple of changes to the tests to respond to recent changes in GH Action runners:
- it includes testing python 3.12 in the test matrix
- it skips tests for FreeImage if we can't find a compatible FreeImage library for the OS (relevant for M1)
- it skips tests for FFMPEG if we can't find a compatible FFMPEG library for the os (relevant for M1)