### PR TITLE
BUG: Unpin numpy (regression)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ package_data = [
 
 # pinned to > 8.3.2 due to security vulnerability
 # See: https://github.com/advisories/GHSA-98vv-pw6r-q6q4
-install_requires = ["numpy<2.0.0", "pillow>= 8.3.2"]
+install_requires = ["numpy", "pillow>= 8.3.2"]
 
 plugins = {
     "bsdf": [],


### PR DESCRIPTION
Closes: #1097 

This PR unpins numpy so that v2 and newer can be used with ImageIO again. There was no reason for the pin - beyond me resolving a merge conflict and missing the fact that it re-introduced the pin from an earlier version. Let's not do that :)