### PR TITLE
fix: allow mimwrite to consume iterators

### DIFF
--- a/imageio/plugins/pillow.py
+++ b/imageio/plugins/pillow.py
@@ -414,7 +414,9 @@ class PillowPlugin(PluginV3):
             )
             kwargs["duration"] = 1000 * 1 / kwargs.get("fps")
 
-        if isinstance(ndimage, list):
+        if is_batch is True:
+            pass
+        elif isinstance(ndimage, list):
             ndimage = np.stack(ndimage, axis=0)
             is_batch = True
         else:
@@ -442,6 +444,7 @@ class PillowPlugin(PluginV3):
             ndimage = ndimage[None, ...]
 
         for frame in ndimage:
+            frame = np.asarray(frame)
             pil_frame = Image.fromarray(frame, mode=mode)
             if "bits" in kwargs:
                 pil_frame = pil_frame.quantize(colors=2 ** kwargs["bits"])

--- a/imageio/v2.py
+++ b/imageio/v2.py
@@ -3,6 +3,7 @@
 
 import re
 import warnings
+from collections.abc import Iterator
 from numbers import Number
 from pathlib import Path
 from typing import Dict
@@ -234,6 +235,9 @@ class LegacyWriter:
 
 def is_batch(ndimage):
     if isinstance(ndimage, (list, tuple)):
+        return True
+
+    if isinstance(ndimage, Iterator):
         return True
 
     ndimage = np.asarray(ndimage)

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -66,6 +66,34 @@ def test_mimwrite_exception(tmp_path):
         iio.mimwrite(tmp_path / "test.png", img)
 
 
+def test_mimwrite_accepts_generator(tmp_path):
+    def frames():
+        for value in range(3):
+            yield np.full((8, 8, 3), value, dtype=np.uint8)
+
+    iio.mimwrite(tmp_path / "test.gif", frames())
+
+    imgs = iio.mimread(tmp_path / "test.gif")
+    assert len(imgs) == 3
+    assert [img[0, 0, 0] for img in imgs] == [0, 1, 2]
+
+
+def test_mimwrite_accepts_iterator(tmp_path):
+    frames = iter(
+        [
+            np.full((8, 8, 3), 0, dtype=np.uint8),
+            np.full((8, 8, 3), 1, dtype=np.uint8),
+            np.full((8, 8, 3), 2, dtype=np.uint8),
+        ]
+    )
+
+    iio.mimwrite(tmp_path / "test.gif", frames)
+
+    imgs = iio.mimread(tmp_path / "test.gif")
+    assert len(imgs) == 3
+    assert [img[0, 0, 0] for img in imgs] == [0, 1, 2]
+
+
 def test_kwarg_forwarding(tmp_path):
     rng = np.random.default_rng()
 


### PR DESCRIPTION
Closes #1179.

This PR allows `mimwrite` to accept generators and iterators as multi-image input.

Changes:
- Treat `Iterator` inputs as batch image data in the v2 API.
- Avoid coercing explicitly batched Pillow input to a NumPy array before iteration.
- Convert each frame individually before passing it to Pillow.
- Add regression tests for generator and iterator inputs.

Validation:
- Compiled the touched files successfully.
- Manually verified generator and iterator inputs by writing and reading back multi-frame GIFs.