### PR TITLE
Fix installation failure of `av==14.1.0` on PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ plugins = {
     "numpy": [],
     "pillow-heif": ["pillow-heif"],
     "pillow": [],
-    "pyav": ["av"],
+    "pyav": ["av!=14.1.0"],
     "simpleitk": [],
     "spe": [],
     "swf": [],


### PR DESCRIPTION
### Issue
During CI/CD testing on PyPy, pyav failed to install. I have inquired about this issue and received a response: [PyAV Discussion #1794](https://github.com/PyAV-Org/PyAV/discussions/1794).

### Fix
Avoid the version `av==14.1.0`.