### PR TITLE
Fix the error when `time_base` is set to null

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -45,7 +45,7 @@ Imageio can read from filenames, file objects.
 
 
     # from HTTPS
-    web_image = "https://upload.wikimedia.org/wikipedia/commons/d/d3/Newtons_cradle_animation_book_2.gif"
+    web_image = "https://raw.githubusercontent.com/imageio/test_images/refs/heads/main/newtonscradle.gif"
     frames = iio.imread(web_image, index=None)
 
     # from bytes

--- a/docs/imageio_ext.py
+++ b/docs/imageio_ext.py
@@ -1,5 +1,4 @@
-""" Invoke various functionality for imageio docs.
-"""
+"""Invoke various functionality for imageio docs."""
 
 from pathlib import Path
 

--- a/imageio/core/__init__.py
+++ b/imageio/core/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
-""" This subpackage provides the core functionality of imageio
+"""This subpackage provides the core functionality of imageio
 (everything but the plugins).
 """
 

--- a/imageio/core/fetching.py
+++ b/imageio/core/fetching.py
@@ -2,8 +2,7 @@
 # Based on code from the vispy project
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
-"""Data downloading and reading functions
-"""
+"""Data downloading and reading functions"""
 
 from math import log
 import os

--- a/imageio/core/findlib.py
+++ b/imageio/core/findlib.py
@@ -2,8 +2,7 @@
 # Copyright (c) 2015-1018, imageio contributors
 # Copyright (C) 2013, Zach Pincus, Almar Klein and others
 
-""" This module contains generic code to find and load a dynamic library.
-"""
+"""This module contains generic code to find and load a dynamic library."""
 
 import os
 import sys

--- a/imageio/plugins/_dicom.py
+++ b/imageio/plugins/_dicom.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Plugin for reading DICOM files.
-"""
+"""Plugin for reading DICOM files."""
 
 # todo: Use pydicom:
 # * Note: is not py3k ready yet

--- a/imageio/plugins/_freeimage.py
+++ b/imageio/plugins/_freeimage.py
@@ -3,7 +3,7 @@
 
 # styletest: ignore E261
 
-""" Module imageio/freeimage.py
+"""Module imageio/freeimage.py
 
 This module contains the wrapper code for the freeimage library.
 The functions defined in this module are relatively thin; just thin

--- a/imageio/plugins/bsdf.py
+++ b/imageio/plugins/bsdf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Read/Write BSDF files.
+"""Read/Write BSDF files.
 
 Backend Library: internal
 

--- a/imageio/plugins/example.py
+++ b/imageio/plugins/example.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Example plugin. You can use this as a template for your own plugin.
-"""
+"""Example plugin. You can use this as a template for your own plugin."""
 
 import numpy as np
 

--- a/imageio/plugins/freeimagemulti.py
+++ b/imageio/plugins/freeimagemulti.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-"""Plugin for multi-image freeimafe formats, like animated GIF and ico.
-"""
+"""Plugin for multi-image freeimafe formats, like animated GIF and ico."""
 
 import logging
 import numpy as np

--- a/imageio/plugins/gdal.py
+++ b/imageio/plugins/gdal.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Read GDAL files.
+"""Read GDAL files.
 
 Backend: `GDAL <https://gdal.org/>`_
 

--- a/imageio/plugins/lytro.py
+++ b/imageio/plugins/lytro.py
@@ -3,7 +3,7 @@
 # imageio is distributed under the terms of the (new) BSD License.
 #
 
-""" Read LFR files (Lytro Illum).
+"""Read LFR files (Lytro Illum).
 
 Backend: internal
 
@@ -315,7 +315,7 @@ class LytroLfrFormat(LytroFormat):
             """
             Checks if file has correct header and skip it.
             """
-            file_header = b"\x89LFP\x0D\x0A\x1A\x0A\x00\x00\x00\x01"
+            file_header = b"\x89LFP\x0d\x0a\x1a\x0a\x00\x00\x00\x01"
             # Read and check header of file
             header = self._file.read(HEADER_LENGTH)
             if header != file_header:
@@ -328,7 +328,7 @@ class LytroLfrFormat(LytroFormat):
             """
             Gets start position and size of data chunks in file.
             """
-            chunk_header = b"\x89LFC\x0D\x0A\x1A\x0A\x00\x00\x00\x00"
+            chunk_header = b"\x89LFC\x0d\x0a\x1a\x0a\x00\x00\x00\x00"
 
             for i in range(0, DATA_CHUNKS_ILLUM):
                 data_pos, size, sha1 = self._get_chunk(chunk_header)
@@ -339,7 +339,7 @@ class LytroLfrFormat(LytroFormat):
             Gets a data chunk that contains information over content
             of other data chunks.
             """
