### PR TITLE
TEST: remove 3.9 tests and test on Windows

### DIFF
--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "macos-12"]
-        pyversion: ["pypy-3.9", "pypy-3.10"]
+        os: ["ubuntu-latest", "macos-12", "windows-latest"]
+        pyversion: "pypy-3.10"
     steps:
       - uses: actions/checkout@v4
       - name: Set up pypy

--- a/.github/workflows/pypy_tests.yml
+++ b/.github/workflows/pypy_tests.yml
@@ -5,19 +5,18 @@ on:
 
 jobs:
   pypy:
-    name: "${{ matrix.os }} / ${{ matrix.pyversion }}"
+    name: "${{ matrix.os }} / pypy-3.10"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-12", "windows-latest"]
-        pyversion: "pypy-3.10"
     steps:
       - uses: actions/checkout@v4
       - name: Set up pypy
         uses: actions/setup-python@v5
         with:
-          python-version: "${{ matrix.pyversion }}"
+          python-version: "pypy-3.10"
       - name: MacOS Numpy Fix
         if: runner.os == 'macOS'
         run: |


### PR DESCRIPTION
This PR removes pypy3.9 from the test suite. It is no longer officially supported and pillow has stopped releasing prebuilt binaries for it.

The PR also re-introduces windows as an OS for which we run pypy tests. I remember that I removed it because a dependency was not supported there, but I will try to reintroduce it because time has passed. If it doesn't work we will keep running without.