### PR TITLE
DEV: Update actions/checkout and actions/setup-python

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -8,8 +8,8 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install Dependencies

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,10 +32,10 @@ jobs:
     outputs:
       make_release: ${{ env.make_release }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Install Dependencies
@@ -77,8 +77,8 @@ jobs:
     if: needs.initial_check.outputs.make_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies for tests
@@ -93,7 +93,7 @@ jobs:
     needs: [cpython_tests, pypy_tests, build_test, docs]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Python Semantic Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
     name: "Linting"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - uses: psf/black@24.1.1
@@ -49,8 +49,8 @@ jobs:
     name: "No-Internet Install"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Install Dependencies

--- a/.github/workflows/cpython_tests.yml
+++ b/.github/workflows/cpython_tests.yml
@@ -27,11 +27,11 @@ jobs:
           - os: windows-latest
             pyversion: '3.11'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Set up Python ${{ matrix.pyversion }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pyversion }}
       - name: Install dependencies for tests

--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -13,9 +13,9 @@ jobs:
         os: ["ubuntu-latest", "macos-12"]
         pyversion: ["pypy-3.8", "pypy-3.9", "pypy-3.10"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up pypy
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.pyversion }}"
       - name: MacOS Numpy Fix


### PR DESCRIPTION
The current versions will run on soon to be unsupported versions of Node
(see https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/).