### PR TITLE
Fix plugin `ffmpeg` cannot load file with carets

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -173,6 +173,11 @@ def get_exe():  # pragma: no cover
     return imageio_ffmpeg.get_ffmpeg_exe()
 
 
+def get_version():
+    """Return the version of imageio-ffmpeg in tuple."""
+    return tuple(map(int, imageio_ffmpeg.__version__.split(".")))
+
+
 class FfmpegFormat(Format):
     """Read/Write ImageResources using FFMPEG.
 
@@ -299,8 +304,9 @@ class FfmpegFormat(Format):
                 self._filename = self._get_cam_inputname(index)
             else:
                 self._filename = self.request.get_local_filename()
-                # When passed to ffmpeg on command line, carets need to be escaped.
-                self._filename = self._filename.replace("^", "^^")
+                # When passed to imageio-ffmpeg (<0.4.2) on command line, carets need to be escaped.
+                if get_version() < (0, 4, 2):
+                    self._filename = self._filename.replace("^", "^^")
             # Determine pixel format and depth
             self._depth = 3
             if self._dtype.name == "uint8":

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -707,6 +707,7 @@ def test_h264_reading(test_images, tmp_path):
 
     imageio.get_reader(tmp_path / "cockatoo.h264", "ffmpeg")
 
+
 def test_read_path_with_caret(test_images, tmp_path):
     # regression test for
     # https://github.com/imageio/imageio/issues/1133

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -11,7 +11,7 @@ import time
 import warnings
 from io import BytesIO
 from pathlib import Path
-
+import shutil
 import numpy as np
 import pytest
 from conftest import IS_PYPY, deprecated_test
@@ -706,3 +706,10 @@ def test_h264_reading(test_images, tmp_path):
     iio3.imwrite(tmp_path / "cockatoo.h264", frames, plugin="FFMPEG")
 
     imageio.get_reader(tmp_path / "cockatoo.h264", "ffmpeg")
+
+def test_read_path_with_caret(test_images, tmp_path):
+    # regression test for
+    # https://github.com/imageio/imageio/issues/1133
+    shutil.copy(test_images / "cockatoo.mp4", tmp_path / "^cockatoo.mp4")
+    video = iio3.imopen(tmp_path / "^cockatoo.mp4", "r", plugin="FFMPEG")
+    assert video.metadata() is not None


### PR DESCRIPTION
Resolves #1133.

The root cause is `imageio-ffmpeg` accepts caret (^) in the filepath without escaping since version `0.4.2`, that the internal `ffmpeg` module is upgraded to `4.2.2`: https://github.com/imageio/imageio-ffmpeg/releases/tag/v0.4.2. Therefore, the escaping operation would be ignored if `imageio-ffmpeg>=0.4.2`.