### PR TITLE
BUG: close video stream when reading

### DIFF
--- a/.github/workflows/cpython_tests.yml
+++ b/.github/workflows/cpython_tests.yml
@@ -42,10 +42,14 @@ jobs:
         if: matrix.os != 'macos-latest'
         run: |
             pip install opencv-python
-      - name: Install RawPy on python > 3.8
+      - name: Install RawPy
         if: matrix.pyversion != '3.8'
         run: |
             pip install rawpy
+      - name: Install pillow-heif
+        if: matrix.pyversion != '3.8' or matrix.os != 'macos-latest'
+        run: |
+            pip install pillow-heif 
       - name: Install optional dependencies for tests
         if: matrix.TEST_FULL == 1
         run: |

--- a/.github/workflows/cpython_tests.yml
+++ b/.github/workflows/cpython_tests.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
             pip install rawpy
       - name: Install pillow-heif
-        if: matrix.pyversion != '3.8' or matrix.os != 'macos-latest'
+        if: matrix.pyversion != '3.8' || matrix.os != 'macos-latest'
         run: |
             pip install pillow-heif 
       - name: Install optional dependencies for tests

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -780,8 +780,12 @@ class PyAVPlugin(PluginV3):
         if is_write and self._video_stream is not None:
             self._flush_writer()
 
+        if self._video_stream is not None:
+            self._video_stream.close()
+
         if self._container is not None:
             self._container.close()
+
         self.request.finish()
 
     def __enter__(self) -> "PyAVPlugin":

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -780,8 +780,11 @@ class PyAVPlugin(PluginV3):
         if is_write and self._video_stream is not None:
             self._flush_writer()
 
-        # if self._video_stream is not None:
-        #     self._video_stream.close()
+        if self._video_stream is not None:
+            try:
+                self._video_stream.close()
+            except ValueError:
+                pass  # stream already closed
 
         if self._container is not None:
             self._container.close()

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -780,8 +780,8 @@ class PyAVPlugin(PluginV3):
         if is_write and self._video_stream is not None:
             self._flush_writer()
 
-        if self._video_stream is not None:
-            self._video_stream.close()
+        # if self._video_stream is not None:
+        #     self._video_stream.close()
 
         if self._container is not None:
             self._container.close()

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,6 @@ plugins = {
     "swf": [],
     "tifffile": ["tifffile"],
     "pyav": ["av"],
-    "pillow-heif": ["pillow-heif"],
 }
 
 cpython_only_plugins = {
@@ -120,6 +119,7 @@ extras_require = {
         "rawpy",
         "numpy>2",
     ],  # rawpy doesn't support python 3.8 (due to numpy > 2 requirement)
+    "pillow-heif": ["pillow-heif"],  # pillow-heif doesn#t support py3.8 on MacOS ARM
 }
 
 extras_require["full"] = sorted(set(chain.from_iterable(extras_require.values())))

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -709,6 +709,7 @@ def test_writable_output():
 
 @pytest.mark.needs_internet
 def test_heif_remote():
+    pytest.importorskip("pillow_heif")
     url = "http://github.com/tigranbs/test-heic-images/raw/master/image4.heic"
     im = iio.imread(url, plugin="pillow")
     assert im.shape == (476, 700, 4)
@@ -716,6 +717,8 @@ def test_heif_remote():
 
 @pytest.mark.needs_internet
 def test_avif_remote():
+    pytest.importorskip("pillow_heif")
+
     url = "https://github.com/link-u/avif-sample-images/raw/master/fox.profile0.10bpc.yuv420.avif"
     im = iio.imread(url, plugin="pillow")
     assert im.shape == (800, 1204, 3)

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -602,7 +602,7 @@ def test_lagging_video_stream(test_images):
     # see: https://github.com/imageio/imageio/issues/1095
 
     with iio.imopen(
-        test_images / "imageio:cockatoo.mp4",
+        test_images / "cockatoo.mp4",
         "r",
         plugin="pyav",
     ) as img_file:

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -13,8 +13,7 @@ import imageio.v3 as iio
 
 av = pytest.importorskip("av", reason="pyAV is not installed.")
 
-from av.video.format import \
-    names as video_format_names  # type: ignore # noqa: E402
+from av.video.format import names as video_format_names  # type: ignore # noqa: E402
 
 from imageio.plugins.pyav import _format_to_dtype  # noqa: E402
 

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -1,4 +1,6 @@
+import gc
 import io
+import multiprocessing
 import warnings
 from contextlib import ExitStack
 from pathlib import Path
@@ -11,7 +13,8 @@ import imageio.v3 as iio
 
 av = pytest.importorskip("av", reason="pyAV is not installed.")
 
-from av.video.format import names as video_format_names  # type: ignore # noqa: E402
+from av.video.format import \
+    names as video_format_names  # type: ignore # noqa: E402
 
 from imageio.plugins.pyav import _format_to_dtype  # noqa: E402
 
@@ -585,3 +588,32 @@ def test_trim_filter(test_images):
     )
 
     assert frames.shape == (20, 720, 1280, 3)
+
+
+def subprocess(func, conn):
+    try:
+        result = func()
+        conn.send(result)
+    except BaseException as e:
+        conn.send(e)
+
+
+def test_lagging_video_stream(test_images):
+    # this is a regression test
+    # see: https://github.com/imageio/imageio/issues/1095
+
+    with iio.imopen(
+        test_images / "imageio:cockatoo.mp4",
+        "r",
+        plugin="pyav",
+    ) as img_file:
+        for idx in range(50):
+            img_file.read(index=idx)
+
+    output, input = multiprocessing.Pipe()
+    proc = multiprocessing.Process(target=subprocess, args=(gc.collect, input))
+
+    proc.start()
+    if not output.poll(timeout=5):
+        proc.kill()
+        raise TimeoutError("Test Subprocess failed to respond in time.")


### PR DESCRIPTION
Closes: #1095

This PR adds logic to the PyAV plugin that closes the video stream during cleanup before closing the container.