-            meta_header = b"\x89LFM\x0D\x0A\x1A\x0A\x00\x00\x00\x00"
+            meta_header = b"\x89LFM\x0d\x0a\x1a\x0a\x00\x00\x00\x00"
             data_pos, size, sha1 = self._get_chunk(meta_header)
 
             # Get content
@@ -607,7 +607,7 @@ class LytroLfpFormat(LytroFormat):
             """
             Checks if file has correct header and skip it.
             """
-            file_header = b"\x89LFP\x0D\x0A\x1A\x0A\x00\x00\x00\x01"
+            file_header = b"\x89LFP\x0d\x0a\x1a\x0a\x00\x00\x00\x01"
 
             # Read and check header of file
             header = self._file.read(HEADER_LENGTH)
@@ -621,7 +621,7 @@ class LytroLfpFormat(LytroFormat):
             """
             Gets start position and size of data chunks in file.
             """
-            chunk_header = b"\x89LFC\x0D\x0A\x1A\x0A\x00\x00\x00\x00"
+            chunk_header = b"\x89LFC\x0d\x0a\x1a\x0a\x00\x00\x00\x00"
 
             for i in range(0, DATA_CHUNKS_F01):
                 data_pos, size, sha1 = self._get_chunk(chunk_header)
@@ -632,7 +632,7 @@ class LytroLfpFormat(LytroFormat):
             Gets a data chunk that contains information over content
             of other data chunks.
             """
-            meta_header = b"\x89LFM\x0D\x0A\x1A\x0A\x00\x00\x00\x00"
+            meta_header = b"\x89LFM\x0d\x0a\x1a\x0a\x00\x00\x00\x00"
 
             data_pos, size, sha1 = self._get_chunk(meta_header)
 

--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Read/Write images using Pillow/PIL.
+"""Read/Write images using Pillow/PIL.
 
 Backend Library: `Pillow <https://pillow.readthedocs.io/en/stable/>`_
 

--- a/imageio/plugins/pillow_legacy.py
+++ b/imageio/plugins/pillow_legacy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Read/Write images using pillow/PIL (legacy).
+"""Read/Write images using pillow/PIL (legacy).
 
 Backend Library: `Pillow <https://pillow.readthedocs.io/en/stable/>`_
 

--- a/imageio/plugins/pillowmulti.py
+++ b/imageio/plugins/pillowmulti.py
@@ -220,7 +220,7 @@ class GifWriter:  # pragma: no cover
             xy = (0, 0)
 
         # Image separator,
-        bb = b"\x2C"
+        bb = b"\x2c"
 
         # Image position and size
         bb += intToBin(xy[0])  # Left position
@@ -245,7 +245,7 @@ class GifWriter:  # pragma: no cover
             loop = 2**16 - 1
         bb = b""
         if loop != 0:  # omit the extension if we would like a nonlooping gif
-            bb = b"\x21\xFF\x0B"  # application extension
+            bb = b"\x21\xff\x0b"  # application extension
             bb += b"NETSCAPE2.0"
             bb += b"\x03\x01"
             bb += intToBin(loop)
@@ -268,7 +268,7 @@ class GifWriter:  # pragma: no cover
           * 4-7 -To be defined.
         """
 
-        bb = b"\x21\xF9\x04"
+        bb = b"\x21\xf9\x04"
         bb += chr((dispose & 3) << 2).encode("utf-8")
         # low bit 1 == transparency,
         # 2nd bit 1 == user input , next 3 bits, the low two of which are used,

