### PR TITLE
Fix minimum Python version in docs

### DIFF
--- a/imageio/__init__.py
+++ b/imageio/__init__.py
@@ -8,7 +8,7 @@
 """
 Imageio is a Python library that provides an easy interface to read and
 write a wide range of image data, including animated images, volumetric
-data, and scientific formats. It is cross-platform, runs on Python 3.5+,
+data, and scientific formats. It is cross-platform, runs on Python 3.9+,
 and is easy to install.
 
 Main website: https://imageio.readthedocs.io/


### PR DESCRIPTION
I noticed this was out of date, so here's a fix! Alternatively, I could get rid of the specific version completely to avoid this issue in the future?