### PR TITLE
Add video in yuv420 format

### DIFF
--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -180,6 +180,7 @@ EXAMPLE_IMAGES = {
     "chelsea.bsdf": "The chelsea.png in a BSDF file(for testing)",
     "newtonscradle.gif": "Animated GIF of a newton's cradle",
     "cockatoo.mp4": "Video file of a cockatoo",
+    "cockatoo_yuv420.mp4": "Video file of a cockatoo with yuv420 pixel format",
     "stent.npz": "Volumetric image showing a stented abdominal aorta",
     "meadow_cube.jpg": "A cubemap image of a meadow, e.g. to render a skybox.",
 }


### PR DESCRIPTION
Having easy access to a video in the more common yuv420p format allows creating sharable scripts to e.g. optimize performance for getting frames on screen. See e.g. https://github.com/pygfx/pygfx/pull/873. The video file was added in https://github.com/imageio/imageio-binaries/pull/24.

For the record, the current `coclatoo.mp4` is in yuv444p.