--- a/imageio/plugins/pyav.py
+++ b/imageio/plugins/pyav.py
@@ -961,7 +961,8 @@ class PyAVPlugin(PluginV3):
             plane_array[...] = frame
 
         stream = self._video_stream
-        av_frame.time_base = stream.codec_context.time_base
+        if stream.codec_context.time_base:
+            av_frame.time_base = stream.codec_context.time_base
         av_frame.pts = self.frames_written
         self.frames_written += 1
 

--- a/imageio/plugins/rawpy.py
+++ b/imageio/plugins/rawpy.py
@@ -1,4 +1,4 @@
-""" Read/Write images using rawpy.
+"""Read/Write images using rawpy.
 
 rawpy is an easy-to-use Python wrapper for the LibRaw library.
 It also contains some extra functionality for finding and repairing hot/dead pixels.

--- a/imageio/plugins/simpleitk.py
+++ b/imageio/plugins/simpleitk.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Read/Write images using SimpleITK.
+"""Read/Write images using SimpleITK.
 
 Backend: `Insight Toolkit <https://itk.org/>`_
 

--- a/imageio/plugins/spe.py
+++ b/imageio/plugins/spe.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Read SPE files.
+"""Read SPE files.
 
 This plugin supports reading files saved in the Princeton Instruments
 SPE file format.

--- a/imageio/plugins/swf.py
+++ b/imageio/plugins/swf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Read/Write SWF files.
+"""Read/Write SWF files.
 
 Backend: internal
 

--- a/imageio/plugins/tifffile.py
+++ b/imageio/plugins/tifffile.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # imageio is distributed under the terms of the (new) BSD License.
 
-""" Read/Write TIFF files.
+"""Read/Write TIFF files.
 
 Backend: internal
 

--- a/imageio/testing.py
+++ b/imageio/testing.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 
-""" Functionality used for testing. This code itself is not covered in tests.
-"""
+"""Functionality used for testing. This code itself is not covered in tests."""
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ plugins = {
     "dicom": [],
     "feisem": [],
     "ffmpeg": ["imageio-ffmpeg", "psutil"],
-    "freeimage": ["fsspec[https]"],
+    "freeimage": ["fsspec[http]"],
     "lytro": [],
     "numpy": [],
     "pillow-heif": ["pillow-heif"],

--- a/tests/test_bsdf.py
+++ b/tests/test_bsdf.py
@@ -1,5 +1,4 @@
-""" Test BSDF plugin.
-"""
+"""Test BSDF plugin."""
 
 import numpy as np
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
-""" Test imageio core functionality.
-"""
+"""Test imageio core functionality."""
 
 import os
 import sys

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,5 +1,4 @@
-""" Test DICOM functionality.
-"""
+"""Test DICOM functionality."""
 
 from zipfile import ZipFile
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -1,6 +1,4 @@
-""" Test ffmpeg
-
-"""
+"""Test ffmpeg"""
 
 import gc
 import os

--- a/tests/test_ffmpeg_info.py
+++ b/tests/test_ffmpeg_info.py
@@ -1,6 +1,5 @@
 # styletest: ignore E501
-""" Tests specific to parsing ffmpeg info.
-"""
+"""Tests specific to parsing ffmpeg info."""
 
 import pytest
 import imageio

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -1,5 +1,4 @@
-""" Test fits plugin functionality.
-"""
+"""Test fits plugin functionality."""
 
 import pytest
 

--- a/tests/test_freeimage.py
+++ b/tests/test_freeimage.py
@@ -1,5 +1,4 @@
-""" Tests for imageio's freeimage plugin
-"""
+"""Tests for imageio's freeimage plugin"""
 
 import os
 import shutil

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -1,5 +1,4 @@
-""" Test gdal plugin functionality.
-"""
+"""Test gdal plugin functionality."""
 
 import pytest
 import imageio

--- a/tests/test_lytro.py
+++ b/tests/test_lytro.py
@@ -1,5 +1,4 @@
-""" Test npz plugin functionality.
-"""
+"""Test npz plugin functionality."""
 
 from __future__ import division
 import numpy as np

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,5 +1,4 @@
-""" Test imageio meta stuff, like namespaces and spuriuos imports
-"""
+"""Test imageio meta stuff, like namespaces and spuriuos imports"""
 
 from __future__ import print_function
 

