### PR TITLE
TEST: don't test pyav on pypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ plugins = {
     "numpy": [],
     "pillow-heif": ["pillow-heif"],
     "pillow": [],
-    "pyav": ["av"],
     "simpleitk": [],
     "spe": [],
     "swf": [],
@@ -103,6 +102,7 @@ plugins = {
 }
 
 cpython_only_plugins = {
+    "pyav": ["av"],
     "fits": ["astropy"],
     "rawpy": ["rawpy", "numpy>2"],
 }


### PR DESCRIPTION
This PR makes pyav a cpython only plugin. PyAV no longer builds compatible binaries for pypy and thus installation of this plugin fails unless it gets manually compiled.

Since ImageIO doesn't complie anything today, we will disable testing of pyAV on pypy. We are still testing on cpython so we still have coverage of the plugin itself.