### PR TITLE
Fix test_video_format_to_dtype for d3d12

### DIFF
--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -144,6 +144,7 @@ def test_video_format_to_dtype():
         "vaapi_vld",
         "d3d11",
         "d3d11va_vld",
+        "d3d12",
         "videotoolbox_vld",
         "vaapi",
         "vaapi_idct",


### PR DESCRIPTION
New video format added in recent ffmpeg releases, should be handled the same way as other hardware accelerated ones.