### PR TITLE
Fix CICD failure in stage 'build-docs'

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.12'
     - name: Install Dependencies
       run: |
         pip install -e .[docs]


### PR DESCRIPTION
### Issue
The `build-docs` stage in CICD failed with the following error:
```
Could not import extension sphinx.builders.epub3 (exception: No module named 'imghdr')
```
This occurs because the built-in module `imghdr` was removed in Python 3.13.

### Fix
Downgraded to Python 3.12 to restore compatibility.