### PR TITLE
Fix __array_wrap__ deprecation warning

### DIFF
--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -155,12 +155,12 @@ class Array(np.ndarray):
         else:
             self._copy_meta({})
 
-    def __array_wrap__(self, out, context=None):
+    def __array_wrap__(self, out, context=None, return_scalar=True):
         """So that we return a native numpy array (or scalar) when a
         reducting ufunc is applied (such as sum(), std(), etc.)
         """
-        if not out.shape:
-            return out.dtype.type(out)  # Scalar
+        if out.ndim == 0 and return_scalar:
+            return out[()]  # Scalar
         elif out.shape != self.shape:
             return out.view(type=np.ndarray)
         elif not isinstance(out, Array):


### PR DESCRIPTION
Fixes #1125. Added a return_scalar parameter, based on the warning: "DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future." Also used indexing to extract the scalar.

Note that numpy examples suggest defaulting return_scalar to False; however defaulting to true preserves backwards compatibility with the existing behavior, and it seems that numpy 2 always passes the parameter anyway.