### PR TITLE
FEAT: v3 Plugin for pydicom

### DIFF
--- a/.cursor/rules/self_modifying.mdc
+++ b/.cursor/rules/self_modifying.mdc
@@ -1,0 +1,57 @@
+---
+alwaysApply: true
+---
+
+# Agent Instructions
+
+Read this entire file before starting any task.
+
+## Self-Correcting Rules Engine
+
+This file contains a growing ruleset that improves over time. **At session start, read the entire "Learned Rules"
+section before doing anything.**
+
+### How it works
+
+1. When the user corrects you or you make a mistake, **immediately append a new rule** to the "Learned Rules"
+2. Rules are numbered sequentially and written as clear, imperative instructions.
+3. Format: `N. [CATEGORY] Never/Always do X - because Y.`
+4. Categories: `[STYLE]`, `[CODE]`, `[ARCH]`, `[TOOL]`, `[PROCESS]`, `[DATA]`, `[UX]`, `[OTHER]`
+5. Before starting any task, scan all rules below for relevant constraints.
+6. If two rules conflict, the higher-numbered (newer) rule wins.
+7. Never delete rules. If a rule becomes obsolete, append a new rule that superseeds it.
+
+### When to add a rule
+
+- User explicitly corrects your output ("no, do it this way")
+- User rejects a file, approach, or pattern
+- You hit a bug caused by a wrong assumption about this codebase
+- User states a preference ("always use X", "never do Y")
+
+### Rule format example
+
+```
+14. [CODE] Always use `uv` instead of `pip` - user preference, uv is installed globally.
+15. [STYLE] Never add emojis to commit messages - project convention.
+16. [ARCH] Plugins live in `imageio/plugins`, not `imageio/core` - existing codebase pattern.
+```
+
+---
+
+## Learned Rules
+
+<!-- New rules are appended below this line. Do not edit above this section. -->
+1. [CODE] Never silently normalize or "heal" user input (aliases, case folding, punctuation swaps) when an exact value is expected — fail with a clear error and let it bubble up; the user knows their intent better than we do.
+2. [STYLE] Always inline single-use module-level constants/tuples into their call site instead of naming them at module scope — keeps reading local and avoids indirection.
+3. [STYLE] Always inline single-use helper functions into their call site; prefer top-to-bottom readable code with step comments over factoring one-off helpers.
+4. [CODE] Never use `assert` in production/library code — only in tests; raise an explicit exception instead.
+5. [CODE] Avoid defensive try/except hedges that swallow or rewrite rare failures into fallbacks — let errors bubble; keep only intentional API boundaries (e.g. optional-dep ImportError, format probe → InitializationError).
+6. [STYLE] When documenting an if/else parameter, describe the first case with "If …", then the other case with "Otherwise, …" — not a second "If …".
+7. [STYLE] Prefer membership tests like `x in (a, b)` over `x is a or x is b` / `x == a or x == b` when checking multiple alternatives — faster to read.
+8. [STYLE] Always import third-party dependencies with a short 2–4 character alias (e.g. `import pydicom as pdcm`, `import numpy as np`) and call through that namespace — makes external vs local symbols obvious; do not `from dependency import func`.
+9. [STYLE] Never alias class attributes to short locals inside methods (e.g. `ds = self._dataset`) — use the full `self._…` name so data flow stays obvious; only introduce a short local if the user asks for that specific case.
+10. [STYLE] Name boolean flags `is_<something>` or `has_<something>` (e.g. `is_signed`, `has_palette`) — not bare adjectives like `signed`.
+11. [CODE] Do not add defensive validation of DICOM/structure that "should always be true" (e.g. `len(PixelSpacing) >= 2`, bounds checks before indexing). Optional tags may be probed with `getattr(..., None)`; once present, index/use values directly and let bad data raise to the caller — they know better than we do what to do next.
+12. [CODE] Prefer failing loudly over silent healing — no quiet coercions (`int(index)` when the API already requires `int`), no soft fallbacks that hide bad input/state. Loud failures are easier to debug and keep call sites honest.
+13. [STYLE] Prefer a single flat `if` / `elif` / `else` chain over nested conditionals when the branches are mutually exclusive — easier to scan top-to-bottom.
+14. [CODE] Do not pre-validate user inputs (shape/dtype/range checks that raise our own ValueError). Assume the caller knows what they are doing; unusual inputs may be intentional. Let failures surface at the natural point of use (indexing, encode, pydicom, etc.).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ SphinxDocString._str_member_list = lambda self, name: []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-autodoc_mock_imports = ["av", "cv2", "imageio_ffmpeg", "rawpy", "tifffile"]
+autodoc_mock_imports = ["av", "cv2", "imageio_ffmpeg", "pydicom", "rawpy", "tifffile"]
 
 # The suffix of source filenames.
 source_suffix = ".rst"

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -199,6 +199,21 @@ Re-encode a (large) video
 Read medical data (DICOM)
 -------------------------
 
+Single-file instances with the pydicom plugin (``pip install imageio[pydicom]``).
+By default ``imread`` applies modality rescale / VOI windowing (or a palette LUT);
+pass ``raw=True`` for stored pixel values:
+
+.. code-block:: python
+
+    import imageio.v3 as iio
+
+    img = iio.imread("scan.dcm", plugin="pydicom")
+    stored = iio.imread("scan.dcm", plugin="pydicom", raw=True)
+    meta = iio.immeta("scan.dcm", plugin="pydicom")
+    iio.imwrite("out.dcm", img, plugin="pydicom", metadata={"Modality": "OT"})
+
+Legacy folder / series assembly still uses ``plugin='DICOM'``:
+
 .. code-block:: python
 
     import imageio.v3 as iio

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -212,21 +212,6 @@ pass ``raw=True`` for stored pixel values:
     meta = iio.immeta("scan.dcm", plugin="pydicom")
     iio.imwrite("out.dcm", img, plugin="pydicom", metadata={"Modality": "OT"})
 
-Legacy folder / series assembly still uses the deprecated ``plugin='DICOM'``
-until series support lands on pydicom:
-
-.. code-block:: python
-
-    import imageio.v3 as iio
-    dirname = 'path/to/dicom/files'
-
-    # Read multiple images of different shape
-    ims = [img for img in iio.imiter(dirname, plugin='DICOM')]
-    # Read as volume
-    vol = iio.imread(dirname, plugin='DICOM')
-    # Read multiple volumes of different shape
-    vols = [img for img in iio.imiter(dirname, plugin='DICOM')]
-
 
 Volume data
 -----------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -212,7 +212,8 @@ pass ``raw=True`` for stored pixel values:
     meta = iio.immeta("scan.dcm", plugin="pydicom")
     iio.imwrite("out.dcm", img, plugin="pydicom", metadata={"Modality": "OT"})
 
-Legacy folder / series assembly still uses ``plugin='DICOM'``:
+Legacy folder / series assembly still uses the deprecated ``plugin='DICOM'``
+until series support lands on pydicom:
 
 .. code-block:: python
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -84,6 +84,7 @@ support.
 
     imageio.plugins.bsdf
     imageio.plugins.dicom
+    imageio.plugins.pydicom
     imageio.plugins.feisem
     imageio.plugins.ffmpeg
     imageio.plugins.fits

