### PR TITLE
BUG: add fsspec as freeimage dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ plugins = {
     "dicom": [],
     "feisem": [],
     "ffmpeg": ["imageio-ffmpeg", "psutil"],
-    "freeimage": [],
+    "freeimage": ["fsspec[https]"],
     "lytro": [],
     "numpy": [],
     "pillow-heif": ["pillow-heif"],


### PR DESCRIPTION
This PR adds the `fsspec[https]` dependency as a transitive dependency to freeimage. Im not sure when fsspec made the "https" option optional, but since it now is, we need to install it to test freeimage.