--- a/tests/test_npz.py
+++ b/tests/test_npz.py
@@ -1,5 +1,4 @@
-""" Test npz plugin functionality.
-"""
+"""Test npz plugin functionality."""
 
 import pytest
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -364,11 +364,11 @@ def test_gif_list_write(test_images, tmp_path):
 def test_gif_first_p_frame():
     # Bugfix: https://github.com/imageio/imageio/issues/1030
     im = iio.imread(
-        "https://upload.wikimedia.org/wikipedia/commons/d/d3/Newtons_cradle_animation_book_2.gif",
+        "https://raw.githubusercontent.com/imageio/test_images/refs/heads/main/newtonscradle.gif",
         plugin="pillow",
         index=None,
     )
-    assert im.shape == (36, 360, 480, 3)
+    assert im.shape == (36, 150, 200, 3)
 
 
 def test_legacy_exif_orientation(test_images, tmp_path):

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -1,5 +1,4 @@
-""" Tests for imageio's pillow plugin
-"""
+"""Tests for imageio's pillow plugin"""
 
 import io
 import os

--- a/tests/test_pillow_legacy.py
+++ b/tests/test_pillow_legacy.py
@@ -1,5 +1,4 @@
-""" Tests for imageio's pillow plugin
-"""
+"""Tests for imageio's pillow plugin"""
 
 import os
 import sys

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -438,8 +438,8 @@ def test_sequential_reading(test_images):
 
     assert np.allclose(actual_imgs, expected_imgs)
 
-
-def test_uri_reading(test_images):
+@pytest.mark.skip(reason="PyAV no longer supports DASH natively. This needs separate investigation.")
+def test_uri_reading(test_images):    
     uri = "https://dash.akamaized.net/dash264/TestCases/2c/qualcomm/1/MultiResMPEG2.mpd"
 
     with av.open(uri) as container:

--- a/tests/test_pyav.py
+++ b/tests/test_pyav.py
@@ -438,8 +438,11 @@ def test_sequential_reading(test_images):
 
     assert np.allclose(actual_imgs, expected_imgs)
 
-@pytest.mark.skip(reason="PyAV no longer supports DASH natively. This needs separate investigation.")
-def test_uri_reading(test_images):    
+
+@pytest.mark.skip(
+    reason="PyAV no longer supports DASH natively. This needs separate investigation."
+)
+def test_uri_reading(test_images):
     uri = "https://dash.akamaized.net/dash264/TestCases/2c/qualcomm/1/MultiResMPEG2.mpd"
 
     with av.open(uri) as container:

--- a/tests/test_rawpy.py
+++ b/tests/test_rawpy.py
@@ -1,5 +1,4 @@
-"""Tests for rawpy plugin
-"""
+"""Tests for rawpy plugin"""
 
 import imageio.v3 as iio
 

--- a/tests/test_simpleitk.py
+++ b/tests/test_simpleitk.py
@@ -1,5 +1,4 @@
-""" Test simpleitk plugin functionality.
-"""
+"""Test simpleitk plugin functionality."""
 
 import numpy as np
 

--- a/tests/test_swf.py
+++ b/tests/test_swf.py
@@ -1,5 +1,4 @@
-""" Tests for the shockwave flash plugin
-"""
+"""Tests for the shockwave flash plugin"""
 
 import numpy as np
 

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -1,5 +1,4 @@
-""" Test tifffile plugin functionality.
-"""
+"""Test tifffile plugin functionality."""
 
 import datetime
 import io

--- a/tests/test_tifffile_v3.py
+++ b/tests/test_tifffile_v3.py
@@ -1,5 +1,4 @@
-""" Test tifffile plugin functionality.
-"""
+"""Test tifffile plugin functionality."""
 
 import datetime
 import numpy as np


### PR DESCRIPTION
Resolve #1139.
Since [PyAV 13.1.0](https://pyav.basswood-io.com/docs/stable/development/changelog.html#v13-1-0), `time_base` can only be set to `Fraction`.