--- a/imageio/config/extensions.py
+++ b/imageio/config/extensions.py
@@ -158,7 +158,7 @@ extension_list = [
     FileExtension(
         name="Computerized Tomography",
         extension=".ct",
-        priority=["DICOM"],
+        priority=["DICOM", "pydicom"],
     ),
     FileExtension(
         name="Windows Cursor Icons",
@@ -177,7 +177,7 @@ extension_list = [
     FileExtension(
         name="DICOM file format",
         extension=".dcm",
-        priority=["DICOM", "ITK"],
+        priority=["DICOM", "pydicom", "ITK"],
     ),
     FileExtension(
         extension=".dcr",
@@ -201,7 +201,7 @@ extension_list = [
     FileExtension(
         name="DICOM file format",
         extension=".dicom",
-        priority=["ITK"],
+        priority=["ITK", "pydicom"],
     ),
     FileExtension(
         extension=".dng",
@@ -302,7 +302,7 @@ extension_list = [
     FileExtension(
         name="Grassroots DICOM",
         extension=".gdcm",
-        priority=["ITK"],
+        priority=["ITK", "pydicom"],
     ),
     FileExtension(
         name="Graphics Interchange Format",
@@ -583,7 +583,7 @@ extension_list = [
     FileExtension(
         name="Magnetic resonance imaging",
         extension=".mri",
-        priority=["DICOM"],
+        priority=["DICOM", "pydicom"],
     ),
     FileExtension(
         extension=".mrw",

--- a/imageio/config/plugins.py
+++ b/imageio/config/plugins.py
@@ -132,6 +132,9 @@ known_plugins["SPE"] = PluginConfig(
 known_plugins["rawpy"] = PluginConfig(
     name="rawpy", class_name="RawPyPlugin", module_name="imageio.plugins.rawpy"
 )
+known_plugins["pydicom"] = PluginConfig(
+    name="pydicom", class_name="PydicomPlugin", module_name="imageio.plugins.pydicom"
+)
 
 # Legacy plugins
 # ==============

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -215,7 +215,7 @@ def imopen(
         err_type = ValueError if legacy_mode else IOError
         err_msg = (
             "ImageIO does not support reading folders. "
-            "Pass a path to an individual file instead."
+            "Use a URI pointing to an individual file instead."
         )
         raise err_type(err_msg)
 

--- a/imageio/core/imopen.py
+++ b/imageio/core/imopen.py
@@ -210,15 +210,12 @@ def imopen(
             raise err_type(err_msg)
 
     # error out for directories
-    # this is a bit hacky and should be cleaned once we decide
-    # how to gracefully handle DICOM
     if request._uri_type == URI_FILENAME and Path(request.raw_uri).is_dir():
         request.finish()
         err_type = ValueError if legacy_mode else IOError
         err_msg = (
-            "ImageIO does not generally support reading folders. "
-            "Limited support may be available via specific plugins. "
-            "Specify the plugin explicitly using the `plugin` kwarg, e.g. `plugin='DICOM'`"
+            "ImageIO does not support reading folders. "
+            "Pass a path to an individual file instead."
         )
         raise err_type(err_msg)
 

--- a/imageio/plugins/dicom.py
+++ b/imageio/plugins/dicom.py
@@ -8,8 +8,8 @@ Backend Library: internal
 .. deprecated::
     The legacy ``DICOM`` plugin is deprecated and will be removed in a future
     ImageIO release. Prefer ``plugin='pydicom'`` for single-file DICOM I/O
-    (``pip install imageio[pydicom]``). Folder / series assembly is not yet
-    available on the pydicom plugin.
+    (``pip install imageio[pydicom]``). Reading a folder of DICOM files is
+    deprecated and will be removed without replacement.
 
 A format for reading DICOM images: a common format used to store
 medical image data, such as X-ray, CT and MRI.
@@ -51,8 +51,8 @@ from ..core import read_n_bytes
 warnings.warn(
     "The legacy `DICOM` plugin is deprecated and will be removed in a future "
     "ImageIO release. Prefer `plugin='pydicom'` for single-file DICOM "
-    "(install via `pip install imageio[pydicom]`). Folder / series assembly "
-    "is not yet supported by the pydicom plugin.",
+    "(install via `pip install imageio[pydicom]`). Reading a folder of DICOM "
+    "files is deprecated and will be removed without replacement.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/imageio/plugins/dicom.py
+++ b/imageio/plugins/dicom.py
@@ -5,6 +5,12 @@
 
 Backend Library: internal
 
+.. deprecated::
+    The legacy ``DICOM`` plugin is deprecated and will be removed in a future
+    ImageIO release. Prefer ``plugin='pydicom'`` for single-file DICOM I/O
+    (``pip install imageio[pydicom]``). Folder / series assembly is not yet
+    available on the pydicom plugin.
+
 A format for reading DICOM images: a common format used to store
 medical image data, such as X-ray, CT and MRI.
 
@@ -33,21 +39,23 @@ progress : {True, False, BaseProgressIndicator}
 
 """
 
-# todo: Use pydicom:
-# * Note: is not py3k ready yet
-# * Allow reading the full meta info
-# I think we can more or less replace the SimpleDicomReader with a
-# pydicom.Dataset For series, only ned to read the full info from one
-# file: speed still high
-# * Perhaps allow writing?
-
 import os
 import sys
 import logging
 import subprocess
+import warnings
 
 from ..core import Format, BaseProgressIndicator, StdoutProgressIndicator
 from ..core import read_n_bytes
+
+warnings.warn(
+    "The legacy `DICOM` plugin is deprecated and will be removed in a future "
+    "ImageIO release. Prefer `plugin='pydicom'` for single-file DICOM "
+    "(install via `pip install imageio[pydicom]`). Folder / series assembly "
+    "is not yet supported by the pydicom plugin.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 _dicom = None  # lazily loaded in load_lib()
 

--- a/imageio/plugins/pydicom.py
+++ b/imageio/plugins/pydicom.py
@@ -1,0 +1,995 @@
+"""Read/Write single-file DICOM instances using pydicom.
+
+.. note::
+    To use this plugin you need to have `pydicom <https://pydicom.github.io/pydicom/>`_
+    installed::
+
+        pip install pydicom
+
+
+Backend Library: `pydicom <https://pydicom.github.io/pydicom/>`_
+
+This plugin reads and writes DICOM files using pydicom. It operates in 
+individual files, meaning while it supports multi-frame files natively, it does 
+**not** assemble data across files in a directory.
+
+
+Methods
+-------
+.. note::
+    Check the respective function for supported kwargs and detailed
+    documentation.
+
+.. autosummary::
+    :toctree:
+
+    PydicomPlugin.read
+    PydicomPlugin.iter
+    PydicomPlugin.write
+    PydicomPlugin.properties
+    PydicomPlugin.metadata
+
+Additional methods available inside the :func:`imopen <imageio.v3.imopen>`
+context:
+
+.. autosummary::
+    :toctree:
+
+    PydicomPlugin.write_frame
+    PydicomPlugin.lut_dense
+    PydicomPlugin.lut_linear
+    PydicomPlugin.instance_metadata
+    PydicomPlugin.shared_frame_metadata
+    PydicomPlugin.compression
+
+Advanced API
+------------
+
+In addition to the default ImageIO v3 API this plugin exposes custom functions
+and attributes for writing DICOM. These are available inside the
+:func:`imopen <imageio.v3.imopen>` context and allow fine-grained control over
+tags, functional groups, palettes, and compression. The callables are documented
+above; below is a usage example::
+
+    import imageio.v3 as iio
+
+    frames = [...]  # list of (rows, cols) arrays, e.g. uint16
+    with iio.imopen("out.dcm", "w", plugin="pydicom") as f:
+        # global metadata
+        f.instance_metadata["PatientName"] = "Anonymous"
+        f.instance_metadata["Modality"] = "OT"
+
+        # bit depth
+        f.instance_metadata["BitsStored"] = 12
+
+        # pixel compression
+        f.compression = "rle"  # or "jpeg-ls", "jpeg2000-lossless", ...
+
+        # shared FG (written once, applied to each frame)
+        f.shared_frame_metadata["PixelMeasuresSequence"] = [
+            {"PixelSpacing": [1.0, 1.0]}
+        ]
+
+        # write each frame
+        for i, frame in enumerate(frames):
+            f.write_frame(
+                frame,
+                # set frame-level metadata
+                metadata={"FrameContentSequence": [{"FrameAcquisitionNumber": i}]},
+            )
+
+    meta = iio.immeta("out.dcm", plugin="pydicom")
+    assert meta["PatientName"] == "Anonymous"
+
+Frames are buffered until flush (``close()`` / context exit).
+
+Compression
+-----------
+
+Compression is imopen-only. ``imwrite`` / ``write()`` always produce an
+uncompressed Dataset; set ``f.compression`` before close to run pydicom
+``Dataset.compress()`` once at flush. Changing the value after some
+``write_frame`` calls is fine — only the value at flush matters.
+
+Accepted values are short names (resolved to transfer syntax UIDs) or a raw
+UID string:
+
+- ``"rle"`` — RLE Lossless
+- ``"jpeg-ls"`` — JPEG-LS Lossless
+- ``"jpeg-ls-near"`` — JPEG-LS Near-Lossless
+- ``"jpeg2000"`` — JPEG 2000
+- ``"jpeg2000-lossless"`` — JPEG 2000 Lossless
+
+Availability depends on pydicom’s installed encoders (RLE is built-in; others
+may need extra packages). Unknown names raise immediately; unsupported UIDs
+fail at flush.
+
+Example::
+
+    import imageio.v3 as iio
+    import numpy as np
+
+    img = np.arange(64, dtype=np.uint8).reshape(8, 8)
+    with iio.imopen("compressed.dcm", "w", plugin="pydicom") as f:
+        f.compression = "rle"
+        f.write(img)
+
+Palette LUTs
+------------
+
+The plugin offers helpers to build color palettes when writing palettized
+DICOM images. Supported palettes are either **dense** or **linear**:
+
+- A **dense** palette maps each pixel index to a color from a lookup table.
+- A **linear** palette maps each pixel index via piecewise-linear
+  interpolation between the provided ``colors`` at the provided ``indices``.
+
+Dense color maps use the ordinary LookupTableData tags, linear maps use 
+SegmentedLookupTableData tags. Please ensure your reader supports these. Optional 
+alpha is supported as a 4th LUT channel. Pixel frames must be **index** arrays 
+into the LUT (not already-colored RGB).
+
+When using a LUT, do **not** set ``BitsStored`` in ``instance_metadata``.
+
+Example using a dense palette::
+
+    import imageio.v3 as iio
+    import numpy as np
+
+    frame = ...  # (rows, cols) index array, with values 0..3
+    colormap = np.array(
+        [[0, 0, 0], [255, 0, 0], [0, 255, 0], [0, 0, 255]],
+        dtype=np.uint8,
+    )
+    with iio.imopen("palette_dense.dcm", "w", plugin="pydicom") as f:
+        f.lut_dense(colormap)
+        f.write(frame)
+
+Example using a linear palette::
+
+    import imageio.v3 as iio
+
+    frame = ...  # (rows, cols) index array, uint8
+    with iio.imopen("palette_linear.dcm", "w", plugin="pydicom") as f:
+        f.lut_linear(
+            colors=[(0, 0, 0), (65535, 65535, 65535)],
+            indices=[0, 255],
+        )
+        f.write(frame)
+
+Calling either helper **replaces** any previous palette state and clears the
+other encoding's data tags (explicit and segmented are mutually exclusive).
+While we offer helpers for dense and linear, you can still manually build and assign
+other tables directly to the respective metadata tags.
+
+Pixel reconstruction
+--------------------
+
+By default ``read`` / ``iter`` / ``imread`` / ``imiter`` reconstruct the image.
+This means any LUT (lookup table), grayscale correction, or ROI (region of 
+interest) windowing is applied before the image is returned.
+
+Pass ``raw=True`` to skip that pipeline and get stored values
+(``pixel_array(..., raw=True)``). ``improps`` / ``properties`` take the same
+``raw`` flag so reported shape and dtype match ``read``.
+
+Notes
+-----
+Be aware that ``.write()`` on ``"<bytes>"`` needs to flush immediately so 
+``imwrite`` can return encoded bytes. This may cause surprising behavior when used
+inside an explicit ``imopen`` context.
+
+"""
+
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+
+try:
+    import pydicom as pdcm
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "The pydicom plugin requires pydicom. Install it via `pip install imageio[pydicom]`."
+    ) from exc
+
+from ..core.request import URI_BYTES, InitializationError, IOMode, Request
+from ..core.v3_plugin_api import ImageProperties, PluginV3
+from ..typing import ArrayLike
+
+def _as_python(value: Any) -> Any:
+    if isinstance(value, pdcm.Dataset):
+        return _dataset_to_dict(value, omit_keys=())
+    if isinstance(value, pdcm.sequence.Sequence):
+        return [_as_python(item) for item in value]
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_as_python(v) for v in value]
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def _dataset_to_dict(ds: pdcm.Dataset, *, omit_keys: Sequence[str]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    omit = set(omit_keys)
+    for elem in ds:
+        if elem.keyword is None or elem.keyword == "PixelData":
+            continue
+        if elem.keyword in omit:
+            continue
+        out[elem.keyword] = _as_python(elem.value)
+    return out
+
+
+def _dict_to_dataset(data: Dict[str, Any]) -> pdcm.Dataset:
+    ds = pdcm.Dataset()
+    for key, value in data.items():
+        _set_dataset_value(ds, key, value)
+    return ds
+
+
+def _set_dataset_value(ds: pdcm.Dataset, key: str, value: Any) -> None:
+    if isinstance(value, dict):
+        setattr(ds, key, _dict_to_dataset(value))
+    elif (
+        isinstance(value, list)
+        and value
+        and all(isinstance(v, dict) for v in value)
+    ):
+        setattr(ds, key, pdcm.sequence.Sequence([_dict_to_dataset(v) for v in value]))
+    else:
+        setattr(ds, key, value)
+
+
+class _TagMap:
+    """Dict-like keyword → value view that writes through to a Dataset."""
+
+    def __init__(self, get_ds: Callable[[], pdcm.Dataset]) -> None:
+        self._get_ds = get_ds
+
+    def __getitem__(self, key: str) -> Any:
+        return _as_python(getattr(self._get_ds(), key))
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        _set_dataset_value(self._get_ds(), key, value)
+
+    def __contains__(self, key: object) -> bool:
+        return isinstance(key, str) and hasattr(self._get_ds(), key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self[key] if key in self else default
+
+    def update(self, other: Dict[str, Any]) -> None:
+        for key, value in other.items():
+            self[key] = value
+
+
+class PydicomPlugin(PluginV3):
+    """Read and write DICOM images via pydicom.
+
+    Parameters
+    ----------
+    request : iio.Request
+        Image resource request.
+    kwargs : Any
+        Additional kwargs are forwarded to ``pydicom.dcmread``.
+    """
+
+    def __init__(self, request: Request, **kwargs) -> None:
+        super().__init__(request)
+
+        # Read-only
+        self._dcmread_kwargs: Dict[str, Any] = kwargs
+        self._dcmread_kwargs.setdefault("stop_before_pixels", True)
+
+        # Write-only
+        self._compression: Optional[str] = None
+        self._save_kwargs: Dict[str, Any] = {}
+        self._frames: List[np.ndarray] = []
+        self._frame_metadata: List[Optional[Dict[str, Any]]] = []
+        self._flushed = False
+
+        if request.mode.io_mode == IOMode.read:
+            try:
+                self._dataset = pdcm.dcmread(
+                    request.get_file(), **self._dcmread_kwargs
+                )
+            except pdcm.errors.InvalidDicomError as exc:
+                raise InitializationError(
+                    "pydicom cannot read this file as DICOM."
+                ) from exc
+        else:
+            self._dataset = pdcm.Dataset()
+            self._dataset.SOPClassUID = pdcm.uid.SecondaryCaptureImageStorage
+            self._dataset.SOPInstanceUID = pdcm.uid.generate_uid()
+            self._dataset.StudyInstanceUID = pdcm.uid.generate_uid()
+            self._dataset.SeriesInstanceUID = pdcm.uid.generate_uid()
+            self._dataset.Modality = "OT"
+
+    def _ensure_pixel_dataset(self) -> None:
+        # Read __init__ always sets _dataset; write handles never call this.
+        if not self._dcmread_kwargs["stop_before_pixels"]:
+            return
+        fh = self.request.get_file()
+        fh.seek(0)
+        self._dcmread_kwargs["stop_before_pixels"] = False
+        self._dataset = pdcm.dcmread(fh, **self._dcmread_kwargs)
+
+    def _postprocess(self, arr: np.ndarray, *, raw: bool) -> np.ndarray:
+        if raw:
+            return arr
+
+        if self._dataset.PhotometricInterpretation == "PALETTE COLOR":
+            return pdcm.pixels.apply_color_lut(arr, self._dataset)
+        arr = pdcm.pixels.apply_rescale(arr, self._dataset)
+        return pdcm.pixels.apply_voi_lut(arr, self._dataset)
+
+    def read(
+        self,
+        *,
+        index: Optional[int] = None,
+        raw: bool = False,
+        **kwargs,
+    ) -> np.ndarray:
+        """Read pixel data from the DICOM instance.
+
+        Parameters
+        ----------
+        index : int or Ellipsis or None
+            ``None`` (default) returns the full array. ``int`` selects one
+            frame. ``...`` ensures a leading batch axis (shape
+            ``(frames, rows, cols[, channels])``).
+        raw : bool
+            If ``False`` (default), return a fully reconstructed image:
+            pydicom decode (including YBR→RGB), then palette LUT **or**
+            modality rescale / modality LUT followed by VOI LUT / windowing.
+            Otherwise, return stored pixel values only.
+        kwargs : Any
+            Additional kwargs are forwarded to pydicom ``pixel_array``.
+
+        Returns
+        -------
+        ndimage : np.ndarray
+            Decoded pixels (always channel-last).
+        """
+        self._ensure_pixel_dataset()
+        frame_index = None if index in (Ellipsis, None) else index
+        arr = np.asarray(
+            pdcm.pixels.pixel_array(self._dataset, index=frame_index, raw=raw, **kwargs)
+        )
+        arr = self._postprocess(arr, raw=raw)
+
+        # ``...`` ensures a leading batch axis; multi-frame already has one.
+        if index is Ellipsis and int(getattr(self._dataset, "NumberOfFrames", 1)) == 1:
+            arr = arr[None, ...]
+
+        return arr
+
+    def iter(self, *, raw: bool = False, **kwargs) -> Iterator[np.ndarray]:
+        """Yield decoded frames one at a time (frame-wise decode).
+
+        Parameters
+        ----------
+        raw : bool
+            Same meaning as ``read(..., raw=...)``. Default ``False`` applies
+            full reconstruction per frame.
+        kwargs : Any
+            Forwarded to pydicom ``iter_pixels``.
+
+        Yields
+        ------
+        frame : np.ndarray
+            One frame with shape ``(rows, cols[, channels])``.
+        """
+        self._ensure_pixel_dataset()
+        for frame in pdcm.pixels.iter_pixels(self._dataset, raw=raw, **kwargs):
+            yield self._postprocess(np.asarray(frame), raw=raw)
+
+    def properties(
+        self, *, index: Optional[int] = None, raw: bool = False
+    ) -> ImageProperties:
+        """Standardized ndimage metadata from Dataset tags (no PixelData decode).
+
+        Parameters
+        ----------
+        index : int or Ellipsis or None
+            Same conventions as ``read``.
+        raw : bool
+            If ``False`` (default), shape and dtype match reconstructed
+            ``read`` / ``iter`` output (palette → RGB channels; rescale /
+            VOI may change dtype). Otherwise, report stored layout: integer
+            ``Pixel Data`` (has ``PixelRepresentation``) or float modules
+            (no ``PixelRepresentation``, ``BitsAllocated`` 32 / 64).
+
+        Returns
+        -------
+        properties : ImageProperties
+        """
+        rows = int(self._dataset.Rows)
+        cols = int(self._dataset.Columns)
+        n_frames = int(getattr(self._dataset, "NumberOfFrames", 1))
+        is_batch = index is Ellipsis or (index is None and n_frames > 1)
+
+        # figure out how many channels are in the file
+        if not raw and (
+            hasattr(self._dataset, "AlphaPaletteColorLookupTableData")
+            or hasattr(self._dataset, "SegmentedAlphaPaletteColorLookupTableData")
+        ):
+            channels = 4
+        elif not raw and self._dataset.PhotometricInterpretation == "PALETTE COLOR":
+            channels = 3
+        else:
+            channels = int(self._dataset.SamplesPerPixel)
+
+        if is_batch:
+            shape: Tuple[int, ...] = (n_frames, rows, cols)
+        else:
+            shape = (rows, cols)
+        if channels > 1:
+            shape = shape + (channels,)
+
+        # figure out the dtype
+        bits_allocated = int(self._dataset.BitsAllocated)
+        is_signed = (
+            int(self._dataset.PixelRepresentation) == 1
+            if hasattr(self._dataset, "PixelRepresentation")
+            else None
+        )
+        if not raw and self._dataset.PhotometricInterpretation == "PALETTE COLOR":
+            bits = int(self._dataset.RedPaletteColorLookupTableDescriptor[2])
+            dtype = np.dtype(np.uint8 if bits <= 8 else np.uint16)
+        elif not raw and getattr(self._dataset, "VOILUTSequence", None) is not None:
+            bits = int(self._dataset.VOILUTSequence[0].LUTDescriptor[2])
+            dtype = np.dtype(np.uint8 if bits <= 8 else np.uint16)
+        elif not raw and hasattr(self._dataset, "WindowCenter") and hasattr(
+            self._dataset, "WindowWidth"
+        ):
+            dtype = np.dtype(np.float64)
+        elif not raw and getattr(self._dataset, "ModalityLUTSequence", None) is not None:
+            bits = int(self._dataset.ModalityLUTSequence[0].LUTDescriptor[2])
+            dtype = np.dtype(np.uint8 if bits <= 8 else np.uint16)
+        elif not raw and hasattr(self._dataset, "RescaleSlope") and hasattr(
+            self._dataset, "RescaleIntercept"
+        ):
+            dtype = np.dtype(np.float64)
+        elif is_signed is None and bits_allocated == 32:
+            dtype = np.dtype(np.float32)
+        elif is_signed is None and bits_allocated == 64:
+            dtype = np.dtype(np.float64)
+        elif is_signed is not None and bits_allocated == 1:
+            dtype = np.dtype(np.uint8)
+        elif is_signed is not None and bits_allocated == 8:
+            dtype = np.dtype(np.int8 if is_signed else np.uint8)
+        elif is_signed is not None and bits_allocated == 16:
+            dtype = np.dtype(np.int16 if is_signed else np.uint16)
+        elif is_signed is not None and bits_allocated == 32:
+            dtype = np.dtype(np.int32 if is_signed else np.uint32)
+        else:
+            raise ValueError(
+                "Unsupported stored pixel type: BitsAllocated="
+                f"{bits_allocated}, PixelRepresentation="
+                f"{getattr(self._dataset, 'PixelRepresentation', None)}."
+            )
+
+        # figure out spacing
+        # per-frame FG > shared FG > instance tags
+        row_sp = None
+        col_sp = None
+        slice_sp = None
+
+        # 1. Instance-level (global) tags
+        pixel_spacing = getattr(self._dataset, "PixelSpacing", None)
+        if pixel_spacing is not None:
+            row_sp = float(pixel_spacing[0])
+            col_sp = float(pixel_spacing[1])
+        spacing_between_slices = getattr(
+            self._dataset, "SpacingBetweenSlices", None
+        )
+        if spacing_between_slices is not None:
+            slice_sp = float(spacing_between_slices)
+
+        # 2. Shared functional group pixel measures (overwrite if set)
+        shared_fg = getattr(self._dataset, "SharedFunctionalGroupsSequence", None)
+        if shared_fg is not None:
+            measures_seq = getattr(shared_fg[0], "PixelMeasuresSequence", None)
+            if measures_seq is not None:
+                measures = measures_seq[0]
+                pixel_spacing = getattr(measures, "PixelSpacing", None)
+                if pixel_spacing is not None:
+                    row_sp = float(pixel_spacing[0])
+                    col_sp = float(pixel_spacing[1])
+                spacing_between_slices = getattr(
+                    measures, "SpacingBetweenSlices", None
+                )
+                if spacing_between_slices is not None:
+                    slice_sp = float(spacing_between_slices)
+
+        # 3. Per-frame functional group pixel measures (overwrite if index given)
+        if isinstance(index, int):
+            per_frame_fg = getattr(
+                self._dataset, "PerFrameFunctionalGroupsSequence", None
+            )
+            if per_frame_fg is not None:
+                measures_seq = getattr(
+                    per_frame_fg[index], "PixelMeasuresSequence", None
+                )
+                if measures_seq is not None:
+                    measures = measures_seq[0]
+                    pixel_spacing = getattr(measures, "PixelSpacing", None)
+                    if pixel_spacing is not None:
+                        row_sp = float(pixel_spacing[0])
+                        col_sp = float(pixel_spacing[1])
+                    spacing_between_slices = getattr(
+                        measures, "SpacingBetweenSlices", None
+                    )
+                    if spacing_between_slices is not None:
+                        slice_sp = float(spacing_between_slices)
+
+        # Map spacing components onto the reported shape axes.
+        if row_sp is None or col_sp is None:
+            spacing = None
+        else:
+            spacing_list: List[Any] = []
+            if is_batch:
+                spacing_list.append(slice_sp if slice_sp is not None else 1.0)
+            spacing_list.extend([row_sp, col_sp])
+            if channels > 1:
+                spacing_list.append(1.0)
+            spacing = tuple(spacing_list)
+
+        return ImageProperties(
+            shape=shape,
+            dtype=dtype,
+            n_images=n_frames if is_batch else None,
+            is_batch=is_batch,
+            spacing=spacing,
+        )
+
+    def metadata(
+        self,
+        *,
+        index: Any = Ellipsis,
+        exclude_applied: bool = True,
+        raw: bool = False,
+    ) -> Dict[str, Any]:
+        """Read (non-data) DICOM tags.
+
+        Parameters
+        ----------
+        index : Ellipsis or int
+            Metadata is built by layered ``dict.update``:
+
+            1. If ``index`` is ``...`` or ``None``, add instance-level tags
+               (FG sequences omitted as top-level keys;
+               ``TransferSyntaxUID`` included from file_meta).
+            2. If a shared functional group is present, update with its macros.
+            3. If ``index`` is an ``int``, update with that frame's per-frame
+               FG (per-frame wins on conflict).
+
+            Classic files with no FG data therefore yield ``{}`` for an
+            integer ``index``.
+        exclude_applied : bool
+            If True (default) and ``raw`` is False, drop tags consumed by the
+            default ``read`` / ``iter`` reconstruction (rescale / windowing).
+            Otherwise, leave those tags in the returned dict.
+        raw : bool
+            Pair with ``read(..., raw=...)``. If ``False`` (default),
+            ``exclude_applied`` may drop reconstruction tags. Otherwise,
+            those tags are kept even when ``exclude_applied`` is True.
+
+        Returns
+        -------
+        metadata : dict
+            Keyword → value mapping (pydicom keyword names).
+        """
+
+        omit_applied: Tuple[str, ...] = (
+            (
+                "RescaleSlope",
+                "RescaleIntercept",
+                "RescaleType",
+                "WindowCenter",
+                "WindowWidth",
+                "WindowCenterWidthExplanation",
+                "VOILUTFunction",
+            )
+            if exclude_applied and not raw
+            else ()
+        )
+
+        meta: Dict[str, Any] = {}
+
+        # 1. Instance-level tags
+        if index in (Ellipsis, None):
+            meta.update(
+                _dataset_to_dict(
+                    self._dataset,
+                    omit_keys=(
+                        "SharedFunctionalGroupsSequence",
+                        "PerFrameFunctionalGroupsSequence",
+                        *omit_applied,
+                    ),
+                )
+            )
+            if (
+                hasattr(self._dataset, "file_meta")
+                and self._dataset.file_meta is not None
+            ):
+                ts = getattr(self._dataset.file_meta, "TransferSyntaxUID", None)
+                if ts is not None:
+                    meta.setdefault("TransferSyntaxUID", str(ts))
+
+        # 2. Shared functional group macros
+        shared_seq = getattr(self._dataset, "SharedFunctionalGroupsSequence", None)
+        if shared_seq is not None:
+            meta.update(_dataset_to_dict(shared_seq[0], omit_keys=omit_applied))
+
+        # 3. Per-frame functional group macros for a concrete frame index
+        if isinstance(index, int):
+            per_seq = getattr(
+                self._dataset, "PerFrameFunctionalGroupsSequence", None
+            )
+            if per_seq is not None:
+                meta.update(_dataset_to_dict(per_seq[index], omit_keys=omit_applied))
+
+        return meta
+
+    def write(
+        self,
+        ndimage: Union[ArrayLike, List[ArrayLike]],
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        is_planar: bool = False,
+        **kwargs,
+    ) -> Optional[bytes]:
+        """Write an image stack to DICOM.
+
+        Parameters
+        ----------
+        ndimage : ArrayLike
+            The ndimage to write.
+        metadata : dict
+            Global metadata (instance-level) to write to the file.
+        is_planar : bool
+            If True, the provided ndimage is assumed to use planar color layout
+            ([Frame, Channel], Height, Width). Otherwise, it is assumed to
+            be interleaved ([Frame], Height, Width, [Channel]).
+            Stored as DICOM ``PlanarConfiguration``.
+        kwargs : Any
+            Additional kwargs are forwarded to ``pydicom.dcmwrite``.
+
+        Returns
+        -------
+        bytes or None
+            Encoded bytes when the URI is ``"<bytes>"``, else ``None``.
+        """
+        if metadata:
+            for key, value in metadata.items():
+                _set_dataset_value(self._dataset, key, value)
+        self._dataset.PlanarConfiguration = int(is_planar)
+        self._save_kwargs.update(kwargs)
+
+        # Prepend a batch axis for single-frame inputs: (H, W), planar (C, H, W),
+        # or interleaved RGB (H, W, 3). Otherwise axis 0 is already the batch.
+        arr = np.asarray(ndimage)
+        if (
+            arr.ndim == 2
+            or (arr.ndim == 3 and is_planar)
+            or (arr.ndim == 3 and arr.shape[-1] == 3)
+        ):
+            arr = arr[None, ...]
+
+        for frame in arr:
+            self.write_frame(frame)
+
+        if self.request._uri_type == URI_BYTES:
+            self._flush()
+            return self.request.get_file().getvalue()
+        return None
+
+    @property
+    def instance_metadata(self) -> _TagMap:
+        """Instance-level (global) metadata of the file.
+        """
+        return _TagMap(lambda: self._dataset)
+
+    @instance_metadata.setter
+    def instance_metadata(self, value: Dict[str, Any]) -> None:
+        for key, val in dict(value).items():
+            _set_dataset_value(self._dataset, key, val)
+
+    @property
+    def shared_frame_metadata(self) -> _TagMap:
+        """Metadata in the shared functional group.
+
+        The tags stored here are writen once but applied to each frame
+        in the dicom file.
+        """
+
+        def get_item() -> pdcm.Dataset:
+            if not hasattr(self._dataset, "SharedFunctionalGroupsSequence") or not len(
+                self._dataset.SharedFunctionalGroupsSequence
+            ):
+                self._dataset.SharedFunctionalGroupsSequence = pdcm.sequence.Sequence([pdcm.Dataset()])
+            return self._dataset.SharedFunctionalGroupsSequence[0]
+
+        return _TagMap(get_item)
+
+    @shared_frame_metadata.setter
+    def shared_frame_metadata(self, value: Dict[str, Any]) -> None:
+        self._dataset.SharedFunctionalGroupsSequence = pdcm.sequence.Sequence(
+            [_dict_to_dataset(dict(value))]
+        )
+
+    @property
+    def compression(self) -> Optional[str]:
+        """The pixel compression to use when writing.
+
+        Available options:
+        - None: (system default)
+        - "rle": RLE lossless compression
+        - "jpeg-ls": JPEG-LS lossless compression
+        - "jpeg-ls-near": JPEG-LS near lossless compression
+        - "jpeg2000": JPEG 2000 lossless compression
+        - "jpeg2000-lossless": JPEG 2000 lossless compression
+        - Any transfer syntax UID string
+
+        Returns
+        -------
+        compression : str or None
+            Resolved transfer syntax UID, or ``None``.
+        """
+        return self._compression
+
+    @compression.setter
+    def compression(self, value: Optional[Union[str, Any]]) -> None:
+        if value is None:
+            self._compression = None
+            return
+        text = str(value)
+        names = {
+            "rle": pdcm.uid.RLELossless,
+            "jpeg-ls": pdcm.uid.JPEGLSLossless,
+            "jpeg-ls-near": pdcm.uid.JPEGLSNearLossless,
+            "jpeg2000": pdcm.uid.JPEG2000,
+            "jpeg2000-lossless": pdcm.uid.JPEG2000Lossless,
+        }
+        if text in names:
+            self._compression = str(names[text])
+            return
+        if text and text[0].isdigit() and "." in text:
+            self._compression = text
+            return
+        raise ValueError(
+            f"Unknown compression {value!r}. Use one of: {', '.join(names)} "
+            "(or a transfer syntax UID string)."
+        )
+
+    def write_frame(
+        self, frame: ArrayLike, *, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Add the given ndimage to the frames in this image.
+
+        Parameters
+        ----------
+        frame : ArrayLike
+            Single frame array.
+        metadata : dict
+            Local metadata associated with this ndimage.
+        """
+        self._frames.append(np.asarray(frame))
+        self._frame_metadata.append(dict(metadata) if metadata else None)
+
+    def lut_dense(
+        self, colormap: ArrayLike, first_mapped: int = 0
+    ) -> None:
+        """Set the given colormap as the image's LUT.
+
+        Parameters
+        ----------
+        colormap : ArrayLike
+            RGB(A) colormap as a 2D array of shape ``(N, 3)`` or ``(N, 4)``
+            with dtype ``uint8`` or ``uint16`` (up to ``2**16`` entries).
+        first_mapped : int
+            Offset subtracted from stored pixel values before indexing the LUT.
+        """
+        cmap = np.asarray(colormap, order="F")
+        bits = 8 * cmap.dtype.itemsize
+        n_entries = 0 if cmap.shape[0] == 65536 else cmap.shape[0]
+        
+        for name in (
+            "RedPaletteColorLookupTableDescriptor",
+            "GreenPaletteColorLookupTableDescriptor",
+            "BluePaletteColorLookupTableDescriptor",
+            "AlphaPaletteColorLookupTableDescriptor",
+            "RedPaletteColorLookupTableData",
+            "GreenPaletteColorLookupTableData",
+            "BluePaletteColorLookupTableData",
+            "AlphaPaletteColorLookupTableData",
+            "SegmentedRedPaletteColorLookupTableData",
+            "SegmentedGreenPaletteColorLookupTableData",
+            "SegmentedBluePaletteColorLookupTableData",
+            "SegmentedAlphaPaletteColorLookupTableData",
+        ):
+            if name in self._dataset:
+                delattr(self._dataset, name)
+        
+        descriptor = [n_entries, first_mapped, bits]
+        channels = ("Red", "Green", "Blue", "Alpha")[: cmap.shape[1]]
+        for i, channel in enumerate(channels):
+            setattr(
+                self._dataset,
+                f"{channel}PaletteColorLookupTableDescriptor",
+                descriptor,
+            )
+            setattr(
+                self._dataset,
+                f"{channel}PaletteColorLookupTableData",
+                cmap[:, i].tobytes(),
+            )
+        self._dataset.PhotometricInterpretation = "PALETTE COLOR"
+
+    def lut_linear(
+        self,
+        colors: ArrayLike,
+        indices: ArrayLike,
+        first_mapped: int = 0,
+    ) -> None:
+        """Set a piecewise linear gradient as the image's LUT.
+
+        Builds a gradient LUT using DICOM's segmented palette tags.
+        This allows more efficient storage of a gradient palette. The 
+        palette is defined by a sequence of knot points at different 
+        pixel intensities. 
+
+        Parameters
+        ----------
+        colors : ArrayLike
+            Knot colors as a 2D array of shape (K, 3) or (K, 4).
+        indices : ArrayLike
+            0-based indicies of pixel intensities where each knot is 
+            located. Assumed to be strictly increasing.
+        first_mapped : int
+            Offset subtracted from stored pixel values before indexing
+            the LUT.
+        """
+        cmap = np.asarray(colors, order="F")
+        indices = np.asarray(indices)
+        n = indices[-1].item() + 1
+        n_entries = 0 if n == 65536 else n
+        bits = 16
+
+        for name in (
+            "RedPaletteColorLookupTableDescriptor",
+            "GreenPaletteColorLookupTableDescriptor",
+            "BluePaletteColorLookupTableDescriptor",
+            "AlphaPaletteColorLookupTableDescriptor",
+            "RedPaletteColorLookupTableData",
+            "GreenPaletteColorLookupTableData",
+            "BluePaletteColorLookupTableData",
+            "AlphaPaletteColorLookupTableData",
+            "SegmentedRedPaletteColorLookupTableData",
+            "SegmentedGreenPaletteColorLookupTableData",
+            "SegmentedBluePaletteColorLookupTableData",
+            "SegmentedAlphaPaletteColorLookupTableData",
+        ):
+            if name in self._dataset:
+                delattr(self._dataset, name)
+
+        descriptor = [n_entries, first_mapped, bits]
+        channels = ("Red", "Green", "Blue", "Alpha")[: cmap.shape[1]]
+        for i, channel in enumerate(channels):
+            setattr(
+                self._dataset,
+                f"{channel}PaletteColorLookupTableDescriptor",
+                descriptor,
+            )
+            # Discrete knot 0, then linear segments between consecutive knots.
+            channel_vals = cmap[:, i]
+            words = np.empty(3 * len(indices), dtype="<u2")
+            words[0:3] = (0, 1, channel_vals[0])
+            for k in range(len(indices) - 1):
+                words[3 * (k + 1) : 3 * (k + 2)] = (
+                    1,
+                    indices[k + 1] - indices[k],
+                    channel_vals[k + 1],
+                )
+            setattr(
+                self._dataset,
+                f"Segmented{channel}PaletteColorLookupTableData",
+                words.tobytes(),
+            )
+        self._dataset.PhotometricInterpretation = "PALETTE COLOR"
+
+    def _flush(self) -> None:
+        if self._flushed:
+            return
+        if self.request.mode.io_mode != IOMode.write:
+            return
+        if not self._frames:
+            self._flushed = True
+            return
+
+        is_planar = int(getattr(self._dataset, "PlanarConfiguration", 0)) == 1
+        has_palette = hasattr(self._dataset, "RedPaletteColorLookupTableData") or hasattr(
+            self._dataset, "SegmentedRedPaletteColorLookupTableData"
+        )
+        arr = (
+            self._frames[0]
+            if len(self._frames) == 1
+            else np.stack(self._frames, axis=0)
+        )
+        bits_stored = (
+            self._dataset.BitsStored
+            if hasattr(self._dataset, "BitsStored")
+            else 8 * arr.dtype.itemsize
+        )
+
+        # PhotometricInterpretation for encode (required by set_pixel_data).
+        if has_palette:
+            photometric = "PALETTE COLOR"
+        elif hasattr(self._dataset, "PhotometricInterpretation"):
+            photometric = str(self._dataset.PhotometricInterpretation)
+        elif self._frames[0].ndim == 2:
+            photometric = "MONOCHROME2"
+        else:
+            photometric = "RGB"
+
+        # write the pixel data
+        if is_planar:
+            # writing planar with pydicom requires manual packing
+            samples, rows, cols = arr.shape[-3:]
+            if len(self._frames) == 1:
+                if "NumberOfFrames" in self._dataset:
+                    delattr(self._dataset, "NumberOfFrames")
+            else:
+                self._dataset.NumberOfFrames = len(self._frames)
+            self._dataset.SamplesPerPixel = samples
+            self._dataset.PhotometricInterpretation = photometric
+            self._dataset.PlanarConfiguration = 1
+            self._dataset.Rows = rows
+            self._dataset.Columns = cols
+            self._dataset.BitsAllocated = 8 * arr.dtype.itemsize
+            self._dataset.BitsStored = bits_stored
+            self._dataset.HighBit = bits_stored - 1
+            self._dataset.PixelRepresentation = 0 if arr.dtype.kind == "u" else 1
+            raw = np.ascontiguousarray(arr).tobytes()
+            if len(raw) % 2 == 1:
+                raw += b"\x00"
+            self._dataset.PixelData = raw
+            self._dataset["PixelData"].VR = (
+                pdcm.valuerep.VR.OB if self._dataset.BitsAllocated <= 8 else pdcm.valuerep.VR.OW
+            )
+            if not hasattr(self._dataset, "file_meta"):
+                self._dataset.file_meta = pdcm.dataset.FileMetaDataset()
+            tsyntax = getattr(self._dataset.file_meta, "TransferSyntaxUID", None)
+            if tsyntax is None or tsyntax.is_compressed:
+                self._dataset.file_meta.TransferSyntaxUID = (
+                    pdcm.uid.ExplicitVRLittleEndian
+                )
+        else:
+            self._dataset.set_pixel_data(
+                arr, photometric, bits_stored, generate_instance_uid=False
+            )
+
+        # write per-frame (local) metadata
+        if any(m is not None for m in self._frame_metadata):
+            items = [_dict_to_dataset(meta or {}) for meta in self._frame_metadata]
+            self._dataset.PerFrameFunctionalGroupsSequence = pdcm.sequence.Sequence(items)
+
+        # apply pixel compression
+        try:
+            if self._compression is not None:
+                self._dataset.compress(str(self._compression))
+            save_kwargs = dict(self._save_kwargs)
+            save_kwargs.setdefault("enforce_file_format", True)
+            self._dataset.save_as(self.request.get_file(), **save_kwargs)
+        finally:
+            self._flushed = True
+
+    def close(self) -> None:
+        """Flush a write buffer (if needed) and release the request."""
+        if self.request.mode.io_mode == IOMode.write:
+            self._flush()
+        self.request.finish()

--- a/imageio/plugins/pydicom.py
+++ b/imageio/plugins/pydicom.py
@@ -9,8 +9,8 @@
 
 Backend Library: `pydicom <https://pydicom.github.io/pydicom/>`_
 
-This plugin reads and writes DICOM files using pydicom. It operates in 
-individual files, meaning while it supports multi-frame files natively, it does 
+This plugin reads and writes DICOM files using pydicom. It operates in
+individual files, meaning while it supports multi-frame files natively, it does
 **not** assemble data across files in a directory.
 
 
@@ -124,9 +124,9 @@ DICOM images. Supported palettes are either **dense** or **linear**:
 - A **linear** palette maps each pixel index via piecewise-linear
   interpolation between the provided ``colors`` at the provided ``indices``.
 
-Dense color maps use the ordinary LookupTableData tags, linear maps use 
-SegmentedLookupTableData tags. Please ensure your reader supports these. Optional 
-alpha is supported as a 4th LUT channel. Pixel frames must be **index** arrays 
+Dense color maps use the ordinary LookupTableData tags, linear maps use
+SegmentedLookupTableData tags. Please ensure your reader supports these. Optional
+alpha is supported as a 4th LUT channel. Pixel frames must be **index** arrays
 into the LUT (not already-colored RGB).
 
 When using a LUT, do **not** set ``BitsStored`` in ``instance_metadata``.
@@ -166,7 +166,7 @@ Pixel reconstruction
 --------------------
 
 By default ``read`` / ``iter`` / ``imread`` / ``imiter`` reconstruct the image.
-This means any LUT (lookup table), grayscale correction, or ROI (region of 
+This means any LUT (lookup table), grayscale correction, or ROI (region of
 interest) windowing is applied before the image is returned.
 
 Pass ``raw=True`` to skip that pipeline and get stored values
@@ -175,7 +175,7 @@ Pass ``raw=True`` to skip that pipeline and get stored values
 
 Notes
 -----
-Be aware that ``.write()`` on ``"<bytes>"`` needs to flush immediately so 
+Be aware that ``.write()`` on ``"<bytes>"`` needs to flush immediately so
 ``imwrite`` can return encoded bytes. This may cause surprising behavior when used
 inside an explicit ``imopen`` context.
 
@@ -195,6 +195,7 @@ except ImportError as exc:  # pragma: no cover
 from ..core.request import URI_BYTES, InitializationError, IOMode, Request
 from ..core.v3_plugin_api import ImageProperties, PluginV3
 from ..typing import ArrayLike
+
 
 def _as_python(value: Any) -> Any:
     if isinstance(value, pdcm.Dataset):
@@ -232,11 +233,7 @@ def _dict_to_dataset(data: Dict[str, Any]) -> pdcm.Dataset:
 def _set_dataset_value(ds: pdcm.Dataset, key: str, value: Any) -> None:
     if isinstance(value, dict):
         setattr(ds, key, _dict_to_dataset(value))
-    elif (
-        isinstance(value, list)
-        and value
-        and all(isinstance(v, dict) for v in value)
-    ):
+    elif isinstance(value, list) and value and all(isinstance(v, dict) for v in value):
         setattr(ds, key, pdcm.sequence.Sequence([_dict_to_dataset(v) for v in value]))
     else:
         setattr(ds, key, value)
@@ -292,9 +289,7 @@ class PydicomPlugin(PluginV3):
 
         if request.mode.io_mode == IOMode.read:
             try:
-                self._dataset = pdcm.dcmread(
-                    request.get_file(), **self._dcmread_kwargs
-                )
+                self._dataset = pdcm.dcmread(request.get_file(), **self._dcmread_kwargs)
             except pdcm.errors.InvalidDicomError as exc:
                 raise InitializationError(
                     "pydicom cannot read this file as DICOM."
@@ -442,15 +437,21 @@ class PydicomPlugin(PluginV3):
         elif not raw and getattr(self._dataset, "VOILUTSequence", None) is not None:
             bits = int(self._dataset.VOILUTSequence[0].LUTDescriptor[2])
             dtype = np.dtype(np.uint8 if bits <= 8 else np.uint16)
-        elif not raw and hasattr(self._dataset, "WindowCenter") and hasattr(
-            self._dataset, "WindowWidth"
+        elif (
+            not raw
+            and hasattr(self._dataset, "WindowCenter")
+            and hasattr(self._dataset, "WindowWidth")
         ):
             dtype = np.dtype(np.float64)
-        elif not raw and getattr(self._dataset, "ModalityLUTSequence", None) is not None:
+        elif (
+            not raw and getattr(self._dataset, "ModalityLUTSequence", None) is not None
+        ):
             bits = int(self._dataset.ModalityLUTSequence[0].LUTDescriptor[2])
             dtype = np.dtype(np.uint8 if bits <= 8 else np.uint16)
-        elif not raw and hasattr(self._dataset, "RescaleSlope") and hasattr(
-            self._dataset, "RescaleIntercept"
+        elif (
+            not raw
+            and hasattr(self._dataset, "RescaleSlope")
+            and hasattr(self._dataset, "RescaleIntercept")
         ):
             dtype = np.dtype(np.float64)
         elif is_signed is None and bits_allocated == 32:
@@ -483,9 +484,7 @@ class PydicomPlugin(PluginV3):
         if pixel_spacing is not None:
             row_sp = float(pixel_spacing[0])
             col_sp = float(pixel_spacing[1])
-        spacing_between_slices = getattr(
-            self._dataset, "SpacingBetweenSlices", None
-        )
+        spacing_between_slices = getattr(self._dataset, "SpacingBetweenSlices", None)
         if spacing_between_slices is not None:
             slice_sp = float(spacing_between_slices)
 
@@ -499,9 +498,7 @@ class PydicomPlugin(PluginV3):
                 if pixel_spacing is not None:
                     row_sp = float(pixel_spacing[0])
                     col_sp = float(pixel_spacing[1])
-                spacing_between_slices = getattr(
-                    measures, "SpacingBetweenSlices", None
-                )
+                spacing_between_slices = getattr(measures, "SpacingBetweenSlices", None)
                 if spacing_between_slices is not None:
                     slice_sp = float(spacing_between_slices)
 
@@ -627,9 +624,7 @@ class PydicomPlugin(PluginV3):
 
         # 3. Per-frame functional group macros for a concrete frame index
         if isinstance(index, int):
-            per_seq = getattr(
-                self._dataset, "PerFrameFunctionalGroupsSequence", None
-            )
+            per_seq = getattr(self._dataset, "PerFrameFunctionalGroupsSequence", None)
             if per_seq is not None:
                 meta.update(_dataset_to_dict(per_seq[index], omit_keys=omit_applied))
 
@@ -690,8 +685,7 @@ class PydicomPlugin(PluginV3):
 
     @property
     def instance_metadata(self) -> _TagMap:
-        """Instance-level (global) metadata of the file.
-        """
+        """Instance-level (global) metadata of the file."""
         return _TagMap(lambda: self._dataset)
 
     @instance_metadata.setter
@@ -711,7 +705,9 @@ class PydicomPlugin(PluginV3):
             if not hasattr(self._dataset, "SharedFunctionalGroupsSequence") or not len(
                 self._dataset.SharedFunctionalGroupsSequence
             ):
-                self._dataset.SharedFunctionalGroupsSequence = pdcm.sequence.Sequence([pdcm.Dataset()])
+                self._dataset.SharedFunctionalGroupsSequence = pdcm.sequence.Sequence(
+                    [pdcm.Dataset()]
+                )
             return self._dataset.SharedFunctionalGroupsSequence[0]
 
         return _TagMap(get_item)
@@ -781,9 +777,7 @@ class PydicomPlugin(PluginV3):
         self._frames.append(np.asarray(frame))
         self._frame_metadata.append(dict(metadata) if metadata else None)
 
-    def lut_dense(
-        self, colormap: ArrayLike, first_mapped: int = 0
-    ) -> None:
+    def lut_dense(self, colormap: ArrayLike, first_mapped: int = 0) -> None:
         """Set the given colormap as the image's LUT.
 
         Parameters
@@ -797,7 +791,7 @@ class PydicomPlugin(PluginV3):
         cmap = np.asarray(colormap, order="F")
         bits = 8 * cmap.dtype.itemsize
         n_entries = 0 if cmap.shape[0] == 65536 else cmap.shape[0]
-        
+
         for name in (
             "RedPaletteColorLookupTableDescriptor",
             "GreenPaletteColorLookupTableDescriptor",
@@ -814,7 +808,7 @@ class PydicomPlugin(PluginV3):
         ):
             if name in self._dataset:
                 delattr(self._dataset, name)
-        
+
         descriptor = [n_entries, first_mapped, bits]
         channels = ("Red", "Green", "Blue", "Alpha")[: cmap.shape[1]]
         for i, channel in enumerate(channels):
@@ -839,16 +833,16 @@ class PydicomPlugin(PluginV3):
         """Set a piecewise linear gradient as the image's LUT.
 
         Builds a gradient LUT using DICOM's segmented palette tags.
-        This allows more efficient storage of a gradient palette. The 
-        palette is defined by a sequence of knot points at different 
-        pixel intensities. 
+        This allows more efficient storage of a gradient palette. The
+        palette is defined by a sequence of knot points at different
+        pixel intensities.
 
         Parameters
         ----------
         colors : ArrayLike
             Knot colors as a 2D array of shape (K, 3) or (K, 4).
         indices : ArrayLike
-            0-based indicies of pixel intensities where each knot is 
+            0-based indicies of pixel intensities where each knot is
             located. Assumed to be strictly increasing.
         first_mapped : int
             Offset subtracted from stored pixel values before indexing
@@ -912,9 +906,9 @@ class PydicomPlugin(PluginV3):
             return
 
         is_planar = int(getattr(self._dataset, "PlanarConfiguration", 0)) == 1
-        has_palette = hasattr(self._dataset, "RedPaletteColorLookupTableData") or hasattr(
-            self._dataset, "SegmentedRedPaletteColorLookupTableData"
-        )
+        has_palette = hasattr(
+            self._dataset, "RedPaletteColorLookupTableData"
+        ) or hasattr(self._dataset, "SegmentedRedPaletteColorLookupTableData")
         arr = (
             self._frames[0]
             if len(self._frames) == 1
@@ -959,7 +953,9 @@ class PydicomPlugin(PluginV3):
                 raw += b"\x00"
             self._dataset.PixelData = raw
             self._dataset["PixelData"].VR = (
-                pdcm.valuerep.VR.OB if self._dataset.BitsAllocated <= 8 else pdcm.valuerep.VR.OW
+                pdcm.valuerep.VR.OB
+                if self._dataset.BitsAllocated <= 8
+                else pdcm.valuerep.VR.OW
             )
             if not hasattr(self._dataset, "file_meta"):
                 self._dataset.file_meta = pdcm.dataset.FileMetaDataset()
@@ -976,7 +972,9 @@ class PydicomPlugin(PluginV3):
         # write per-frame (local) metadata
         if any(m is not None for m in self._frame_metadata):
             items = [_dict_to_dataset(meta or {}) for meta in self._frame_metadata]
-            self._dataset.PerFrameFunctionalGroupsSequence = pdcm.sequence.Sequence(items)
+            self._dataset.PerFrameFunctionalGroupsSequence = pdcm.sequence.Sequence(
+                items
+            )
 
         # apply pixel compression
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ lytro = []
 numpy = []
 pillow-heif = ["pillow-heif"]
 pillow = []
+pydicom = ["pydicom"]
 simpleitk = []
 spe = []
 swf = []
@@ -115,6 +116,7 @@ all-plugins = [
     "numpy>2",
     "pillow-heif",
     "psutil",
+    "pydicom",
     "rawpy",
     "tifffile",
 ]
@@ -135,6 +137,7 @@ full = [
     "numpy>2",
     "pillow-heif",
     "psutil",
+    "pydicom",
     "pydata-sphinx-theme",
     "pytest",
     "pytest-cov",

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,6 +1,7 @@
 """Test DICOM functionality."""
 
 from zipfile import ZipFile
+import warnings
 
 import numpy as np
 
@@ -9,8 +10,15 @@ import pytest
 import imageio.v2 as iio
 import imageio.v3 as iio3
 from imageio import core
-import imageio.plugins.dicom
 from conftest import deprecated_test
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The legacy `DICOM` plugin is deprecated:DeprecationWarning"
+)
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    import imageio.plugins.dicom
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_pydicom.py
+++ b/tests/test_pydicom.py
@@ -9,7 +9,6 @@ import imageio.v3 as iio
 from pydicom.pixels import apply_color_lut, apply_rescale, apply_voi_lut, pixel_array
 from pydicom.uid import ExplicitVRLittleEndian, RLELossless
 
-
 PLUGIN = "pydicom"
 
 
@@ -133,9 +132,7 @@ def test_properties_float_pixel_data(tmp_path):
 
 def test_properties_palette_shape(tmp_path):
     idx = np.array([[0, 1], [2, 3]], dtype=np.uint8)
-    cmap = np.array(
-        [[0, 0, 0], [255, 0, 0], [0, 255, 0], [0, 0, 255]], dtype=np.uint8
-    )
+    cmap = np.array([[0, 0, 0], [255, 0, 0], [0, 255, 0], [0, 0, 255]], dtype=np.uint8)
     path = tmp_path / "pal_props.dcm"
     with iio.imopen(path, "w", plugin=PLUGIN) as f:
         f.lut_dense(cmap)
@@ -245,8 +242,12 @@ def test_write_frame_and_fg(tmp_path):
         f.shared_frame_metadata = {
             "PixelMeasuresSequence": [{"PixelSpacing": [1.0, 1.0]}]
         }
-        f.write_frame(frame, metadata={"FrameContentSequence": [{"FrameAcquisitionNumber": 1}]})
-        f.write_frame(frame, metadata={"FrameContentSequence": [{"FrameAcquisitionNumber": 2}]})
+        f.write_frame(
+            frame, metadata={"FrameContentSequence": [{"FrameAcquisitionNumber": 1}]}
+        )
+        f.write_frame(
+            frame, metadata={"FrameContentSequence": [{"FrameAcquisitionNumber": 2}]}
+        )
     meta = iio.immeta(path, plugin=PLUGIN)
     assert meta.get("PatientName") in ("Anonymous", "Anonymous^")
     frame_meta = iio.immeta(path, index=1, plugin=PLUGIN)
@@ -256,9 +257,7 @@ def test_write_frame_and_fg(tmp_path):
 
 def test_lut_dense(tmp_path):
     idx = np.array([[0, 1], [2, 3]], dtype=np.uint8)
-    cmap = np.array(
-        [[0, 0, 0], [255, 0, 0], [0, 255, 0], [0, 0, 255]], dtype=np.uint8
-    )
+    cmap = np.array([[0, 0, 0], [255, 0, 0], [0, 255, 0], [0, 0, 255]], dtype=np.uint8)
     path = tmp_path / "pal_dense.dcm"
     with iio.imopen(path, "w", plugin=PLUGIN) as f:
         f.lut_dense(cmap)
@@ -296,8 +295,6 @@ def test_lut_helpers_replace(tmp_path):
     ds = pydicom.dcmread(str(path))
     assert hasattr(ds, "SegmentedRedPaletteColorLookupTableData")
     assert not hasattr(ds, "RedPaletteColorLookupTableData")
-
-
 
 
 def test_imwrite_uncompressed(tmp_path):

--- a/tests/test_pydicom.py
+++ b/tests/test_pydicom.py
@@ -5,9 +5,14 @@ import pytest
 
 pydicom = pytest.importorskip("pydicom")
 
-import imageio.v3 as iio
-from pydicom.pixels import apply_color_lut, apply_rescale, apply_voi_lut, pixel_array
-from pydicom.uid import ExplicitVRLittleEndian, RLELossless
+import imageio.v3 as iio  # noqa: E402
+from pydicom.pixels import (  # noqa: E402
+    apply_color_lut,
+    apply_rescale,
+    apply_voi_lut,
+    pixel_array,
+)
+from pydicom.uid import ExplicitVRLittleEndian, RLELossless  # noqa: E402
 
 PLUGIN = "pydicom"
 

--- a/tests/test_pydicom.py
+++ b/tests/test_pydicom.py
@@ -1,0 +1,348 @@
+"""Tests for the pydicom v3 plugin."""
+
+import numpy as np
+import pytest
+
+pydicom = pytest.importorskip("pydicom")
+
+import imageio.v3 as iio
+from pydicom.pixels import apply_color_lut, apply_rescale, apply_voi_lut, pixel_array
+from pydicom.uid import ExplicitVRLittleEndian, RLELossless
+
+
+PLUGIN = "pydicom"
+
+
+def test_plugin_loads():
+    assert "pydicom" in iio.imopen.__module__ or True
+    from imageio.config import known_plugins
+
+    assert "pydicom" in known_plugins
+    assert known_plugins["pydicom"].class_name == "PydicomPlugin"
+
+
+def test_extension_priority():
+    from imageio.config.extensions import known_extensions
+
+    assert known_extensions[".dcm"][0].priority == ["DICOM", "pydicom", "ITK"]
+    assert known_extensions[".ct"][0].priority == ["DICOM", "pydicom"]
+    assert known_extensions[".mri"][0].priority == ["DICOM", "pydicom"]
+    assert known_extensions[".dicom"][0].priority == ["ITK", "pydicom"]
+    assert known_extensions[".gdcm"][0].priority == ["ITK", "pydicom"]
+
+
+def test_read_matches_pixel_array_raw(test_images):
+    path = test_images / "dicom_file01.dcm"
+    expected = pixel_array(str(path), raw=True)
+    actual = iio.imread(path, plugin=PLUGIN, raw=True)
+    np.testing.assert_array_equal(actual, expected)
+    assert actual.shape == (512, 512)
+
+
+def test_read_applies_rescale_by_default(test_images):
+    path = test_images / "dicom_file01.dcm"
+    ds = pydicom.dcmread(str(path))
+    stored = pixel_array(ds, raw=True)
+    expected = apply_voi_lut(apply_rescale(stored, ds), ds)
+    actual = iio.imread(path, plugin=PLUGIN)
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_read_non_dicom_raises(tmp_path):
+    path = tmp_path / "not.dcm"
+    path.write_bytes(b"not a dicom file at all")
+    with pytest.raises(OSError, match="pydicom"):
+        iio.imread(path, plugin=PLUGIN)
+
+
+def test_imiter_framewise(test_images):
+    path = test_images / "dicom_file01.dcm"
+    frames = list(iio.imiter(path, plugin=PLUGIN))
+    assert len(frames) == 1
+    assert frames[0].shape == (512, 512)
+
+
+def test_read_index_ellipsis(test_images):
+    path = test_images / "dicom_file01.dcm"
+    arr = iio.imread(path, index=..., plugin=PLUGIN)
+    assert arr.shape == (1, 512, 512)
+
+
+def test_properties_no_pixel_decode(test_images, monkeypatch):
+    path = test_images / "dicom_file01.dcm"
+    calls = {"pixel_array": 0}
+
+    import imageio.plugins.pydicom as plugin_mod
+
+    real_pixel_array = plugin_mod.pdcm.pixels.pixel_array
+
+    def wrapped(*args, **kwargs):
+        calls["pixel_array"] += 1
+        return real_pixel_array(*args, **kwargs)
+
+    monkeypatch.setattr(plugin_mod.pdcm.pixels, "pixel_array", wrapped)
+    props = iio.improps(path, plugin=PLUGIN, raw=True)
+    assert calls["pixel_array"] == 0
+    assert props.shape == (512, 512)
+    assert props.dtype == np.dtype("uint16") or props.dtype.kind in ("u", "i")
+    assert props.is_batch is False
+    assert props.n_images is None
+
+
+def test_properties_matches_read_reconstruction(test_images):
+    path = test_images / "dicom_file01.dcm"
+    props = iio.improps(path, plugin=PLUGIN)
+    img = iio.imread(path, plugin=PLUGIN)
+    assert props.shape == img.shape
+    assert props.dtype == img.dtype
+
+
+def test_properties_raw_stored_dtype(test_images):
+    path = test_images / "dicom_file01.dcm"
+    props = iio.improps(path, plugin=PLUGIN, raw=True)
+    img = iio.imread(path, plugin=PLUGIN, raw=True)
+    assert props.shape == img.shape
+    assert props.dtype == img.dtype
+
+
+def test_properties_float_pixel_data(tmp_path):
+    # Native Float Pixel Data (no PixelRepresentation); props must not assume int32.
+    arr = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    ds = pydicom.Dataset()
+    ds.file_meta = pydicom.dataset.FileMetaDataset()
+    ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    ds.file_meta.MediaStorageSOPClassUID = pydicom.uid.SecondaryCaptureImageStorage
+    ds.file_meta.MediaStorageSOPInstanceUID = pydicom.uid.generate_uid()
+    ds.SOPClassUID = pydicom.uid.SecondaryCaptureImageStorage
+    ds.SOPInstanceUID = ds.file_meta.MediaStorageSOPInstanceUID
+    ds.StudyInstanceUID = pydicom.uid.generate_uid()
+    ds.SeriesInstanceUID = pydicom.uid.generate_uid()
+    ds.Modality = "OT"
+    ds.SamplesPerPixel = 1
+    ds.PhotometricInterpretation = "MONOCHROME2"
+    ds.Rows = 2
+    ds.Columns = 2
+    ds.BitsAllocated = 32
+    ds.FloatPixelData = arr.tobytes()
+    path = tmp_path / "float32.dcm"
+    ds.save_as(path, enforce_file_format=True)
+    props = iio.improps(path, plugin=PLUGIN, raw=True)
+    assert props.dtype == np.dtype(np.float32)
+    assert props.shape == (2, 2)
+
+
+def test_properties_palette_shape(tmp_path):
+    idx = np.array([[0, 1], [2, 3]], dtype=np.uint8)
+    cmap = np.array(
+        [[0, 0, 0], [255, 0, 0], [0, 255, 0], [0, 0, 255]], dtype=np.uint8
+    )
+    path = tmp_path / "pal_props.dcm"
+    with iio.imopen(path, "w", plugin=PLUGIN) as f:
+        f.lut_dense(cmap)
+        f.write(idx)
+    props = iio.improps(path, plugin=PLUGIN)
+    props_raw = iio.improps(path, plugin=PLUGIN, raw=True)
+    assert props_raw.shape == (2, 2)
+    assert props.shape == (2, 2, 3)
+    assert props.dtype == np.dtype(np.uint8)
+
+
+def test_properties_index_int(test_images):
+    path = test_images / "dicom_file01.dcm"
+    props = iio.improps(path, index=0, plugin=PLUGIN, raw=True)
+    assert props.shape == (512, 512)
+    assert props.n_images is None
+    assert props.is_batch is False
+
+
+def test_immeta_instance_tags(test_images):
+    path = test_images / "dicom_file01.dcm"
+    meta = iio.immeta(path, plugin=PLUGIN)
+    assert "TransferSyntaxUID" in meta or "SOPClassUID" in meta
+    assert "SharedFunctionalGroupsSequence" not in meta
+    assert "PerFrameFunctionalGroupsSequence" not in meta
+    assert "PixelData" not in meta
+
+
+def test_immeta_frame_without_fg(test_images):
+    path = test_images / "dicom_file01.dcm"
+    meta = iio.immeta(path, index=0, plugin=PLUGIN)
+    assert meta == {}
+
+
+def test_write_gray_roundtrip(tmp_path):
+    img = np.arange(64, dtype=np.uint8).reshape(8, 8)
+    path = tmp_path / "gray.dcm"
+    iio.imwrite(path, img, plugin=PLUGIN, metadata={"Modality": "OT"})
+    back = iio.imread(path, plugin=PLUGIN)
+    np.testing.assert_array_equal(back, img)
+    meta = iio.immeta(path, plugin=PLUGIN)
+    assert meta.get("Modality") == "OT"
+
+
+def test_write_rgb_roundtrip(tmp_path):
+    img = np.zeros((6, 7, 3), dtype=np.uint8)
+    img[..., 0] = 10
+    img[..., 1] = 20
+    img[..., 2] = 30
+    path = tmp_path / "rgb.dcm"
+    iio.imwrite(path, img, plugin=PLUGIN)
+    back = iio.imread(path, plugin=PLUGIN)
+    np.testing.assert_array_equal(back, img)
+
+
+def test_write_multiframe_gray(tmp_path):
+    vol = np.arange(3 * 4 * 5, dtype=np.uint16).reshape(3, 4, 5)
+    path = tmp_path / "mf.dcm"
+    iio.imwrite(path, vol, plugin=PLUGIN)
+    back = iio.imread(path, plugin=PLUGIN)
+    np.testing.assert_array_equal(back, vol)
+    props = iio.improps(path, plugin=PLUGIN)
+    assert props.shape == (3, 4, 5)
+    assert props.is_batch is True
+    assert props.n_images == 3
+    frames = list(iio.imiter(path, plugin=PLUGIN))
+    assert len(frames) == 3
+    np.testing.assert_array_equal(frames[1], vol[1])
+
+
+def test_write_bytes():
+    img = np.arange(16, dtype=np.uint8).reshape(4, 4)
+    data = iio.imwrite("<bytes>", img, plugin=PLUGIN, extension=".dcm")
+    assert isinstance(data, (bytes, bytearray))
+    back = iio.imread(data, plugin=PLUGIN, extension=".dcm")
+    np.testing.assert_array_equal(back, img)
+
+
+def test_write_planar_configuration(tmp_path):
+    planar = np.zeros((3, 5, 6), dtype=np.uint8)
+    planar[0] = 1
+    planar[1] = 2
+    planar[2] = 3
+    path = tmp_path / "planar.dcm"
+    iio.imwrite(path, planar, plugin=PLUGIN, is_planar=True)
+    back = iio.imread(path, plugin=PLUGIN)
+    # decoded channel-last
+    assert back.shape == (5, 6, 3)
+    np.testing.assert_array_equal(back[..., 0], 1)
+    np.testing.assert_array_equal(back[..., 1], 2)
+    np.testing.assert_array_equal(back[..., 2], 3)
+
+
+def test_shape_three_frames_not_planar(tmp_path):
+    vol = np.arange(3 * 4 * 4, dtype=np.uint8).reshape(3, 4, 4)
+    path = tmp_path / "three.dcm"
+    iio.imwrite(path, vol, plugin=PLUGIN)  # is_planar default False
+    back = iio.imread(path, plugin=PLUGIN)
+    assert back.shape == (3, 4, 4)
+
+
+def test_write_frame_and_fg(tmp_path):
+    path = tmp_path / "fg.dcm"
+    frame = np.zeros((4, 4), dtype=np.uint8)
+    with iio.imopen(path, "w", plugin=PLUGIN) as f:
+        f.instance_metadata["PatientName"] = "Anonymous"
+        f.shared_frame_metadata = {
+            "PixelMeasuresSequence": [{"PixelSpacing": [1.0, 1.0]}]
+        }
+        f.write_frame(frame, metadata={"FrameContentSequence": [{"FrameAcquisitionNumber": 1}]})
+        f.write_frame(frame, metadata={"FrameContentSequence": [{"FrameAcquisitionNumber": 2}]})
+    meta = iio.immeta(path, plugin=PLUGIN)
+    assert meta.get("PatientName") in ("Anonymous", "Anonymous^")
+    frame_meta = iio.immeta(path, index=1, plugin=PLUGIN)
+    assert frame_meta  # FG present
+    assert "PixelMeasuresSequence" in frame_meta or "FrameContentSequence" in frame_meta
+
+
+def test_lut_dense(tmp_path):
+    idx = np.array([[0, 1], [2, 3]], dtype=np.uint8)
+    cmap = np.array(
+        [[0, 0, 0], [255, 0, 0], [0, 255, 0], [0, 0, 255]], dtype=np.uint8
+    )
+    path = tmp_path / "pal_dense.dcm"
+    with iio.imopen(path, "w", plugin=PLUGIN) as f:
+        f.lut_dense(cmap)
+        f.write(idx)
+    ds = pydicom.dcmread(str(path))
+    assert hasattr(ds, "RedPaletteColorLookupTableData")
+    assert not hasattr(ds, "SegmentedRedPaletteColorLookupTableData")
+    colored = apply_color_lut(pixel_array(ds), ds)
+    assert colored.shape[-1] == 3
+
+
+def test_lut_linear(tmp_path):
+    idx = np.zeros((4, 4), dtype=np.uint8)
+    idx[0, 0] = 0
+    idx[0, 1] = 255
+    path = tmp_path / "pal_lin.dcm"
+    with iio.imopen(path, "w", plugin=PLUGIN) as f:
+        f.lut_linear([(0, 0, 0), (65535, 65535, 65535)], [0, 255])
+        f.write(idx)
+    ds = pydicom.dcmread(str(path))
+    assert hasattr(ds, "SegmentedRedPaletteColorLookupTableData")
+    assert not hasattr(ds, "RedPaletteColorLookupTableData")
+    colored = apply_color_lut(pixel_array(ds), ds)
+    assert colored.shape[-1] == 3
+
+
+def test_lut_helpers_replace(tmp_path):
+    idx = np.zeros((2, 2), dtype=np.uint8)
+    cmap = np.array([[0, 0, 0], [1, 2, 3]], dtype=np.uint16)
+    path = tmp_path / "pal_swap.dcm"
+    with iio.imopen(path, "w", plugin=PLUGIN) as f:
+        f.lut_dense(cmap)
+        f.lut_linear([(0, 0, 0), (100, 100, 100)], [0, 1])
+        f.write(idx)
+    ds = pydicom.dcmread(str(path))
+    assert hasattr(ds, "SegmentedRedPaletteColorLookupTableData")
+    assert not hasattr(ds, "RedPaletteColorLookupTableData")
+
+
+
+
+def test_imwrite_uncompressed(tmp_path):
+    img = np.zeros((4, 4), dtype=np.uint8)
+    path = tmp_path / "unc.dcm"
+    iio.imwrite(path, img, plugin=PLUGIN)
+    meta = iio.immeta(path, plugin=PLUGIN)
+    assert str(meta.get("TransferSyntaxUID", ExplicitVRLittleEndian)).startswith(
+        "1.2.840.10008.1.2"
+    )
+
+
+def test_compression_rle(tmp_path):
+    img = np.arange(64, dtype=np.uint8).reshape(8, 8)
+    path = tmp_path / "rle.dcm"
+    with iio.imopen(path, "w", plugin=PLUGIN) as f:
+        f.compression = "rle"
+        assert f.compression == str(RLELossless)
+        f.write(img)
+    meta = iio.immeta(path, plugin=PLUGIN)
+    assert str(meta["TransferSyntaxUID"]) == str(RLELossless)
+    back = iio.imread(path, plugin=PLUGIN)
+    np.testing.assert_array_equal(back, img)
+
+
+def test_compression_exact_names(tmp_path):
+    path = tmp_path / "exact.dcm"
+    with iio.imopen(path, "w", plugin=PLUGIN) as f:
+        f.compression = "rle"
+        assert f.compression == str(RLELossless)
+        f.compression = str(RLELossless)
+        assert f.compression == str(RLELossless)
+        f.compression = None
+        assert f.compression is None
+        with pytest.raises(ValueError, match="Unknown compression"):
+            f.compression = "RLE"
+        with pytest.raises(ValueError, match="Unknown compression"):
+            f.compression = "jpeg_ls"
+
+
+def test_compression_unsupported_uid(tmp_path):
+    img = np.zeros((4, 4), dtype=np.uint8)
+    path = tmp_path / "baduid.dcm"
+    f = iio.imopen(path, "w", plugin=PLUGIN)
+    f.compression = "1.2.3.4.5.6.7.8.9.0"
+    f.write(img)
+    with pytest.raises(NotImplementedError, match="No pixel data encoders"):
+        f.close()

--- a/uv.lock
+++ b/uv.lock
@@ -837,7 +837,7 @@ wheels = [
 
 [[package]]
 name = "imageio"
-version = "2.37.3"
+version = "2.37.4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -856,6 +856,7 @@ all-plugins = [
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow-heif" },
     { name = "psutil" },
+    { name = "pydicom" },
     { name = "rawpy" },
     { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
@@ -904,6 +905,7 @@ full = [
     { name = "pillow-heif" },
     { name = "psutil" },
     { name = "pydata-sphinx-theme" },
+    { name = "pydicom" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "rawpy" },
@@ -927,6 +929,9 @@ pillow-heif = [
 ]
 pyav = [
     { name = "av" },
+]
+pydicom = [
+    { name = "pydicom" },
 ]
 rawpy = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -987,6 +992,9 @@ requires-dist = [
     { name = "psutil", marker = "extra == 'full'" },
     { name = "pydata-sphinx-theme", marker = "extra == 'docs'" },
     { name = "pydata-sphinx-theme", marker = "extra == 'full'" },
+    { name = "pydicom", marker = "extra == 'all-plugins'" },
+    { name = "pydicom", marker = "extra == 'full'" },
+    { name = "pydicom", marker = "extra == 'pydicom'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'full'" },
     { name = "pytest", marker = "extra == 'test'" },
@@ -1002,7 +1010,7 @@ requires-dist = [
     { name = "tifffile", marker = "extra == 'full'" },
     { name = "tifffile", marker = "extra == 'tifffile'" },
 ]
-provides-extras = ["bsdf", "dicom", "feisem", "ffmpeg", "freeimage", "lytro", "numpy", "pillow-heif", "pillow", "simpleitk", "spe", "swf", "tifffile", "pyav", "fits", "rawpy", "gdal", "itk", "linting", "test", "docs", "dev", "all-plugins", "all-plugins-pypy", "full"]
+provides-extras = ["bsdf", "dicom", "feisem", "ffmpeg", "freeimage", "lytro", "numpy", "pillow-heif", "pillow", "pydicom", "simpleitk", "spe", "swf", "tifffile", "pyav", "fits", "rawpy", "gdal", "itk", "linting", "test", "docs", "dev", "all-plugins", "all-plugins-pypy", "full"]
 
 [[package]]
 name = "imageio-ffmpeg"
@@ -1974,6 +1982,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/ea/3ab478cccacc2e8ef69892c42c44ae547bae089f356c4b47caf61730958d/pydata_sphinx_theme-0.15.4.tar.gz", hash = "sha256:7762ec0ac59df3acecf49fd2f889e1b4565dbce8b88b2e29ee06fdd90645a06d", size = 2400673, upload-time = "2024-06-25T19:28:45.041Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/d3/c622950d87a2ffd1654208733b5bd1c5645930014abed8f4c0d74863988b/pydata_sphinx_theme-0.15.4-py3-none-any.whl", hash = "sha256:2136ad0e9500d0949f96167e63f3e298620040aea8f9c74621959eda5d4cf8e6", size = 4640157, upload-time = "2024-06-25T19:28:42.383Z" },
+]
+
+[[package]]
+name = "pydicom"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/de/52aaf905f1f0ae7aba85996e2592ea2c1fe49157f3cfbcd1871965bdb51d/pydicom-3.0.2.tar.gz", hash = "sha256:5942bfc2d72c6fa4b3b5b62c527f54b7f2355f21d6f5d296df6bb30188df6a4f", size = 2886792, upload-time = "2026-03-19T21:46:20.935Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e0/60466c6d712dad2cf807df315e39863e91609ffd1064ecb835994460bbda/pydicom-3.0.2-py3-none-any.whl", hash = "sha256:abf971a5440f84dbaf42c4b6758e30e62480902584f8b270b9a5d146e278a07b", size = 2376822, upload-time = "2026-03-19T21:46:19.042Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a v3 plugin to use pydicom to write DICOM images (https://github.com/pydicom/pydicom).

Closes: #1 , #658, #347, #18, #136 , #348 

I noticed that our current dicom plugin uses manual parsing and that we have #1 which asks for additional tags to read and mentions pydicom. By now that project has matured nicely so it makes sense for us to have a plugin for it that will eventually superseed our internal dicom reader.

The current plugin reads and writes single dicom files. This is a departure from the internal plugin, which supports folder read/write. The reason for this is that we have a long standing (and idle) discussion on wether ImageIO should support folder reading or not, with consensus that it shouldn't and that users of ImageIO should decide on how folder parsing should be handled.

I've also added the following extras in addition to a general pydicom reader/writer:
- the ability to write planar (channel-first) frames and frame groups.
- support for pixel compression selection in the advanced API
- support for writing paletted images using a dense colormap (LUT tags) or gradient (segmented LUT tags). This is exposed via two helper functions in the advanced API
- incremental writing in the advanced API (buffers frames internally)
- RGBA support via paletted images (Note: image must be provided as palleted RGBA; we won't palettize for you)


I will leave this PR open for at least a week before merging to allow others to review and chime in if interested.

Notes:
- #1 gets closed because pydicom supports all the necessary tags we want
- #685 gets closed because this plugin superseeds the legacy dicom plugin and removes the ability to read folders
- #347 gets closed because pydicom loads the images in storage order of the file, and sorting across files (within folders) is no longer in-scope for imageio.
- #18 gets closed because pydicom handles the file correctly
- #136 gets closed because pydicom picks up GDCM automatically if it is installed
- #348 gets closed because the new plugin automatically applies grayscale correction (with option to opt-out) using pydicom's ability.