### PR TITLE
TYP: ``__init__.pyi`` typing stubs

### DIFF
--- a/imageio/__init__.pyi
+++ b/imageio/__init__.pyi
@@ -1,0 +1,79 @@
+import pathlib
+from _typeshed import Incomplete
+from typing import Final, Protocol, type_check_only
+
+from . import config, plugins, v2, v3
+from .core import (
+    RETURN_BYTES as RETURN_BYTES,
+    FormatManager,
+)
+from .core.v3_plugin_api import PluginV3
+from .v2 import (
+    get_reader,
+    get_reader as read,
+    get_writer,
+    get_writer as save,
+    help,
+    imwrite,
+    imwrite as imsave,
+    mimread,
+    mimwrite,
+    mimwrite as mimsave,
+    mvolread,
+    mvolwrite,
+    mvolwrite as mvolsave,
+    volread,
+    volwrite,
+    volwrite as volsave,
+)
+from .v3 import imiter, imopen
+
+import numpy as np
+
+__all__ = [
+    "v2",
+    "v3",
+    "config",
+    "plugins",
+    "imopen",
+    "imread",
+    "imwrite",
+    "imiter",
+    "mimread",
+    "volread",
+    "mvolread",
+    "imwrite",
+    "mimwrite",
+    "volwrite",
+    "mvolwrite",
+    "read",
+    "save",
+    "imsave",
+    "mimsave",
+    "volsave",
+    "mvolsave",
+    "help",
+    "get_reader",
+    "get_writer",
+    "formats",
+    "show_formats",
+]
+
+@type_check_only
+class _SupportsReadAndClose(Protocol):
+    def read(self, size: int = ..., /) -> bytes: ...
+    def close(self) -> None: ...
+
+__version__: Final[str] = ...
+
+formats: Final[FormatManager] = ...
+
+def show_formats() -> None: ...
+def imread(
+    uri: str | bytes | memoryview | pathlib.Path | _SupportsReadAndClose,
+    format: str | None = None,
+    *,
+    plugin: str | type[PluginV3] | None = None,
+    extension: str | None = None,
+    **plugin_kwargs: Incomplete,
+) -> np.ndarray: ...


### PR DESCRIPTION
I noticed that the top-level `imageio.imread` and `imageio.show_formats` functions didn't have any type annotations, so I wrote some.

SInce you're already using `.pyi` stubs here and there, I also chose stubs instead of inline annotations. But if you prefer inline annotations I wouldn't mind going with that instead here.

The `uri` param annotation matches the implementation in `core.request.Request._parse_uri`. For example, for file-like objects it only requires there to be a `.read(size?)` and a `.close()`  method, so something like a `io.BytesIO` (which has a whole bunch of other methods) would be unnecessarily broad.

I validated that these `__init__.pyi` stubs are valid using basedpyright and Pyrefly.

#### Note to Maintainers

Remember to *squash-merge* the PR and to use an appropriate tag in the commit message title.
Tags are necessary, so that the CD pipeline can correctly pick up and advertize this PR.
A full list of available tags (and how to format them) can be found here:

- [Docs of available Tags (SciPy)](https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message)
- [Docs of the actual Parser (Python Semantic Release)](https://python-semantic-release.readthedocs.io/en/latest/configuration.html#module-semantic_release.history.parser_scipy)
