### PR TITLE
TEST: gracefully handle short-lived processes in ffmpeg plugin

### DIFF
--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -36,8 +36,13 @@ except RuntimeError:
 def get_ffmpeg_pids():
     pids = set()
     for p in psutil.process_iter():
-        if "ffmpeg" in p.name().lower():
-            pids.add(p.pid)
+        try:
+            if "ffmpeg" in p.name().lower():
+                pids.add(p.pid)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            # Process may die between being listed and being checked.
+            # If that happens, skip that process instead of crashing :)
+            pass
     return pids
 
 


### PR DESCRIPTION
closes: https://github.com/imageio/imageio/issues/1150

This PR adds error handling for psutil when testing the webcam on the "old" ffmpeg plugin. Turns out that processes may die while we iterate over the list of processes to find the ffmpeg subprocesses. On MacOS, if that happened to a processes that we haven't checked yet and we access that dead processes name we get an exception. 

The above was causing a race condition in the test. I've fixed it with some error handling that ignores threads that have died while iterating over the list of threads.