### PR TITLE
Add bacterial colony tiff

### DIFF
--- a/imageio/core/request.py
+++ b/imageio/core/request.py
@@ -176,6 +176,7 @@ EXAMPLE_IMAGES = {
     "moon.png": "Image showing a portion of the surface of the moon",
     "page.png": "A scanned page of text",
     "text.png": "A photograph of handdrawn text",
+    "bacterial_colony.tif": "Multi-page TIFF image of a bacterial colony",
     "chelsea.zip": "The chelsea.png in a zipfile (for testing)",
     "chelsea.bsdf": "The chelsea.png in a BSDF file(for testing)",
     "newtonscradle.gif": "Animated GIF of a newton's cradle",


### PR DESCRIPTION
In working on examples for https://github.com/pygfx/pygfx/issues/882, I am finding myself writing 

`im_stack = imageio.v3.imread(imageio.core.get_remote_file("images/bacterial_colony.tif"))` 

a bit. 


Is it acceptable to get this in to make it more reachable? 
