### PR TITLE
Fix `SeekableFileObject` does not have `readline` when loading HTTP file

### DIFF
--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -697,6 +697,9 @@ class SeekableFileObject:
 
         return res
 
+    def readline(self):
+        yield from self._file.readline()
+
     def tell(self):
         return self._i
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -719,3 +719,10 @@ def test_avif_remote():
     url = "https://github.com/link-u/avif-sample-images/raw/master/fox.profile0.10bpc.yuv420.avif"
     im = iio.imread(url, plugin="pillow")
     assert im.shape == (800, 1204, 3)
+
+
+@pytest.mark.needs_internet
+def test_jpeg_of_issue_1065():
+    url = "https://imagenes.20minutos.es/files/image_1920_1080/uploads/imagenes/2022/09/09/fotografia-a-coruna.jpeg"
+    im = iio.imread(url, plugin="pillow")
+    assert im.shape == (1080, 1920, 3)

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -722,7 +722,10 @@ def test_avif_remote():
 
 
 @pytest.mark.needs_internet
-def test_jpeg_of_issue_1065():
-    url = "https://imagenes.20minutos.es/files/image_1920_1080/uploads/imagenes/2022/09/09/fotografia-a-coruna.jpeg"
+def test_webp_remote():
+    # this is a regression test for
+    # https://github.com/imageio/imageio/issues/1065
+    # the image in the issue is actually a webp image
+    url = "https://github.com/python-pillow/Pillow/raw/main/Tests/images/hopper_orientation_2.webp"
     im = iio.imread(url, plugin="pillow")
-    assert im.shape == (1080, 1920, 3)
+    assert im.shape == (128, 128, 3)


### PR DESCRIPTION
Fixes #1065.
The reason of this issue is `Pillow` sometimes read the image with `.readline` but not only `.read`.

**Update:**
It happens seldomly when loading a WebP image.