### PR TITLE
Replace pkg_resources with importlib.resources

### DIFF
--- a/imageio/__main__.py
+++ b/imageio/__main__.py
@@ -44,11 +44,9 @@ def download_bin(plugin_names=["all"], package_dir=False):
     print("Ascertaining binaries for: {}.".format(", ".join(plugin_names)))
 
     if package_dir:
-        # Download the binaries to the `resources` directory
-        # of imageio. If imageio comes as an .egg, then a cache
-        # directory will be created by pkg_resources (requires setuptools).
+        # Download the binaries to the `resources` directory of imageio.
         # see `imageio.core.util.resource_dirs`
-        # and `imageio.core.utilresource_package_dir`
+        # and `imageio.core.util.resource_package_dir`
         directory = util.resource_package_dir()
     else:
         directory = None

--- a/imageio/core/util.py
+++ b/imageio/core/util.py
@@ -501,22 +501,9 @@ def resource_package_dir():
     This is a convenience method that is used by `resource_dirs` and
     imageio entry point scripts.
     """
-    # Make pkg_resources optional if setuptools is not available
-    try:
-        # Avoid importing pkg_resources in the top level due to how slow it is
-        # https://github.com/pypa/setuptools/issues/510
-        import pkg_resources
-    except ImportError:
-        pkg_resources = None
+    import importlib.resources
 
-    if pkg_resources:
-        # The directory returned by `pkg_resources.resource_filename`
-        # also works with eggs.
-        pdir = pkg_resources.resource_filename("imageio", "resources")
-    else:
-        # If setuptools is not available, use fallback
-        pdir = os.path.abspath(os.path.join(THIS_DIR, "..", "resources"))
-    return pdir
+    return str(importlib.resources.files("imageio") / "resources")
 
 
 def get_platform():


### PR DESCRIPTION
`pkg_resources` is deprecated and `importlib.resources` has been in the standard library since Python 3.7. This PR replaces the call to `pkg_resources.resource_filename` with `importlib.resources.files`.
Fixes #1137