### PR TITLE
TEST: remove tests for pypy38

### DIFF
--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-12"]
-        pyversion: ["pypy-3.8", "pypy-3.9", "pypy-3.10"]
+        pyversion: ["pypy-3.9", "pypy-3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up pypy


### PR DESCRIPTION
This PR removes our tests for pypy38. Pypy 3.8 has stopped receiving support for the better part of 2 years now. Tests have started to get really flakey, so it is time we say goodbye :)