### PR TITLE
MAINT: fix build hook in CD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!--next-version-placeholder-->
 
+## v2.37.1 (2025-10-22)
+
+### Bug
+
+- Add fsspec as freeimage dependency ([#1145](https://github.com/imageio/imageio/pull/1145),
+  [`0f9692e`](https://github.com/imageio/imageio/commit/0f9692e9c5a5fd523db6aa98860b385272d48e31))
+
+- Fix plugin `ffmpeg` cannot load file with carets
+  ([#1135](https://github.com/imageio/imageio/pull/1135),
+  [`3009a96`](https://github.com/imageio/imageio/commit/3009a9651aae9e008065c68155160969f369c583))
+
+- Fix the error when `time_base` is set to null
+  ([#1144](https://github.com/imageio/imageio/pull/1144),
+  [`eadfc59`](https://github.com/imageio/imageio/commit/eadfc5906f5c2c3731f56a582536dbc763c3a7a9))
+
+### Doc
+
+- 'imageio[ffmpeg]' argument needs quoting ([#1140](https://github.com/imageio/imageio/pull/1140),
+  [`013582a`](https://github.com/imageio/imageio/commit/013582acfce692428d8100bb54f407dc8b43ccbb))
+
+- It's "Deprecating" without an "i" ([#1141](https://github.com/imageio/imageio/pull/1141),
+  [`ffc0539`](https://github.com/imageio/imageio/commit/ffc053963e1ce1f42e90a939cb46dd8b7dc69e47))
+
+- Pin python version to build docs ([#1122](https://github.com/imageio/imageio/pull/1122),
+  [`3e2a165`](https://github.com/imageio/imageio/commit/3e2a165e484135d4d627c8f1fed5cb3bf13438c6))
+
+### Maint
+
+- Avoid calling PIL.Image twice to open a file
+  ([#1149](https://github.com/imageio/imageio/pull/1149),
+  [`6a45d8a`](https://github.com/imageio/imageio/commit/6a45d8a30ca067f3719dfb35b313fdf7fab0548e))
+
+- Fix CD failure ([#1154](https://github.com/imageio/imageio/pull/1154),
+  [`7919501`](https://github.com/imageio/imageio/commit/7919501eacb93795ce2bdaf2f166681ab4eef7dc))
+
+### Test
+
+- Don't test pyav on pypy ([#1146](https://github.com/imageio/imageio/pull/1146),
+  [`570a114`](https://github.com/imageio/imageio/commit/570a11438e2e1379defe61df03451c678b77787a))
+
+- Fix race condition in ffmpeg plugin test ([#1153](https://github.com/imageio/imageio/pull/1153),
+  [`57a43c4`](https://github.com/imageio/imageio/commit/57a43c417863aa6128e71f114cdbca92caa6529d))
+
+- Handle `amf` and `ohcodec` in pyav tests and update pypy to 3.11 due to current pillow support
+  ([#1152](https://github.com/imageio/imageio/pull/1152),
+  [`a223fb3`](https://github.com/imageio/imageio/commit/a223fb32674bb86f5d8ed41bd0e2c1059d85aecc))
+
+- Mark more tests as needing the internet ([#1142](https://github.com/imageio/imageio/pull/1142),
+  [`ab7c836`](https://github.com/imageio/imageio/commit/ab7c836271e95b03839cf862598692775863f731))
+
+
 ## v2.37.0 (2025-01-20)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ImageIO"
-version = "2.37.0"
+version = "2.37.1"
 authors = [
     {name = "ImageIO contributors"}
 ]


### PR DESCRIPTION
Looks like the last step of the new CD pipeline still needs some tweaks. Releases are detected, validated and tested, but the actual release to GH and Pypi fails.

This PR fixes that. 