### PR TITLE
tests: mark more tests as needing the internet

### DIFF
--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -678,6 +678,7 @@ def test_reverse_read(tmpdir):
     W.close()
 
 
+@pytest.mark.needs_internet
 def test_read_stream(test_images):
     """Test stream reading workaround"""
 

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -439,6 +439,7 @@ def test_sequential_reading(test_images):
     assert np.allclose(actual_imgs, expected_imgs)
 
 
+@pytest.mark.needs_internet
 def test_uri_reading(test_images):
     uri = "https://dash.akamaized.net/dash264/TestCases/2c/qualcomm/1/MultiResMPEG2.mpd"
 
@@ -578,6 +579,7 @@ def test_keyframe_intervals(test_images):
     assert np.max(np.diff(key_dist)) <= 5
 
 
+@pytest.mark.needs_internet
 def test_trim_filter(test_images):
     # this is a regression test for:
     # https://github.com/imageio/imageio/issues/951


### PR DESCRIPTION
These tests use the internet more than others that accept `test_images`, since they use the `imageio:` syntax or a specific URL in the case of `test_uri_reading`.