### PR TITLE
Support JPEG-XL image file

### DIFF
--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -1865,6 +1865,11 @@ extension_list = [
         extension=".avif",
         priority=["pillow"],
     ),
+    FileExtension(
+        name="JPEG XL Image File Format",
+        extension=".jxl",
+        priority=["pillow"],
+    ),
 ]
 extension_list.sort(key=lambda x: x.extension)
 

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -96,6 +96,12 @@ class PillowPlugin(PluginV3):
         else:
             register_avif_opener()
 
+        # Initialize JXL plugin for Pillow
+        try:
+            import pillow_jxl as _
+        except ImportError:
+            pass
+
         self._image: Image = None
         self.images_to_write = []
 

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ plugins = {
     "spe": [],
     "swf": [],
     "tifffile": ["tifffile"],
+    "pillow-jxl": ["pillow-jxl-plugin"],
 }
 
 cpython_only_plugins = {

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -732,3 +732,18 @@ def test_webp_remote():
     url = "https://github.com/python-pillow/Pillow/raw/main/Tests/images/hopper_orientation_2.webp"
     im = iio.imread(url, plugin="pillow")
     assert im.shape == (128, 128, 3)
+
+
+@pytest.mark.needs_internet
+def test_jxl_read_remote():
+    url = "https://github.com/libjxl/conformance/raw/refs/heads/master/testcases/cafe/input.jxl"
+    im = iio.imread(url, plugin="pillow")
+    assert im.shape == (1600, 1280, 3)
+
+
+def test_jxl_write(test_images, tmp_path):
+    actual = iio.imread(test_images / "chelsea.png")
+    iio.imwrite(tmp_path / "chelsea.jxl", actual, lossless=True)
+
+    target = iio.imread(tmp_path / "chelsea.jxl")
+    assert np.allclose(actual, target)


### PR DESCRIPTION
Resolves #1113.
Enable to read/write operation on JPEG-XL (jxl) image file by registering the Pillow plugin [pillow-jxl-plugin](https://pypi.org/project/pillow-jxl-plugin/).