### PR TITLE
add ffmpeg multiple frame np array support

### DIFF
--- a/imageio/plugins/ffmpeg.py
+++ b/imageio/plugins/ffmpeg.py
@@ -562,9 +562,15 @@ class FfmpegFormat(Format):
 
         def _append_data(self, im, meta):
             # Get props of image
-            h, w = im.shape[:2]
+            if im.ndim == 4:
+                h, w = im.shape[1:3]
+            else:
+                h, w = im.shape[:2]
             size = w, h
-            depth = 1 if im.ndim == 2 else im.shape[2]
+            if im.ndim == 4:
+                depth = im.shape[3]
+            else:
+                depth = 1 if im.ndim == 2 else im.shape[2]
 
             # Ensure that image is in uint8
             im = image_as_uint(im, bitdepth=8)


### PR DESCRIPTION
This modification will support multiple frames numpy array to be sent into ffmpeg pipe at once. The numpy array itself already native allocate the memory that we don't need call python loop iteratively to send frame one by one. This implementation can help us save a bit python calling overhead.